### PR TITLE
Feature/19943 entity attachments list

### DIFF
--- a/src/app/ext-commons/ext-common-entity/entity-widget/entity-widget.component.html
+++ b/src/app/ext-commons/ext-common-entity/entity-widget/entity-widget.component.html
@@ -1,3 +1,4 @@
+Entity widget
 <ng-container *ngIf="xmEntity$ | async as fetchedXmEntity; else loading ">
   <ng-container
     *ngIf="fetchedXmEntity; then cardsData; else noData"
@@ -24,12 +25,19 @@
               [xmEntitySpec]="xmEntitySpec"
             ></xm-entity-data-card>
           </div>
-          <div *ngSwitchCase="'attachment-list'">
+          <div *ngSwitchCase="'attachment-grid'">
             <xm-attachment-list
               [xmEntityId]="fetchedXmEntity.id"
               [attachmentSpecs]="xmEntitySpec?.attachments"
               *ngIf="xmEntitySpec?.attachments">
             </xm-attachment-list>
+          </div>
+          <div *ngSwitchCase="'attachment-list'">
+            <xm-attachment-list-simplified
+              [xmEntityId]="fetchedXmEntity.id"
+              [attachmentSpecs]="xmEntitySpec?.attachments"
+              *ngIf="xmEntitySpec?.attachments">
+            </xm-attachment-list-simplified>
           </div>
           <div *ngSwitchCase="'location-list-card'">
             <xm-location-list-card

--- a/src/app/ext-commons/ext-common-entity/entity-widget/entity-widget.component.html
+++ b/src/app/ext-commons/ext-common-entity/entity-widget/entity-widget.component.html
@@ -1,4 +1,3 @@
-Entity widget
 <ng-container *ngIf="xmEntity$ | async as fetchedXmEntity; else loading ">
   <ng-container
     *ngIf="fetchedXmEntity; then cardsData; else noData"

--- a/src/app/ext-commons/ext-common-entity/entity-widget/entity-widget.component.ts
+++ b/src/app/ext-commons/ext-common-entity/entity-widget/entity-widget.component.ts
@@ -13,32 +13,6 @@ import {LinkSpec, Spec, XmEntity, XmEntityService, XmEntitySpec} from '../../../
 })
 export class EntityWidgetComponent implements OnInit, OnDestroy {
 
-    GRID = {
-        'DEFAULT': [
-            {class: 'row',
-                content: [{class: 'col-sm-6', component: 'entity-card'}, {class: 'col-sm-6', component: 'entity-data-card'}]
-            },
-            {class: 'row', content: [{class: 'col-sm-12', component: 'function-list-card'}]},
-            {class: 'row', content: [{class: 'col-sm-12', component: 'attachment-list'}]},
-            {class: 'row', content: [{class: 'col-sm-12', component: 'location-list-card'}]},
-            {class: 'row', content: [{class: 'col-sm-12', component: 'link-list'}]},
-            {class: 'row', content: [{class: 'col-sm-12', component: 'comment-list'}]},
-            {class: 'row', content: [{class: 'col-sm-12', component: 'calendar-card'}]},
-            {class: 'row', content: [{class: 'col-sm-12', component: 'timeline'}]}
-        ],
-        'ALL-IN-ROW': [
-            {class: 'row', content: [{class: 'col-sm-12 col-xl-8 offset-xl-2', component: 'entity-card'}]},
-            {class: 'row', content: [{class: 'col-sm-12', component: 'entity-data-card'}]},
-            {class: 'row', content: [{class: 'col-sm-12', component: 'function-list-card'}]},
-            {class: 'row', content: [{class: 'col-sm-12', component: 'attachment-list'}]},
-            {class: 'row', content: [{class: 'col-sm-12', component: 'location-list-card'}]},
-            {class: 'row', content: [{class: 'col-sm-12', component: 'link-list'}]},
-            {class: 'row', content: [{class: 'col-sm-12', component: 'comment-list'}]},
-            {class: 'row', content: [{class: 'col-sm-12', component: 'calendar-card'}]},
-            {class: 'row', content: [{class: 'col-sm-12', component: 'timeline'}]}
-        ]
-    };
-
     config: any;
     grid: any;
     xmEntity: XmEntity;
@@ -96,7 +70,9 @@ export class EntityWidgetComponent implements OnInit, OnDestroy {
                 detailLayoutType = entityUiConfig.detailLayoutType;
             }
 
-            this.grid = this.config.grid ? this.config.grid : this.GRID[detailLayoutType];
+            this.grid = this.config.grid ?
+                this.config.grid :
+                this.getGridLayout(entityUiConfig.attachments && entityUiConfig.attachments.view, detailLayoutType);
         });
     }
 
@@ -121,5 +97,42 @@ export class EntityWidgetComponent implements OnInit, OnDestroy {
                 l.name = l.backName;
                 return l;
             });
+    }
+
+    // TODO: better typization
+    getGridLayout(attachmentsView: 'list'|undefined, detailLayoutType: string): any[] {
+
+        let attachmentsComponent = 'attachment-grid';
+
+        if (attachmentsView === 'list') {
+            attachmentsComponent = 'attachment-list';
+        }
+
+        if (detailLayoutType === 'ALL-IN-ROW') {
+            return [
+                {class: 'row', content: [{class: 'col-sm-12 col-xl-8 offset-xl-2', component: 'entity-card'}]},
+                {class: 'row', content: [{class: 'col-sm-12', component: 'entity-data-card'}]},
+                {class: 'row', content: [{class: 'col-sm-12', component: 'function-list-card'}]},
+                {class: 'row', content: [{class: 'col-sm-12', component: attachmentsComponent}]},
+                {class: 'row', content: [{class: 'col-sm-12', component: 'location-list-card'}]},
+                {class: 'row', content: [{class: 'col-sm-12', component: 'link-list'}]},
+                {class: 'row', content: [{class: 'col-sm-12', component: 'comment-list'}]},
+                {class: 'row', content: [{class: 'col-sm-12', component: 'calendar-card'}]},
+                {class: 'row', content: [{class: 'col-sm-12', component: 'timeline'}]}
+            ]
+        }
+
+        return [
+            {class: 'row',
+                content: [{class: 'col-sm-6', component: 'entity-card'}, {class: 'col-sm-6', component: 'entity-data-card'}]
+            },
+            {class: 'row', content: [{class: 'col-sm-12', component: 'function-list-card'}]},
+            {class: 'row', content: [{class: 'col-sm-12', component: attachmentsComponent}]},
+            {class: 'row', content: [{class: 'col-sm-12', component: 'location-list-card'}]},
+            {class: 'row', content: [{class: 'col-sm-12', component: 'link-list'}]},
+            {class: 'row', content: [{class: 'col-sm-12', component: 'comment-list'}]},
+            {class: 'row', content: [{class: 'col-sm-12', component: 'calendar-card'}]},
+            {class: 'row', content: [{class: 'col-sm-12', component: 'timeline'}]}
+        ]
     }
 }

--- a/src/app/ext-commons/ext-common-entity/entity-widget/entity-widget.component.ts
+++ b/src/app/ext-commons/ext-common-entity/entity-widget/entity-widget.component.ts
@@ -1,10 +1,10 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { JhiEventManager } from 'ng-jhipster';
-import {Observable, Subscription} from 'rxjs';
-import {finalize, map, tap} from 'rxjs/operators';
+import { Observable, Subscription } from 'rxjs';
+import { map, tap } from 'rxjs/operators';
 
 import { ContextService, XmConfigService } from '../../../shared';
-import {LinkSpec, Spec, XmEntity, XmEntityService, XmEntitySpec} from '../../../xm-entity';
+import { LinkSpec, Spec, XmEntity, XmEntityService, XmEntitySpec } from '../../../xm-entity';
 
 @Component({
     selector: 'xm-entity-widget',

--- a/src/app/ext-commons/ext-common-entity/entity-widget/entity-widget.component.ts
+++ b/src/app/ext-commons/ext-common-entity/entity-widget/entity-widget.component.ts
@@ -72,7 +72,7 @@ export class EntityWidgetComponent implements OnInit, OnDestroy {
 
             this.grid = this.config.grid ?
                 this.config.grid :
-                this.getGridLayout(entityUiConfig.attachments && entityUiConfig.attachments.view, detailLayoutType);
+                this.getGridLayout(entityUiConfig && entityUiConfig.attachments && entityUiConfig.attachments.view, detailLayoutType);
         });
     }
 
@@ -99,7 +99,7 @@ export class EntityWidgetComponent implements OnInit, OnDestroy {
             });
     }
 
-    // TODO: better typization
+    // TODO: improve types
     getGridLayout(attachmentsView: 'list'|undefined, detailLayoutType: string): any[] {
 
         let attachmentsComponent = 'attachment-grid';

--- a/src/app/xm-entity/attachment-card/attachment-card.component.ts
+++ b/src/app/xm-entity/attachment-card/attachment-card.component.ts
@@ -81,7 +81,6 @@ export class AttachmentCardComponent implements OnInit {
     }
 
     onDownload() {
-        console.log(this.attachment);
         if (this.attachment.contentUrl && !this.attachment.contentChecksum) {
             saveFileFromUrl(this.attachment.contentUrl, this.attachment.name);
         } else {

--- a/src/app/xm-entity/attachment-list/attachment-list-base.component.ts
+++ b/src/app/xm-entity/attachment-list/attachment-list-base.component.ts
@@ -1,0 +1,67 @@
+import {Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges} from '@angular/core';
+import {Subscription} from 'rxjs';
+import {AttachmentSpec} from '../shared/attachment-spec.model';
+import {XmEntity} from '../shared/xm-entity.model';
+import {Attachment} from '../shared/attachment.model';
+import {XmEntityService} from '../shared/xm-entity.service';
+import {JhiEventManager} from 'ng-jhipster';
+import {HttpResponse} from '@angular/common/http';
+import {Principal} from '../../shared';
+
+const ATTACHMENT_EVENT = 'attachmentListModification';
+
+@Component({
+  selector: 'xm-attachment-list-base',
+  template: `no template, to be extended`
+})
+export class AttachmentListBaseComponent implements OnInit, OnChanges, OnDestroy {
+
+    private modificationSubscription: Subscription;
+
+    @Input() xmEntityId: number;
+    @Input() attachmentSpecs: AttachmentSpec[];
+
+    xmEntity: XmEntity;
+    attachments: Attachment[];
+
+    constructor(private xmEntityService: XmEntityService,
+                private eventManager: JhiEventManager,
+                public principal: Principal) {
+    }
+
+    ngOnInit() {
+        this.registerListModify();
+    }
+
+    ngOnChanges(changes: SimpleChanges) {
+        if (changes.xmEntityId && changes.xmEntityId.previousValue !== changes.xmEntityId.currentValue) {
+            this.load();
+        }
+    }
+
+    ngOnDestroy() {
+        this.eventManager.destroy(this.modificationSubscription);
+    }
+
+    private registerListModify() {
+        this.modificationSubscription = this.eventManager.subscribe(ATTACHMENT_EVENT, (response) => {
+            console.log(response)
+            this.load()
+        });
+    }
+
+    private load() {
+        this.attachments = [];
+        this.xmEntityService.find(this.xmEntityId, {'embed': 'attachments'}).subscribe((xmEntity: HttpResponse<XmEntity>) => {
+            this.xmEntity = xmEntity.body;
+            if (xmEntity.body.attachments) {
+                this.attachments = [...xmEntity.body.attachments];
+            }
+        });
+    }
+
+    getAttachmentSpec(attachment: Attachment) {
+        return this.attachmentSpecs.filter((ls) => ls.key === attachment.typeKey).shift();
+    }
+
+}

--- a/src/app/xm-entity/attachment-list/attachment-list-base.component.ts
+++ b/src/app/xm-entity/attachment-list/attachment-list-base.component.ts
@@ -9,8 +9,8 @@ import { HttpResponse } from '@angular/common/http';
 import { Principal } from '../../shared';
 import { AttachmentService } from '../shared/attachment.service';
 import { TranslateService } from '@ngx-translate/core';
-import {saveFile, saveFileFromUrl} from '../../shared/helpers/file-download-helper';
-import {XM_EVENT_LIST} from '../../xm.constants';
+import { saveFile, saveFileFromUrl } from '../../shared/helpers/file-download-helper';
+import { XM_EVENT_LIST } from '../../xm.constants';
 
 declare let swal: any;
 

--- a/src/app/xm-entity/attachment-list/attachment-list-base.component.ts
+++ b/src/app/xm-entity/attachment-list/attachment-list-base.component.ts
@@ -9,31 +9,12 @@ import { HttpResponse } from '@angular/common/http';
 import { Principal } from '../../shared';
 import { AttachmentService } from '../shared/attachment.service';
 import { TranslateService } from '@ngx-translate/core';
-import {Content} from '..';
 import {saveFile, saveFileFromUrl} from '../../shared/helpers/file-download-helper';
+import {XM_EVENT_LIST} from '../../xm.constants';
 
 declare let swal: any;
 
-const ATTACHMENT_EVENT = 'attachmentListModification';
-
-class UIAttachment extends Attachment {
-    constructor(public id?: number,
-                public typeKey?: string,
-                public name?: string,
-                public contentUrl?: string,
-                public description?: string,
-                public startDate?: any,
-                public endDate?: any,
-                public valueContentType?: string,
-                public valueContentSize?: number,
-                public content?: Content,
-                public contentChecksum?: string,
-                public xmEntity?: XmEntity,
-                public body?: any) {
-        super(id, typeKey, name, contentUrl, description, startDate, endDate,
-            valueContentType, valueContentSize, content, contentChecksum, xmEntity, body);
-    }
-}
+const ATTACHMENT_EVENT = XM_EVENT_LIST.XM_ATTACHMENT_LIST_MODIFICATION;
 
 @Component({
   selector: 'xm-attachment-list-base',

--- a/src/app/xm-entity/attachment-list/attachment-list-simplified.component.ts
+++ b/src/app/xm-entity/attachment-list/attachment-list-simplified.component.ts
@@ -22,9 +22,6 @@ import {AttachmentListBaseComponent} from './attachment-list-base.component';
                     <button mat-menu-item class="btn-sm" (click)="onRefresh()">
                         {{'xm-entity.entity-list-card.refresh' | translate}}
                     </button>
-                    <button mat-menu-item class="btn-sm" (click)="onRefresh()">
-                        {{'xm-entity.common.add' | translate}}
-                    </button>
                 </mat-menu>
             </div>
             <ng-container *ngIf="attachments">
@@ -50,7 +47,7 @@ import {AttachmentListBaseComponent} from './attachment-list-base.component';
                             </td>
                             <td>{{attachment.name}}</td>
                             <td>{{getAttachmentSpec(attachment)?.name | i18nName : principal}}</td>
-                            <td>{{getFileSize(attachment, 2)}}</td>
+                            <td>{{getFileSize(attachment, 2)}} ({{attachment.valueContentType}})</td>
                             <td>
                                 <a href="javascript: void(0);" (click)="onDownload(attachment)" *xmPermitted="['ATTACHMENT.GET_LIST.ITEM']">
                                     <i class="material-icons">cloud_download</i>

--- a/src/app/xm-entity/attachment-list/attachment-list-simplified.component.ts
+++ b/src/app/xm-entity/attachment-list/attachment-list-simplified.component.ts
@@ -7,29 +7,66 @@ import {AttachmentListBaseComponent} from './attachment-list-base.component';
         <div class="card">
         <div class="card-header card-header-icon card-header-primary">
             <div class="card-icon">
-                <i class="material-icons">{{'link'}}</i>
+                <i class="material-icons">{{'attach_file'}}</i>
             </div>
-            <h4 class="card-title">{{'attachments' | i18nName: principal}}</h4>
+            <h4 class="card-title" jhiTranslate="xm-entity.attachment-card.title"></h4>
         </div>
 
         <div class="card-body">
+            <div class="dropdown xm-entity-attachment-actions">
+                <button mat-icon-button [matMenuTriggerFor]="entityListActions">
+                    <mat-icon>more_vert</mat-icon>
+                </button>
 
+                <mat-menu #entityListActions="matMenu">
+                    <button mat-menu-item class="btn-sm" (click)="onRefresh()">
+                        {{'xm-entity.entity-list-card.refresh' | translate}}
+                    </button>
+                    <button mat-menu-item class="btn-sm" (click)="onRefresh()">
+                        {{'xm-entity.common.add' | translate}}
+                    </button>
+                </mat-menu>
+            </div>
             <ng-container *ngIf="attachments">
                 <div class="table-responsive sm-overflow">
                     <table class="table table-striped">
                         <thead>
                         <tr >
+                            <th></th>
+                            <th><span jhiTranslate="xm-entity.common.fields.name">Name</span></th>
+                            <th><span jhiTranslate="xm-entity.common.fields.description">Description</span></th>
+                            <th></th>
+                            <th></th>
+                            <!--
                             <th *ngFor="let field of fields">
-                                <!-- TODO translate -->
                                 <span *ngIf="field">{{field | i18nName :principal}}</span>
                             </th>
+                            -->
                         </tr>
                         </thead>
 
                         <tbody>
-                        <tr *ngFor="let xmEntity of attachments">
-                            <td *ngFor="let field of fields">
-                                {{ field == 'startDate' ? (xmEntity[field] | date) : xmEntity[field] }}
+                        <tr *ngFor="let attachment of attachments">
+                            <td>
+                                <div class="xm-avatar-img-container">
+                                    <img src="./assets/img/placeholder.png">
+                                    <i class="material-icons">attach_file</i>
+                                </div>
+                            </td>
+                            <td>{{attachment.name}}</td>
+                            <td>{{getAttachmentSpec(attachment)?.name | i18nName : principal}}</td>
+                            <td>{{getFileSize(attachment, 2)}}</td>
+                            <td>
+                                <a href="javascript: void(0);" (click)="onDownload(attachment)" *xmPermitted="['ATTACHMENT.GET_LIST.ITEM']">
+                                    <i class="material-icons">cloud_download</i>
+                                </a>
+                                &nbsp;
+                                <a href="javascript: void(0);" (click)="onRemove(attachment)" *xmPermitted="['ATTACHMENT.DELETE']">
+                                    <i class="material-icons">delete</i>
+                                </a>
+                            </td>
+                            <!--<td *ngFor="let field of fields">
+                                {{ field == 'startDate' ? (xmEntity[field] | date) : xmEntity[field] }}-->
                         </tr>
                         </tbody>
                     </table>

--- a/src/app/xm-entity/attachment-list/attachment-list-simplified.component.ts
+++ b/src/app/xm-entity/attachment-list/attachment-list-simplified.component.ts
@@ -37,11 +37,6 @@ import {AttachmentListBaseComponent} from './attachment-list-base.component';
                             <th><span jhiTranslate="xm-entity.common.fields.description">Description</span></th>
                             <th></th>
                             <th></th>
-                            <!--
-                            <th *ngFor="let field of fields">
-                                <span *ngIf="field">{{field | i18nName :principal}}</span>
-                            </th>
-                            -->
                         </tr>
                         </thead>
 
@@ -65,8 +60,6 @@ import {AttachmentListBaseComponent} from './attachment-list-base.component';
                                     <i class="material-icons">delete</i>
                                 </a>
                             </td>
-                            <!--<td *ngFor="let field of fields">
-                                {{ field == 'startDate' ? (xmEntity[field] | date) : xmEntity[field] }}-->
                         </tr>
                         </tbody>
                     </table>
@@ -74,10 +67,8 @@ import {AttachmentListBaseComponent} from './attachment-list-base.component';
             </ng-container>
 
         </div>
-    </div>`
+    </div>`,
+    styleUrls: ['./attachment-list.component.scss']
 })
 export class AttachmentListSimplifiedComponent extends AttachmentListBaseComponent {
-    public fields = [
-        'id', 'typeKey', 'name', 'contentUrl', 'valueContentSize', 'valueContentType', 'startDate'
-    ];
 }

--- a/src/app/xm-entity/attachment-list/attachment-list-simplified.component.ts
+++ b/src/app/xm-entity/attachment-list/attachment-list-simplified.component.ts
@@ -1,0 +1,46 @@
+import {Component} from '@angular/core';
+import {AttachmentListBaseComponent} from './attachment-list-base.component';
+
+@Component({
+    selector: 'xm-attachment-list-simplified',
+    template: `
+        <div class="card">
+        <div class="card-header card-header-icon card-header-primary">
+            <div class="card-icon">
+                <i class="material-icons">{{'link'}}</i>
+            </div>
+            <h4 class="card-title">{{'attachments' | i18nName: principal}}</h4>
+        </div>
+
+        <div class="card-body">
+
+            <ng-container *ngIf="attachments">
+                <div class="table-responsive sm-overflow">
+                    <table class="table table-striped">
+                        <thead>
+                        <tr >
+                            <th *ngFor="let field of fields">
+                                <!-- TODO translate -->
+                                <span *ngIf="field">{{field | i18nName :principal}}</span>
+                            </th>
+                        </tr>
+                        </thead>
+
+                        <tbody>
+                        <tr *ngFor="let xmEntity of attachments">
+                            <td *ngFor="let field of fields">
+                                {{ field == 'startDate' ? (xmEntity[field] | date) : xmEntity[field] }}
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </ng-container>
+
+        </div>
+    </div>`
+})
+export class AttachmentListSimplifiedComponent extends AttachmentListBaseComponent {
+    public fields = [
+        'id', 'typeKey', 'name', 'contentUrl', 'valueContentSize', 'valueContentType', 'startDate'
+    ];
+}

--- a/src/app/xm-entity/attachment-list/attachment-list-simplified.component.ts
+++ b/src/app/xm-entity/attachment-list/attachment-list-simplified.component.ts
@@ -1,5 +1,5 @@
-import {Component} from '@angular/core';
-import {AttachmentListBaseComponent} from './attachment-list-base.component';
+import { Component } from '@angular/core';
+import { AttachmentListBaseComponent } from './attachment-list-base.component';
 
 @Component({
     selector: 'xm-attachment-list-simplified',

--- a/src/app/xm-entity/attachment-list/attachment-list.component.html
+++ b/src/app/xm-entity/attachment-list/attachment-list.component.html
@@ -1,6 +1,0 @@
-<div class="row">
-  <div class="col-lg-2 col-md-4 col-sm-4" *ngFor="let attachment of attachments">
-    <xm-attachment-card [attachment]="attachment" [attachmentSpec]="getAttachmentSpec(attachment)">
-    </xm-attachment-card>
-  </div>
-</div>

--- a/src/app/xm-entity/attachment-list/attachment-list.component.scss
+++ b/src/app/xm-entity/attachment-list/attachment-list.component.scss
@@ -5,7 +5,4 @@
         top: -40px;
         z-index: 4;
     }
-    .mat-icon-button {
-        color: rgb(51, 51, 51);
-    }
 }

--- a/src/app/xm-entity/attachment-list/attachment-list.component.scss
+++ b/src/app/xm-entity/attachment-list/attachment-list.component.scss
@@ -1,0 +1,11 @@
+.xm-entity-attachment-actions {
+    &.dropdown {
+        position: absolute;
+        right: 5px;
+        top: -40px;
+        z-index: 4;
+    }
+    .mat-icon-button {
+        color: rgb(51, 51, 51);
+    }
+}

--- a/src/app/xm-entity/attachment-list/attachment-list.component.ts
+++ b/src/app/xm-entity/attachment-list/attachment-list.component.ts
@@ -1,67 +1,17 @@
-import { HttpResponse } from '@angular/common/http';
-import { Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
-import { JhiEventManager } from 'ng-jhipster';
-import { Subscription } from 'rxjs';
-
-import { AttachmentSpec } from '../shared/attachment-spec.model';
-import { Attachment } from '../shared/attachment.model';
-import { XmEntity } from '../shared/xm-entity.model';
-import { XmEntityService } from '../shared/xm-entity.service';
-
-const ATTACHMENT_EVENT = 'attachmentListModification';
+import { Component } from '@angular/core';
+import {AttachmentListBaseComponent} from './attachment-list-base.component';
 
 @Component({
     selector: 'xm-attachment-list',
-    templateUrl: './attachment-list.component.html',
+    template: `
+        <div class="row">
+        <div class="col-lg-2 col-md-4 col-sm-4" *ngFor="let attachment of attachments">
+            <xm-attachment-card [attachment]="attachment" [attachmentSpec]="getAttachmentSpec(attachment)">
+            </xm-attachment-card>
+        </div>
+    </div>`,
     styleUrls: ['./attachment-list.component.scss']
 })
-export class AttachmentListComponent implements OnInit, OnChanges, OnDestroy {
-
-    private modificationSubscription: Subscription;
-
-    @Input() xmEntityId: number;
-    @Input() attachmentSpecs: AttachmentSpec[];
-
-    xmEntity: XmEntity;
-    attachments: Attachment[];
-
-    constructor(private xmEntityService: XmEntityService,
-                private eventManager: JhiEventManager) {
-    }
-
-    ngOnInit() {
-        this.registerListModify();
-    }
-
-    ngOnChanges(changes: SimpleChanges) {
-        if (changes.xmEntityId && changes.xmEntityId.previousValue !== changes.xmEntityId.currentValue) {
-            this.load();
-        }
-    }
-
-    ngOnDestroy() {
-        this.eventManager.destroy(this.modificationSubscription);
-    }
-
-    private registerListModify() {
-        this.modificationSubscription = this.eventManager.subscribe(ATTACHMENT_EVENT, (response) => {
-            console.log(response)
-            this.load()
-        });
-    }
-
-    private load() {
-        this.attachments = [];
-        this.xmEntityService.find(this.xmEntityId, {'embed': 'attachments'}).subscribe((xmEntity: HttpResponse<XmEntity>) => {
-            this.xmEntity = xmEntity.body;
-            if (xmEntity.body.attachments) {
-                this.attachments = [...xmEntity.body.attachments];
-            }
-        });
-    }
-
-    getAttachmentSpec(attachment: Attachment) {
-        return this.attachmentSpecs.filter((ls) => ls.key === attachment.typeKey).shift();
-    }
+export class AttachmentListComponent extends AttachmentListBaseComponent {
 
 }

--- a/src/app/xm-entity/xm-entity.module.ts
+++ b/src/app/xm-entity/xm-entity.module.ts
@@ -67,6 +67,8 @@ import {
 } from './';
 
 import {StateChangeDialogComponent} from './state-change-dialog/state-change-dialog.component';
+import { AttachmentListSimplifiedComponent } from './attachment-list/attachment-list-simplified.component';
+import { AttachmentListBaseComponent } from './attachment-list/attachment-list-base.component';
 
 @NgModule({
     imports: [
@@ -123,7 +125,9 @@ import {StateChangeDialogComponent} from './state-change-dialog/state-change-dia
         TagListSectionComponent,
         EntityListFabComponent,
         LocationCardNamePipe,
-        StatesManagementDialogComponent
+        StatesManagementDialogComponent,
+        AttachmentListSimplifiedComponent,
+        AttachmentListBaseComponent
     ],
     entryComponents: [
         StatesManagementDialogComponent,
@@ -142,6 +146,7 @@ import {StateChangeDialogComponent} from './state-change-dialog/state-change-dia
         AreaComponent,
         AttachmentCardComponent,
         AttachmentListComponent,
+        AttachmentListSimplifiedComponent,
         CalendarCardComponent,
         CommentCardComponent,
         CommentListComponent,

--- a/src/i18n/en/xm-entity.json
+++ b/src/i18n/en/xm-entity.json
@@ -33,6 +33,7 @@
             }
         },
         "attachment-card": {
+            "title": "Attachments",
             "volume": {
                 "bytes": "bytes",
                 "KB": "Kb",

--- a/src/i18n/ru/xm-entity.json
+++ b/src/i18n/ru/xm-entity.json
@@ -33,6 +33,7 @@
             }
         },
         "attachment-card": {
+            "title": "Вложения",
             "volume": {
                 "bytes": "байт",
                 "KB": "Кб",

--- a/src/i18n/uk/xm-entity.json
+++ b/src/i18n/uk/xm-entity.json
@@ -33,6 +33,7 @@
             }
         },
         "attachment-card": {
+            "title": "Файли",
             "volume": {
                 "bytes": "байт",
                 "KB": "Кб",


### PR DESCRIPTION
New feature for XM-EntityCard.Attachment

Possibility to define Attachment widget layout from standard to simplified list version.

To define layout type use
```
applications:
    config:
        entities:
            - typeKey: 'DOCUMENT'
              attachments:
                  view: 'list'
```
view values = 'list' | 'grid' | none == 'grid'

Improvements: layout list requires only 1 call (no content select performed)

Details
https://tracker.jbs.com.ua/issues/19943