### PR TITLE
Refactor/rest

### DIFF
--- a/src/app/application/entity-detail.component.ts
+++ b/src/app/application/entity-detail.component.ts
@@ -66,8 +66,8 @@ export class EntityDetailComponent implements OnInit, OnDestroy {
         $.xmEntity = null;
         this.xmEntity = null;
         this.xmEntityService.find(id, {'embed': 'data'}).subscribe((xmEntity) => {
-                    this.xmEntity = xmEntity.body;
-                    $.xmEntity = xmEntity.body;
+                    this.xmEntity = xmEntity;
+                    $.xmEntity = xmEntity;
                     this.routeData.pageSubSubTitle = this.xmEntity.name;
                     this.jhiLanguageHelper.updateTitle();
                 },

--- a/src/app/ext-commons/ext-common-entity/available-offerings-widget/available-offerings-widget.component.ts
+++ b/src/app/ext-commons/ext-common-entity/available-offerings-widget/available-offerings-widget.component.ts
@@ -49,8 +49,8 @@ export class AvailableOfferingsWidgetComponent implements OnInit, OnDestroy {
     load() {
         if (this.config.query) {
             this.xmEntityService.search({query: this.config.query}).subscribe(
-                (resp: HttpResponse<XmEntity[]>) => {
-                    this.offerings = resp.body;
+                (resp: XmEntity[]) => {
+                    this.offerings = resp;
                     this.rows = Array.from(Array(Math.ceil(this.offerings.length / this.rowSize)).keys());
                 },
                 () => {

--- a/src/app/ext-commons/ext-common-entity/chartist-line-widget/chartist-line-widget.component.ts
+++ b/src/app/ext-commons/ext-common-entity/chartist-line-widget/chartist-line-widget.component.ts
@@ -30,8 +30,8 @@ export class ChartistLineWidgetComponent implements OnInit {
             page: 0,
             size: this.config.size,
             sort: [this.firstSeries.sort]
-        }).subscribe((resp: HttpResponse<XmEntity[]>) => {
-            const entities: any[] = resp.body;
+        }).subscribe((resp: XmEntity[]) => {
+            const entities: any[] = resp;
             const series = [[]];
             const labels = [];
             for (const entity of entities) {

--- a/src/app/ext-commons/ext-common-entity/customer-info-widget/customer-info-widget.component.ts
+++ b/src/app/ext-commons/ext-common-entity/customer-info-widget/customer-info-widget.component.ts
@@ -77,7 +77,7 @@ export class CustomerInfoWidgetComponent implements OnInit, OnDestroy {
             this.showCurrencies = this.config.showCurrencies;
         }
 
-        this.profile = this.xmEntityService.getProfile().pipe(map(responce => responce.body));
+        this.profile = this.xmEntityService.getProfile().pipe(map(responce => responce));
         this.createForm();
         this.resetForm();
         this.attachmentsSubscription = this.eventManager.subscribe(ATTACHMENT_EVENT, event => {
@@ -85,7 +85,7 @@ export class CustomerInfoWidgetComponent implements OnInit, OnDestroy {
             if (event.profileId || this.profileId) {
                 this.attachments = this.xmEntityService.find(event.profileId ? event.profileId : this.profileId, ['attachments'])
                     .pipe(
-                        map(entity => entity.body.attachments),
+                        map(entity => entity.attachments),
                         finalize(() => this.showAttachmentLoader = false),
                         catchError(() => {
                             this.showAttachmentLoader = false;
@@ -126,7 +126,7 @@ export class CustomerInfoWidgetComponent implements OnInit, OnDestroy {
             this.showAttachmentLoader = true;
             this.attachments = this.xmEntityService.find(profile.id, {'embed': 'attachments'})
                 .pipe(
-                    map(entity => entity.body.attachments),
+                    map(entity => entity.attachments),
                     finalize(() => this.showAttachmentLoader = false),
                     catchError(() => {
                         this.showAttachmentLoader = false;
@@ -188,8 +188,8 @@ export class CustomerInfoWidgetComponent implements OnInit, OnDestroy {
                 profile.stateKey = 'ON-REVIEW';
                 this.xmEntityService.update(profile).subscribe(p => {
                     this.alertService.info('tsg.notification.varificationDataSendSuccess');
-                    this.updateState(p.body);
-                    this.runProfileInterval(p.body.stateKey);
+                    this.updateState(p);
+                    this.runProfileInterval(p.stateKey);
                 });
             });
         } else {

--- a/src/app/ext-commons/ext-common-entity/entity-widget/entity-widget.component.ts
+++ b/src/app/ext-commons/ext-common-entity/entity-widget/entity-widget.component.ts
@@ -61,7 +61,7 @@ export class EntityWidgetComponent implements OnInit, OnDestroy {
 
         this.xmEntity$ = this.xmEntityService.find(xmEntityId, {'embed': 'data'})
             .pipe(
-                map(responce => responce.body),
+                map(responce => responce),
                 tap((entity) => this.xmEntity = entity),
                 tap((entity) => this.xmEntitySpec = this.getXmEntitySpec(entity.typeKey)),
                 tap(() => DEBUG_INFO_ENABLED ? console.log(`DBG spec = %o`, this.xmEntitySpec) : () => {} ),

--- a/src/app/ext-commons/ext-common-entity/location-map-widget/location-map-widget.component.ts
+++ b/src/app/ext-commons/ext-common-entity/location-map-widget/location-map-widget.component.ts
@@ -45,12 +45,12 @@ export class LocationMapWidgetComponent implements OnInit {
             query: this.currentGroup.query,
             size: this.currentGroup.size ? this.currentGroup.size : 20
         }).subscribe(
-            (res: HttpResponse<XmEntity[]>) => {
+            (res: XmEntity[]) => {
                 this.gMapApiReady$
                     .pipe(
                         filter(status => status === true)
                     )
-                    .subscribe(() => this.onShowMap(res.body))
+                    .subscribe(() => this.onShowMap(res))
             },
             (res: Response) =>
                 console.log('Error')

--- a/src/app/ext-commons/ext-common-entity/stats-widget/stats-widget.component.ts
+++ b/src/app/ext-commons/ext-common-entity/stats-widget/stats-widget.component.ts
@@ -77,7 +77,7 @@ export class StatsWidgetComponent implements OnInit {
             page: 0,
             size: 1
         }).pipe(
-            map((resp: HttpResponse<XmEntity[]>) => resp.headers.get('X-Total-Count')),
+            map(res => res.xTotalCount),
             catchError(e => of(iFunction.errorValue ? iFunction.errorValue : '?'))
         )
     }

--- a/src/app/ext-commons/ext-common-entity/tasks-widget/tasks-widget.component.ts
+++ b/src/app/ext-commons/ext-common-entity/tasks-widget/tasks-widget.component.ts
@@ -42,7 +42,7 @@ export class TasksWidgetComponent implements OnInit, OnDestroy {
             page: 0,
             size: 1000
         }).subscribe(
-            (res: HttpResponse<XmEntity[]>) => this.prepareData(res.body),
+            (res: XmEntity[]) => this.prepareData(res),
             (err) => console.log(err)
         );
     }

--- a/src/app/xm-entity/attachment-list/attachment-list-base.component.ts
+++ b/src/app/xm-entity/attachment-list/attachment-list-base.component.ts
@@ -95,9 +95,9 @@ export class AttachmentListBaseComponent implements OnInit, OnChanges, OnDestroy
             return;
         }
 
-        this.xmEntityService.find(this.xmEntityId, {'embed': 'attachments'}).subscribe((xmEntity: HttpResponse<XmEntity>) => {
-            if (xmEntity.body.attachments) {
-                this.attachments = [...xmEntity.body.attachments];
+        this.xmEntityService.find(this.xmEntityId, {'embed': 'attachments'}).subscribe((xmEntity: XmEntity) => {
+            if (xmEntity.attachments) {
+                this.attachments = [...xmEntity.attachments];
             }
         });
     }

--- a/src/app/xm-entity/avatar-dialog/avatar-dialog.component.ts
+++ b/src/app/xm-entity/avatar-dialog/avatar-dialog.component.ts
@@ -56,8 +56,8 @@ export class AvatarDialogComponent implements OnInit {
             // window.navigator.msSaveBlob(file, 'avatar-' + this.xmEntity.id);
         }
         this.xmEntityService.createAvatar(file).subscribe((avatarUrl) => {
-            this.xmEntityService.find(this.xmEntity.id, {'embed': 'data'}).subscribe((xmEntity: HttpResponse<XmEntity>) => {
-                const xmEntityCopy = xmEntity.body;
+            this.xmEntityService.find(this.xmEntity.id, {'embed': 'data'}).subscribe((xmEntity: XmEntity) => {
+                const xmEntityCopy = xmEntity;
                 xmEntityCopy.avatarUrl = avatarUrl;
                 this.xmEntityService.update(xmEntityCopy).subscribe(() => {
                     this.eventManager.broadcast({

--- a/src/app/xm-entity/calendar-card/calendar-card.component.ts
+++ b/src/app/xm-entity/calendar-card/calendar-card.component.ts
@@ -60,10 +60,10 @@ export class CalendarCardComponent implements OnInit, OnChanges {
             return
         }
 
-        this.xmEntityService.find(this.xmEntityId, {'embed': 'calendars.events'}).subscribe((xmEntity: HttpResponse<XmEntity>) => {
-            this.xmEntity = xmEntity.body;
-            if (xmEntity.body.calendars) {
-                this.calendars = [...xmEntity.body.calendars];
+        this.xmEntityService.find(this.xmEntityId, {'embed': 'calendars.events'}).subscribe((xmEntity: XmEntity) => {
+            this.xmEntity = xmEntity;
+            if (xmEntity.calendars) {
+                this.calendars = [...xmEntity.calendars];
             }
 
             const notIncludedSpecs = this.calendarSpecs.filter((cs) => this.calendars.filter((c) => c.typeKey === cs.key).length === 0);

--- a/src/app/xm-entity/calendar-event-dialog/calendar-event-dialog.component.ts
+++ b/src/app/xm-entity/calendar-event-dialog/calendar-event-dialog.component.ts
@@ -53,7 +53,7 @@ export class CalendarEventDialogComponent implements OnInit {
             this.event.calendar = this.calendar;
             this.eventService.create(this.event).pipe(finalize(() => this.showLoader = false))
                 .subscribe(
-                (eventResp: HttpResponse<Event>) => this.onSaveSuccess(this.calendar.id, eventResp.body),
+                (eventResp: Event) => this.onSaveSuccess(this.calendar.id, eventResp),
                 (err) => console.log(err),
                 () => this.showLoader = false);
         } else {
@@ -63,7 +63,7 @@ export class CalendarEventDialogComponent implements OnInit {
             this.calendar.events = [copy];
             this.calendarService.create(this.calendar).pipe(finalize(() => this.showLoader = false))
                 .subscribe(
-                (calendarResp: HttpResponse<Calendar>) => this.onSaveSuccess(calendarResp.body.id, calendarResp.body.events.shift()),
+                (calendarResp: Calendar) => this.onSaveSuccess(calendarResp.id, calendarResp.events.shift()),
                 (err) => console.log(err),
                 () => this.showLoader = false);
         }

--- a/src/app/xm-entity/comment-card/comment-card.component.ts
+++ b/src/app/xm-entity/comment-card/comment-card.component.ts
@@ -21,7 +21,7 @@ export class CommentCardComponent implements OnInit {
 
     ngOnInit() {
         this.commentator$ = this.entityService.getProfileByKey(this.comment.userKey).pipe(
-            map(responce => responce.body),
+            map(responce => responce),
             catchError(e => of({}))
         )
     }

--- a/src/app/xm-entity/comment-list/comment-list.component.ts
+++ b/src/app/xm-entity/comment-list/comment-list.component.ts
@@ -48,10 +48,10 @@ export class CommentListComponent implements OnInit, OnChanges, OnDestroy {
     }
 
     private load() {
-        this.xmEntityService.find(this.xmEntityId, {'embed': 'comments'}).subscribe((xmEntity: HttpResponse<XmEntity>) => {
-            this.xmEntity = xmEntity.body;
-            if (xmEntity.body.comments) {
-                this.comments = [...xmEntity.body.comments];
+        this.xmEntityService.find(this.xmEntityId, {'embed': 'comments'}).subscribe((xmEntity: XmEntity) => {
+            this.xmEntity = xmEntity;
+            if (xmEntity.comments) {
+                this.comments = [...xmEntity.comments];
             }
         });
     }

--- a/src/app/xm-entity/entity-data-card/entity-data-card.component.ts
+++ b/src/app/xm-entity/entity-data-card/entity-data-card.component.ts
@@ -53,8 +53,8 @@ export class EntityDataCardComponent implements OnInit, OnChanges {
         this.xmEntityService.update(this.xmEntity).pipe(finalize(() => this.showLoader = false))
             .subscribe(
             (res) => {
-                this.eventManager.broadcast({name: 'xmEntityDetailModification', content: {entity: res.body}});
-                this.xmEntity = Object.assign(this.xmEntity, res.body);
+                this.eventManager.broadcast({name: 'xmEntityDetailModification', content: {entity: res}});
+                this.xmEntity = Object.assign(this.xmEntity, res);
                 this.alert('success', 'xm-entity.entity-data-card.update-success');
             },
             (err) => {

--- a/src/app/xm-entity/entity-detail-dialog/entity-detail-dialog.component.ts
+++ b/src/app/xm-entity/entity-detail-dialog/entity-detail-dialog.component.ts
@@ -95,14 +95,14 @@ export class EntityDetailDialogComponent implements OnInit, AfterViewInit {
         this.xmEntity.description = this.smartDescription.value;
         if (this.xmEntity.id !== undefined) {
             this.xmEntityService.update(this.xmEntity).pipe(finalize(() => this.showLoader = false))
-                .subscribe((resp) => this.onSaveSuccess(resp.body),
+                .subscribe((resp) => this.onSaveSuccess(resp),
                     // TODO: error processing
                     (err) => this.onConfirmError(err));
         } else {
             this.xmEntity.stateKey = this.selectedXmEntitySpec.states && this.selectedXmEntitySpec.states.length ?
                 Object.assign([], this.selectedXmEntitySpec.states).shift().key : null;
             this.xmEntityService.create(this.xmEntity).pipe(finalize(() => this.showLoader = false))
-                .subscribe((resp) => this.onSaveSuccess(resp.body),
+                .subscribe((resp) => this.onSaveSuccess(resp),
                     // TODO: error processing
                     (err) => this.onConfirmError(err));
         }

--- a/src/app/xm-entity/entity-list-card/entity-list-card.component.ts
+++ b/src/app/xm-entity/entity-list-card/entity-list-card.component.ts
@@ -137,18 +137,17 @@ export class EntityListCardComponent implements OnInit, OnChanges, OnDestroy {
             size: this.entitiesPerPage,
             sort: [this.predicate + ',' + (this.reverse ? 'asc' : 'desc')],
         };
-        let method = 'query';
+        let method: 'query' | 'search' = 'query';
         if (entityOptions.currentQuery) {
             options.query = entityOptions.currentQuery;
             method = 'search';
         }
 
         return this.xmEntityService[method](options).pipe(
-            tap((xmEntities: HttpResponse<XmEntity[]>) => {
-                entityOptions.totalItems = xmEntities.headers.get('X-Total-Count');
-                entityOptions.queryCount = entityOptions.totalItems;
+            tap((xmEntities) => {
+                entityOptions.queryCount = entityOptions.totalItems  = xmEntities.xTotalCount;
             }),
-            map((xmEntities: HttpResponse<XmEntity[]>) => xmEntities.body),
+            map((xmEntities: XmEntity[]) => xmEntities),
             map((xmEntities: XmEntity[]) => {
                 return xmEntities.map(e => this.enrichEntity(e));
             }),

--- a/src/app/xm-entity/function-list-section/function-list-section.component.ts
+++ b/src/app/xm-entity/function-list-section/function-list-section.component.ts
@@ -100,12 +100,12 @@ export class FunctionListSectionComponent implements OnInit, OnChanges, OnDestro
     }
 
     private getContext() {
-        this.xmEntityService.find(this.xmEntityId, {'embed': 'functionContexts'}).subscribe((xmEntity: HttpResponse<XmEntity>) => {
+        this.xmEntityService.find(this.xmEntityId, {'embed': 'functionContexts'}).subscribe((xmEntity: XmEntity) => {
             this.functionSpecs = this.functionSpecs.filter(
-                f => !f.allowedStateKeys || f.allowedStateKeys.includes(xmEntity.body.stateKey));
-            this.xmEntity = xmEntity.body;
-            if (xmEntity.body.functionContexts) {
-                this.functionContexts = [...xmEntity.body.functionContexts];
+                f => !f.allowedStateKeys || f.allowedStateKeys.includes(xmEntity.stateKey));
+            this.xmEntity = xmEntity;
+            if (xmEntity.functionContexts) {
+                this.functionContexts = [...xmEntity.functionContexts];
             }
         });
     }

--- a/src/app/xm-entity/link-detail-dialog/link-detail-search-section.component.ts
+++ b/src/app/xm-entity/link-detail-dialog/link-detail-search-section.component.ts
@@ -72,9 +72,9 @@ export class LinkDetailSearchSectionComponent implements OnInit {
                 + (this.searchQuery ? ` AND ${this.searchQuery}` : ''),
             size: 5,
             page: this.page
-        }).subscribe((xmEntities: HttpResponse<XmEntity[]>) => {
-                this.total = parseInt(xmEntities.headers.get('X-Total-Count'), 10);
-                this.searchXmEntities.push(...xmEntities.body);
+        }).subscribe((res) => {
+                this.total = res.xTotalCount;
+                this.searchXmEntities.push(...res);
             },
             (err) => console.log(err), // tslint:disable-line
             () => this.showLoader = false);

--- a/src/app/xm-entity/link-list-tree-section/link-list-tree-section.component.ts
+++ b/src/app/xm-entity/link-list-tree-section/link-list-tree-section.component.ts
@@ -45,8 +45,8 @@ export class LinkListTreeSectionComponent implements OnInit {
 
     toggle(link) {
         if (!link.target.targets) {
-            this.xmEntityService.find(link.target.id, {'embed': 'targets'}).subscribe((xmEntity: HttpResponse<XmEntity>) => {
-                link.target = xmEntity.body;
+            this.xmEntityService.find(link.target.id, {'embed': 'targets'}).subscribe((xmEntity: XmEntity) => {
+                link.target = xmEntity;
                 link.target.targets = link.target.targets ? link.target.targets : [];
             });
         }

--- a/src/app/xm-entity/link-list/link-list.component.ts
+++ b/src/app/xm-entity/link-list/link-list.component.ts
@@ -52,10 +52,10 @@ export class LinkListComponent implements OnInit, OnDestroy, OnChanges {
     private load() {
         this.links = [];
 
-        this.xmEntityService.find(this.xmEntityId, {'embed': 'targets'}).subscribe((xmEntity: HttpResponse<XmEntity>) => {
-            this.xmEntity = xmEntity.body;
-            if (xmEntity.body.targets) {
-                this.links.push(...xmEntity.body.targets);
+        this.xmEntityService.find(this.xmEntityId, {'embed': 'targets'}).subscribe((xmEntity: XmEntity) => {
+            this.xmEntity = xmEntity;
+            if (xmEntity.targets) {
+                this.links.push(...xmEntity.targets);
             }
         });
 
@@ -76,7 +76,7 @@ export class LinkListComponent implements OnInit, OnDestroy, OnChanges {
 
         return this.xmEntityService.findLinkSourcesInverted('' + this.xmEntityId, keys, {sort: ['id,desc']})
             .pipe(
-                map(response => response.body),
+                map(response => response),
                 map(items => items.map(item => this.inverseLink(item))),
                 catchError(err => of([]))
             )

--- a/src/app/xm-entity/location-list-card/location-list-card.component.ts
+++ b/src/app/xm-entity/location-list-card/location-list-card.component.ts
@@ -86,10 +86,10 @@ export class LocationListCardComponent implements OnInit, OnChanges, OnDestroy {
     private load() {
         this.locations = [];
         this.locationMaps = {};
-        this.xmEntityService.find(this.xmEntityId, {'embed': 'locations'}).subscribe((xmEntity: HttpResponse<XmEntity>) => {
-            this.xmEntity = xmEntity.body;
-            if (xmEntity.body.locations) {
-                this.locations = [...xmEntity.body.locations];
+        this.xmEntityService.find(this.xmEntityId, {'embed': 'locations'}).subscribe((xmEntity: XmEntity) => {
+            this.xmEntity = xmEntity;
+            if (xmEntity.locations) {
+                this.locations = [...xmEntity.locations];
             }
         });
     }

--- a/src/app/xm-entity/rating-list-section/rating-list-section.component.ts
+++ b/src/app/xm-entity/rating-list-section/rating-list-section.component.ts
@@ -49,16 +49,16 @@ export class RatingListSectionComponent implements OnInit, OnChanges {
             }
             return
         }
-        this.xmEntityService.find(this.xmEntityId, {'embed': 'ratings'}).subscribe((xmEntity: HttpResponse<XmEntity>) => {
-            this.xmEntity = xmEntity.body;
-            if (xmEntity.body.ratings) {
-                this.ratings = [...xmEntity.body.ratings];
+        this.xmEntityService.find(this.xmEntityId, {'embed': 'ratings'}).subscribe((xmEntity: XmEntity) => {
+            this.xmEntity = xmEntity;
+            if (xmEntity.ratings) {
+                this.ratings = [...xmEntity.ratings];
             }
 
             for (const rating of this.ratings) {
                 this.voteService.search({query: `rating.id:${rating.id}`}).subscribe(
-                    (response: HttpResponse<Vote[]>) => {
-                        this.votesNumber[rating.typeKey] = parseInt(response.headers.get('X-Total-Count'), 10);
+                    (response) => {
+                        this.votesNumber[rating.typeKey] = response.xTotalCount;
                     },
                     // TODO: error processing
                     (err) => console.log(err)
@@ -91,15 +91,15 @@ export class RatingListSectionComponent implements OnInit, OnChanges {
     }
 
     private addRating(rating: Rating, vote: Vote) {
-        this.ratingService.create(rating).subscribe((response: HttpResponse<Rating>) => {
-            vote.rating = response.body;
+        this.ratingService.create(rating).subscribe((response: Rating) => {
+            vote.rating = response;
             this.addVote(vote);
         }, () => this.alert('success', 'xm-entity.rating-list-section.vote-error'));
     }
 
     private updateRating(rating: Rating, vote: Vote) {
-        this.ratingService.update(rating).subscribe((response: HttpResponse<Rating>) => {
-            vote.rating = response.body;
+        this.ratingService.update(rating).subscribe((response: Rating) => {
+            vote.rating = response;
             this.addVote(vote);
         }, () => this.alert('success', 'xm-entity.rating-list-section.vote-error'));
     }

--- a/src/app/xm-entity/shared/attachment.service.ts
+++ b/src/app/xm-entity/shared/attachment.service.ts
@@ -1,90 +1,29 @@
-import { HttpClient, HttpResponse } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { JhiDateUtils } from 'ng-jhipster';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
-
-import { createRequestOption } from '../../shared/model/request-util';
 import { SERVER_API_URL } from '../../xm.constants';
 import { Attachment } from './attachment.model';
+import { dateParse, RestfulBase, toDate } from './restful-base';
 
 @Injectable()
-export class AttachmentService {
+export class AttachmentService extends RestfulBase<Attachment> {
 
-    private resourceUrl = SERVER_API_URL + 'entity/api/attachments';
-    private resourceSearchUrl = SERVER_API_URL + 'entity/api/_search/attachments';
-
-    constructor(private http: HttpClient, private dateUtils: JhiDateUtils) {
+    constructor(protected http: HttpClient) {
+        super(http);
+        this.resourceUrl = SERVER_API_URL + 'entity/api/attachments';
+        this.resourceSearchUrl = SERVER_API_URL + 'entity/api/_search/attachments';
     }
 
-    create(attachment: Attachment): Observable<HttpResponse<Attachment>> {
-        const copy = this.convert(attachment);
-        return this.http.post<Attachment>(this.resourceUrl, copy, {observe: 'response'}).pipe(
-            map((res: HttpResponse<Attachment>) => this.convertResponse(res)));
+    protected convertFromServer(data: Attachment): Attachment {
+        data.startDate = dateParse(data.startDate);
+        data.endDate = dateParse(data.endDate);
+        return data;
     }
 
-    update(attachment: Attachment): Observable<HttpResponse<Attachment>> {
-        const copy = this.convert(attachment);
-        return this.http.put<Attachment>(this.resourceUrl, copy, {observe: 'response'}).pipe(
-            map((res: HttpResponse<Attachment>) => this.convertResponse(res)));
+    protected convertForServer(data: Attachment): Attachment {
+        data = Object.assign({}, data);
+        data.startDate = toDate(data.startDate);
+        data.endDate = toDate(data.endDate);
+        return data;
     }
 
-    find(id: number): Observable<HttpResponse<Attachment>> {
-        return this.http.get<Attachment>(`${this.resourceUrl}/${id}`, {observe: 'response'}).pipe(
-            map((res: HttpResponse<Attachment>) => this.convertResponse(res)));
-    }
-
-    query(req?: any): Observable<HttpResponse<Attachment[]>> {
-        const options = createRequestOption(req);
-        return this.http.get<Attachment[]>(this.resourceUrl, {params: options, observe: 'response'}).pipe(
-            map((res: HttpResponse<Attachment[]>) => this.convertArrayResponse(res)));
-    }
-
-    delete(id: number): Observable<HttpResponse<any>> {
-        return this.http.delete<any>(`${this.resourceUrl}/${id}`, {observe: 'response'});
-    }
-
-    search(req?: any): Observable<HttpResponse<Attachment[]>> {
-        const options = createRequestOption(req);
-        return this.http.get<Attachment[]>(this.resourceSearchUrl, {params: options, observe: 'response'}).pipe(
-            map((res: HttpResponse<Attachment[]>) => this.convertArrayResponse(res)));
-    }
-
-    private convertResponse(res: HttpResponse<Attachment>): HttpResponse<Attachment> {
-        const body: Attachment = this.convertItemFromServer(res.body);
-        return res.clone({body});
-    }
-
-    private convertArrayResponse(res: HttpResponse<Attachment[]>): HttpResponse<Attachment[]> {
-        const jsonResponse: Attachment[] = res.body;
-        const body: Attachment[] = [];
-        for (let i = 0; i < jsonResponse.length; i++) {
-            body.push(this.convertItemFromServer(jsonResponse[i]));
-        }
-        return res.clone({body});
-    }
-
-    /**
-     * Convert a returned JSON object to Attachment.
-     */
-    private convertItemFromServer(attachment: Attachment): Attachment {
-        const copy: Attachment = Object.assign({}, attachment);
-        copy.startDate = this.dateUtils
-            .convertDateTimeFromServer(attachment.startDate);
-        copy.endDate = this.dateUtils
-            .convertDateTimeFromServer(attachment.endDate);
-        return copy;
-    }
-
-    /**
-     * Convert a Attachment to a JSON which can be sent to the server.
-     */
-    private convert(attachment: Attachment): Attachment {
-        const copy: Attachment = Object.assign({}, attachment);
-
-        copy.startDate = this.dateUtils.toDate(attachment.startDate);
-
-        copy.endDate = this.dateUtils.toDate(attachment.endDate);
-        return copy;
-    }
 }

--- a/src/app/xm-entity/shared/calendar.service.ts
+++ b/src/app/xm-entity/shared/calendar.service.ts
@@ -1,90 +1,29 @@
-import { HttpClient, HttpResponse } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { JhiDateUtils } from 'ng-jhipster';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
-
-import { createRequestOption } from '../../shared/model/request-util';
 import { SERVER_API_URL } from '../../xm.constants';
 import { Calendar } from './calendar.model';
+import { dateParse, RestfulBase, toDate } from './restful-base';
 
 @Injectable()
-export class CalendarService {
+export class CalendarService extends RestfulBase<Calendar> {
 
-    private resourceUrl = SERVER_API_URL + 'entity/api/calendars';
-    private resourceSearchUrl = SERVER_API_URL + 'entity/api/_search/calendars';
-
-    constructor(private http: HttpClient, private dateUtils: JhiDateUtils) {
+    constructor(protected http: HttpClient) {
+        super(http);
+        this.resourceUrl = SERVER_API_URL + 'entity/api/calendars';
+        this.resourceSearchUrl = SERVER_API_URL + 'entity/api/_search/calendars';
     }
 
-    create(calendar: Calendar): Observable<HttpResponse<Calendar>> {
-        const copy = this.convert(calendar);
-        return this.http.post<Calendar>(this.resourceUrl, copy, {observe: 'response'}).pipe(
-            map((res: HttpResponse<Calendar>) => this.convertResponse(res)));
+    protected convertFromServer(data: Calendar): Calendar {
+        data.startDate = dateParse(data.startDate);
+        data.endDate = dateParse(data.endDate);
+        return data;
     }
 
-    update(calendar: Calendar): Observable<HttpResponse<Calendar>> {
-        const copy = this.convert(calendar);
-        return this.http.put<Calendar>(this.resourceUrl, copy, {observe: 'response'}).pipe(
-            map((res: HttpResponse<Calendar>) => this.convertResponse(res)));
+    protected convertForServer(data: Calendar): Calendar {
+        data = Object.assign({}, data);
+        data.startDate = toDate(data.startDate);
+        data.endDate = toDate(data.endDate);
+        return data;
     }
 
-    find(id: number): Observable<HttpResponse<Calendar>> {
-        return this.http.get<Calendar>(`${this.resourceUrl}/${id}`, {observe: 'response'}).pipe(
-            map((res: HttpResponse<Calendar>) => this.convertResponse(res)));
-    }
-
-    query(req?: any): Observable<HttpResponse<Calendar[]>> {
-        const options = createRequestOption(req);
-        return this.http.get<Calendar[]>(this.resourceUrl, {params: options, observe: 'response'}).pipe(
-            map((res: HttpResponse<Calendar[]>) => this.convertArrayResponse(res)));
-    }
-
-    delete(id: number): Observable<HttpResponse<any>> {
-        return this.http.delete<any>(`${this.resourceUrl}/${id}`, {observe: 'response'});
-    }
-
-    search(req?: any): Observable<HttpResponse<Calendar[]>> {
-        const options = createRequestOption(req);
-        return this.http.get<Calendar[]>(this.resourceSearchUrl, {params: options, observe: 'response'}).pipe(
-            map((res: HttpResponse<Calendar[]>) => this.convertArrayResponse(res)));
-    }
-
-    private convertResponse(res: HttpResponse<Calendar>): HttpResponse<Calendar> {
-        const body: Calendar = this.convertItemFromServer(res.body);
-        return res.clone({body});
-    }
-
-    private convertArrayResponse(res: HttpResponse<Calendar[]>): HttpResponse<Calendar[]> {
-        const jsonResponse: Calendar[] = res.body;
-        const body: Calendar[] = [];
-        for (let i = 0; i < jsonResponse.length; i++) {
-            body.push(this.convertItemFromServer(jsonResponse[i]));
-        }
-        return res.clone({body});
-    }
-
-    /**
-     * Convert a returned JSON object to Calendar.
-     */
-    private convertItemFromServer(calendar: Calendar): Calendar {
-        const copy: Calendar = Object.assign({}, calendar);
-        copy.startDate = this.dateUtils
-            .convertDateTimeFromServer(calendar.startDate);
-        copy.endDate = this.dateUtils
-            .convertDateTimeFromServer(calendar.endDate);
-        return copy;
-    }
-
-    /**
-     * Convert a Calendar to a JSON which can be sent to the server.
-     */
-    private convert(calendar: Calendar): Calendar {
-        const copy: Calendar = Object.assign({}, calendar);
-
-        copy.startDate = this.dateUtils.toDate(calendar.startDate);
-
-        copy.endDate = this.dateUtils.toDate(calendar.endDate);
-        return copy;
-    }
 }

--- a/src/app/xm-entity/shared/comment.service.ts
+++ b/src/app/xm-entity/shared/comment.service.ts
@@ -1,86 +1,27 @@
-import { HttpClient, HttpResponse } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { JhiDateUtils } from 'ng-jhipster';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
-
-import { createRequestOption } from '../../shared/model/request-util';
 import { SERVER_API_URL } from '../../xm.constants';
 import { Comment } from './comment.model';
+import { dateParse, RestfulBase, toDate } from './restful-base';
 
 @Injectable()
-export class CommentService {
+export class CommentService extends RestfulBase<Comment> {
 
-    private resourceUrl = SERVER_API_URL + 'entity/api/comments';
-    private resourceSearchUrl = SERVER_API_URL + 'entity/api/_search/comments';
-
-    constructor(private http: HttpClient, private dateUtils: JhiDateUtils) {
+    constructor(protected http: HttpClient) {
+        super(http);
+        this.resourceUrl = SERVER_API_URL + 'entity/api/comments';
+        this.resourceSearchUrl = SERVER_API_URL + 'entity/api/_search/comments';
     }
 
-    create(comment: Comment): Observable<HttpResponse<Comment>> {
-        const copy = this.convert(comment);
-        return this.http.post<Comment>(this.resourceUrl, copy, {observe: 'response'}).pipe(
-            map((res: HttpResponse<Comment>) => this.convertResponse(res)));
+    protected convertFromServer(data: Comment): Comment {
+        data.entryDate = dateParse(data.entryDate);
+        return data;
     }
 
-    update(comment: Comment): Observable<HttpResponse<Comment>> {
-        const copy = this.convert(comment);
-        return this.http.put<Comment>(this.resourceUrl, copy, {observe: 'response'}).pipe(
-            map((res: HttpResponse<Comment>) => this.convertResponse(res)));
+    protected convertForServer(data: Comment): Comment {
+        data = Object.assign({}, data);
+        data.entryDate = toDate(data.entryDate);
+        return data;
     }
 
-    find(id: number): Observable<HttpResponse<Comment>> {
-        return this.http.get<Comment>(`${this.resourceUrl}/${id}`, {observe: 'response'}).pipe(
-            map((res: HttpResponse<Comment>) => this.convertResponse(res)));
-    }
-
-    query(req?: any): Observable<HttpResponse<Comment[]>> {
-        const options = createRequestOption(req);
-        return this.http.get<Comment[]>(this.resourceUrl, {params: options, observe: 'response'}).pipe(
-            map((res: HttpResponse<Comment[]>) => this.convertArrayResponse(res)));
-    }
-
-    delete(id: number): Observable<HttpResponse<any>> {
-        return this.http.delete<any>(`${this.resourceUrl}/${id}`, {observe: 'response'});
-    }
-
-    search(req?: any): Observable<HttpResponse<Comment[]>> {
-        const options = createRequestOption(req);
-        return this.http.get<Comment[]>(this.resourceSearchUrl, {params: options, observe: 'response'}).pipe(
-            map((res: HttpResponse<Comment[]>) => this.convertArrayResponse(res)));
-    }
-
-    private convertResponse(res: HttpResponse<Comment>): HttpResponse<Comment> {
-        const body: Comment = this.convertItemFromServer(res.body);
-        return res.clone({body});
-    }
-
-    private convertArrayResponse(res: HttpResponse<Comment[]>): HttpResponse<Comment[]> {
-        const jsonResponse: Comment[] = res.body;
-        const body: Comment[] = [];
-        for (let i = 0; i < jsonResponse.length; i++) {
-            body.push(this.convertItemFromServer(jsonResponse[i]));
-        }
-        return res.clone({body});
-    }
-
-    /**
-     * Convert a returned JSON object to Comment.
-     */
-    private convertItemFromServer(comment: Comment): Comment {
-        const copy: Comment = Object.assign({}, comment);
-        copy.entryDate = this.dateUtils
-            .convertDateTimeFromServer(comment.entryDate);
-        return copy;
-    }
-
-    /**
-     * Convert a Comment to a JSON which can be sent to the server.
-     */
-    private convert(comment: Comment): Comment {
-        const copy: Comment = Object.assign({}, comment);
-
-        copy.entryDate = this.dateUtils.toDate(comment.entryDate);
-        return copy;
-    }
 }

--- a/src/app/xm-entity/shared/content.service.ts
+++ b/src/app/xm-entity/shared/content.service.ts
@@ -1,74 +1,15 @@
-import { HttpClient, HttpResponse } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
-
-import { createRequestOption } from '../../shared/model/request-util';
 import { SERVER_API_URL } from '../../xm.constants';
 import { Content } from './content.model';
+import { RestfulBase } from './restful-base';
 
 @Injectable()
-export class ContentService {
+export class ContentService extends RestfulBase<Content> {
 
-    private resourceUrl = SERVER_API_URL + 'entity/api/contents';
-
-    constructor(private http: HttpClient) {
+    constructor(protected http: HttpClient) {
+        super(http);
+        this.resourceUrl = SERVER_API_URL + 'entity/api/contents';
     }
 
-    create(content: Content): Observable<HttpResponse<Content>> {
-        const copy = this.convert(content);
-        return this.http.post<Content>(this.resourceUrl, copy, {observe: 'response'}).pipe(
-            map((res: HttpResponse<Content>) => this.convertResponse(res)));
-    }
-
-    update(content: Content): Observable<HttpResponse<Content>> {
-        const copy = this.convert(content);
-        return this.http.put<Content>(this.resourceUrl, copy, {observe: 'response'}).pipe(
-            map((res: HttpResponse<Content>) => this.convertResponse(res)));
-    }
-
-    find(id: number): Observable<HttpResponse<Content>> {
-        return this.http.get<Content>(`${this.resourceUrl}/${id}`, {observe: 'response'}).pipe(
-            map((res: HttpResponse<Content>) => this.convertResponse(res)));
-    }
-
-    query(req?: any): Observable<HttpResponse<Content[]>> {
-        const options = createRequestOption(req);
-        return this.http.get<Content[]>(this.resourceUrl, {params: options, observe: 'response'}).pipe(
-            map((res: HttpResponse<Content[]>) => this.convertArrayResponse(res)));
-    }
-
-    delete(id: number): Observable<HttpResponse<any>> {
-        return this.http.delete<any>(`${this.resourceUrl}/${id}`, {observe: 'response'});
-    }
-
-    private convertResponse(res: HttpResponse<Content>): HttpResponse<Content> {
-        const body: Content = this.convertItemFromServer(res.body);
-        return res.clone({body});
-    }
-
-    private convertArrayResponse(res: HttpResponse<Content[]>): HttpResponse<Content[]> {
-        const jsonResponse: Content[] = res.body;
-        const body: Content[] = [];
-        for (let i = 0; i < jsonResponse.length; i++) {
-            body.push(this.convertItemFromServer(jsonResponse[i]));
-        }
-        return res.clone({body});
-    }
-
-    /**
-     * Convert a returned JSON object to Content.
-     */
-    private convertItemFromServer(content: Content): Content {
-        const copy: Content = Object.assign({}, content);
-        return copy;
-    }
-
-    /**
-     * Convert a Content to a JSON which can be sent to the server.
-     */
-    private convert(content: Content): Content {
-        const copy: Content = Object.assign({}, content);
-        return copy;
-    }
 }

--- a/src/app/xm-entity/shared/event.service.ts
+++ b/src/app/xm-entity/shared/event.service.ts
@@ -1,90 +1,29 @@
-import { HttpClient, HttpResponse } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { JhiDateUtils } from 'ng-jhipster';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
-
-import { createRequestOption } from '../../shared/model/request-util';
 import { SERVER_API_URL } from '../../xm.constants';
 import { Event } from './event.model';
+import { dateParse, RestfulBase, toDate } from './restful-base';
 
 @Injectable()
-export class EventService {
+export class EventService extends RestfulBase<Event> {
 
-    private resourceUrl = SERVER_API_URL + 'entity/api/events';
-    private resourceSearchUrl = SERVER_API_URL + 'entity/api/_search/events';
-
-    constructor(private http: HttpClient, private dateUtils: JhiDateUtils) {
+    constructor(protected http: HttpClient) {
+        super(http);
+        this.resourceUrl = SERVER_API_URL + 'entity/api/events';
+        this.resourceSearchUrl = SERVER_API_URL + 'entity/api/_search/events';
     }
 
-    create(event: Event): Observable<HttpResponse<Event>> {
-        const copy = this.convert(event);
-        return this.http.post<Event>(this.resourceUrl, copy, {observe: 'response'}).pipe(
-            map((res: HttpResponse<Event>) => this.convertResponse(res)));
+    protected convertFromServer(data: Event): Event {
+        data.startDate = dateParse(data.startDate);
+        data.endDate = dateParse(data.endDate);
+        return data;
     }
 
-    update(event: Event): Observable<HttpResponse<Event>> {
-        const copy = this.convert(event);
-        return this.http.put<Event>(this.resourceUrl, copy, {observe: 'response'}).pipe(
-            map((res: HttpResponse<Event>) => this.convertResponse(res)));
+    protected convertForServer(data: Event): Event {
+        data = Object.assign({}, data);
+        data.startDate = toDate(data.startDate);
+        data.endDate = toDate(data.endDate);
+        return data;
     }
 
-    find(id: number): Observable<HttpResponse<Event>> {
-        return this.http.get<Event>(`${this.resourceUrl}/${id}`, {observe: 'response'}).pipe(
-            map((res: HttpResponse<Event>) => this.convertResponse(res)));
-    }
-
-    query(req?: any): Observable<HttpResponse<Event[]>> {
-        const options = createRequestOption(req);
-        return this.http.get<Event[]>(this.resourceUrl, {params: options, observe: 'response'}).pipe(
-            map((res: HttpResponse<Event[]>) => this.convertArrayResponse(res)));
-    }
-
-    delete(id: number): Observable<HttpResponse<any>> {
-        return this.http.delete<any>(`${this.resourceUrl}/${id}`, {observe: 'response'});
-    }
-
-    search(req?: any): Observable<HttpResponse<Event[]>> {
-        const options = createRequestOption(req);
-        return this.http.get<Event[]>(this.resourceSearchUrl, {params: options, observe: 'response'}).pipe(
-            map((res: HttpResponse<Event[]>) => this.convertArrayResponse(res)));
-    }
-
-    private convertResponse(res: HttpResponse<Event>): HttpResponse<Event> {
-        const body: Event = this.convertItemFromServer(res.body);
-        return res.clone({body});
-    }
-
-    private convertArrayResponse(res: HttpResponse<Event[]>): HttpResponse<Event[]> {
-        const jsonResponse: Event[] = res.body;
-        const body: Event[] = [];
-        for (let i = 0; i < jsonResponse.length; i++) {
-            body.push(this.convertItemFromServer(jsonResponse[i]));
-        }
-        return res.clone({body});
-    }
-
-    /**
-     * Convert a returned JSON object to Event.
-     */
-    private convertItemFromServer(event: Event): Event {
-        const copy: Event = Object.assign({}, event);
-        copy.startDate = this.dateUtils
-            .convertDateTimeFromServer(event.startDate);
-        copy.endDate = this.dateUtils
-            .convertDateTimeFromServer(event.endDate);
-        return copy;
-    }
-
-    /**
-     * Convert a Event to a JSON which can be sent to the server.
-     */
-    private convert(event: Event): Event {
-        const copy: Event = Object.assign({}, event);
-
-        copy.startDate = this.dateUtils.toDate(event.startDate);
-
-        copy.endDate = this.dateUtils.toDate(event.endDate);
-        return copy;
-    }
 }

--- a/src/app/xm-entity/shared/function-context.service.ts
+++ b/src/app/xm-entity/shared/function-context.service.ts
@@ -1,94 +1,31 @@
-import { HttpClient, HttpResponse } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { JhiDateUtils } from 'ng-jhipster';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
-
-import { createRequestOption } from '../../shared/model/request-util';
 import { SERVER_API_URL } from '../../xm.constants';
 import { FunctionContext } from './function-context.model';
+import { dateParse, RestfulBase, toDate } from './restful-base';
 
 @Injectable()
-export class FunctionContextService {
+export class FunctionContextService extends RestfulBase<FunctionContext> {
 
-    private resourceUrl = SERVER_API_URL + 'entity/api/function-contexts';
-    private resourceSearchUrl = SERVER_API_URL + 'entity/api/_search/function-contexts';
-
-    constructor(private http: HttpClient, private dateUtils: JhiDateUtils) {
+    constructor(protected http: HttpClient) {
+        super(http);
+        this.resourceUrl = SERVER_API_URL + 'entity/api/function-contexts';
+        this.resourceSearchUrl = SERVER_API_URL + 'entity/api/_search/function-contexts';
     }
 
-    create(functionContext: FunctionContext): Observable<HttpResponse<FunctionContext>> {
-        const copy = this.convert(functionContext);
-        return this.http.post<FunctionContext>(this.resourceUrl, copy, {observe: 'response'}).pipe(
-            map((res: HttpResponse<FunctionContext>) => this.convertResponse(res)));
+    protected convertFromServer(data: FunctionContext): FunctionContext {
+        data.startDate = dateParse(data.startDate);
+        data.updateDate = dateParse(data.updateDate);
+        data.endDate = dateParse(data.endDate);
+        return data;
     }
 
-    update(functionContext: FunctionContext): Observable<HttpResponse<FunctionContext>> {
-        const copy = this.convert(functionContext);
-        return this.http.put<FunctionContext>(this.resourceUrl, copy, {observe: 'response'}).pipe(
-            map((res: HttpResponse<FunctionContext>) => this.convertResponse(res)));
+    protected convertForServer(data: FunctionContext): FunctionContext {
+        data = Object.assign({}, data);
+        data.startDate = toDate(data.startDate);
+        data.updateDate = toDate(data.updateDate);
+        data.endDate = toDate(data.endDate);
+        return data;
     }
 
-    find(id: number): Observable<HttpResponse<FunctionContext>> {
-        return this.http.get<FunctionContext>(`${this.resourceUrl}/${id}`, {observe: 'response'}).pipe(
-            map((res: HttpResponse<FunctionContext>) => this.convertResponse(res)));
-    }
-
-    query(req?: any): Observable<HttpResponse<FunctionContext[]>> {
-        const options = createRequestOption(req);
-        return this.http.get<FunctionContext[]>(this.resourceUrl, {params: options, observe: 'response'}).pipe(
-            map((res: HttpResponse<FunctionContext[]>) => this.convertArrayResponse(res)));
-    }
-
-    delete(id: number): Observable<HttpResponse<any>> {
-        return this.http.delete<any>(`${this.resourceUrl}/${id}`, {observe: 'response'});
-    }
-
-    search(req?: any): Observable<HttpResponse<FunctionContext[]>> {
-        const options = createRequestOption(req);
-        return this.http.get<FunctionContext[]>(this.resourceSearchUrl, {params: options, observe: 'response'}).pipe(
-            map((res: HttpResponse<FunctionContext[]>) => this.convertArrayResponse(res)));
-    }
-
-    private convertResponse(res: HttpResponse<FunctionContext>): HttpResponse<FunctionContext> {
-        const body: FunctionContext = this.convertItemFromServer(res.body);
-        return res.clone({body});
-    }
-
-    private convertArrayResponse(res: HttpResponse<FunctionContext[]>): HttpResponse<FunctionContext[]> {
-        const jsonResponse: FunctionContext[] = res.body;
-        const body: FunctionContext[] = [];
-        for (let i = 0; i < jsonResponse.length; i++) {
-            body.push(this.convertItemFromServer(jsonResponse[i]));
-        }
-        return res.clone({body});
-    }
-
-    /**
-     * Convert a returned JSON object to FunctionContext.
-     */
-    private convertItemFromServer(functionContext: FunctionContext): FunctionContext {
-        const copy: FunctionContext = Object.assign({}, functionContext);
-        copy.startDate = this.dateUtils
-            .convertDateTimeFromServer(functionContext.startDate);
-        copy.updateDate = this.dateUtils
-            .convertDateTimeFromServer(functionContext.updateDate);
-        copy.endDate = this.dateUtils
-            .convertDateTimeFromServer(functionContext.endDate);
-        return copy;
-    }
-
-    /**
-     * Convert a FunctionContext to a JSON which can be sent to the server.
-     */
-    private convert(functionContext: FunctionContext): FunctionContext {
-        const copy: FunctionContext = Object.assign({}, functionContext);
-
-        copy.startDate = this.dateUtils.toDate(functionContext.startDate);
-
-        copy.updateDate = this.dateUtils.toDate(functionContext.updateDate);
-
-        copy.endDate = this.dateUtils.toDate(functionContext.endDate);
-        return copy;
-    }
 }

--- a/src/app/xm-entity/shared/index.ts
+++ b/src/app/xm-entity/shared/index.ts
@@ -1,0 +1,58 @@
+export * from './attachment.model';
+export * from './attachment.service';
+export * from './attachment-spec.model';
+
+export * from './calendar.model';
+export * from './calendar.service';
+export * from './calendar-spec.model';
+
+export * from './comment.model';
+export * from './comment.service';
+export * from './comment-spec.model';
+
+export * from './content.model';
+export * from './content.service';
+
+export * from './event.model';
+export * from './event.service';
+export * from './event-spec.model';
+
+export * from './fast-search-spec.model';
+
+export * from './function.service';
+export * from './function-context.model';
+export * from './function-context.service';
+export * from './function-spec.model';
+
+export * from './link.model';
+export * from './link.service';
+export * from './link-spec.model';
+
+export * from './location.model';
+export * from './location.service';
+export * from './location-spec.model';
+
+export * from './password-spec.model';
+
+export * from './rating.model';
+export * from './rating.service';
+export * from './rating-spec.model';
+
+export * from './restful-base';
+
+export * from './spec.model';
+export * from './state-spec.model';
+
+export * from './tag.model';
+export * from './tag.service';
+export * from './tag-spec.model';
+
+export * from './vote.model';
+export * from './vote.service';
+
+export * from './xm-entity.model';
+export * from './xm-entity.service';
+
+export * from './xm-entity-spec.model';
+export * from './xm-entity-spec.service';
+export * from './xm-entity-spec-wrapper.service';

--- a/src/app/xm-entity/shared/link.service.ts
+++ b/src/app/xm-entity/shared/link.service.ts
@@ -1,90 +1,29 @@
-import { HttpClient, HttpResponse } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { JhiDateUtils } from 'ng-jhipster';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
-
-import { createRequestOption } from '../../shared/model/request-util';
 import { SERVER_API_URL } from '../../xm.constants';
 import { Link } from './link.model';
+import { dateParse, RestfulBase, toDate } from './restful-base';
 
 @Injectable()
-export class LinkService {
+export class LinkService extends RestfulBase<Link> {
 
-    private resourceUrl = SERVER_API_URL + 'entity/api/links';
-    private resourceSearchUrl = SERVER_API_URL + 'entity/api/_search/links';
-
-    constructor(private http: HttpClient, private dateUtils: JhiDateUtils) {
+    constructor(protected http: HttpClient) {
+        super(http);
+        this.resourceUrl = SERVER_API_URL + 'entity/api/links';
+        this.resourceSearchUrl = SERVER_API_URL + 'entity/api/_search/links';
     }
 
-    create(link: Link): Observable<HttpResponse<Link>> {
-        const copy = this.convert(link);
-        return this.http.post<Link>(this.resourceUrl, copy, {observe: 'response'}).pipe(
-            map((res: HttpResponse<Link>) => this.convertResponse(res)));
+    protected convertFromServer(data: Link): Link {
+        data.startDate = dateParse(data.startDate);
+        data.endDate = dateParse(data.endDate);
+        return data;
     }
 
-    update(link: Link): Observable<HttpResponse<Link>> {
-        const copy = this.convert(link);
-        return this.http.put<Link>(this.resourceUrl, copy, {observe: 'response'}).pipe(
-            map((res: HttpResponse<Link>) => this.convertResponse(res)));
+    protected convertForServer(data: Link): Link {
+        data = Object.assign({}, data);
+        data.startDate = toDate(data.startDate);
+        data.endDate = toDate(data.endDate);
+        return data;
     }
 
-    find(id: number): Observable<HttpResponse<Link>> {
-        return this.http.get<Link>(`${this.resourceUrl}/${id}`, {observe: 'response'}).pipe(
-            map((res: HttpResponse<Link>) => this.convertResponse(res)));
-    }
-
-    query(req?: any): Observable<HttpResponse<Link[]>> {
-        const options = createRequestOption(req);
-        return this.http.get<Link[]>(this.resourceUrl, {params: options, observe: 'response'}).pipe(
-            map((res: HttpResponse<Link[]>) => this.convertArrayResponse(res)));
-    }
-
-    delete(id: number): Observable<HttpResponse<any>> {
-        return this.http.delete<any>(`${this.resourceUrl}/${id}`, {observe: 'response'});
-    }
-
-    search(req?: any): Observable<HttpResponse<Link[]>> {
-        const options = createRequestOption(req);
-        return this.http.get<Link[]>(this.resourceSearchUrl, {params: options, observe: 'response'}).pipe(
-            map((res: HttpResponse<Link[]>) => this.convertArrayResponse(res)));
-    }
-
-    private convertResponse(res: HttpResponse<Link>): HttpResponse<Link> {
-        const body: Link = this.convertItemFromServer(res.body);
-        return res.clone({body});
-    }
-
-    private convertArrayResponse(res: HttpResponse<Link[]>): HttpResponse<Link[]> {
-        const jsonResponse: Link[] = res.body;
-        const body: Link[] = [];
-        for (let i = 0; i < jsonResponse.length; i++) {
-            body.push(this.convertItemFromServer(jsonResponse[i]));
-        }
-        return res.clone({body});
-    }
-
-    /**
-     * Convert a returned JSON object to Link.
-     */
-    private convertItemFromServer(link: Link): Link {
-        const copy: Link = Object.assign({}, link);
-        copy.startDate = this.dateUtils
-            .convertDateTimeFromServer(link.startDate);
-        copy.endDate = this.dateUtils
-            .convertDateTimeFromServer(link.endDate);
-        return copy;
-    }
-
-    /**
-     * Convert a Link to a JSON which can be sent to the server.
-     */
-    private convert(link: Link): Link {
-        const copy: Link = Object.assign({}, link);
-
-        copy.startDate = this.dateUtils.toDate(link.startDate);
-
-        copy.endDate = this.dateUtils.toDate(link.endDate);
-        return copy;
-    }
 }

--- a/src/app/xm-entity/shared/location.service.ts
+++ b/src/app/xm-entity/shared/location.service.ts
@@ -1,81 +1,16 @@
-import { HttpClient, HttpResponse } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
-
-import { createRequestOption } from '../../shared/model/request-util';
 import { SERVER_API_URL } from '../../xm.constants';
 import { Location } from './location.model';
+import { RestfulBase } from './restful-base';
 
 @Injectable()
-export class LocationService {
+export class LocationService extends RestfulBase<Location> {
 
-    private resourceUrl = SERVER_API_URL + 'entity/api/locations';
-    private resourceSearchUrl = SERVER_API_URL + 'entity/api/_search/locations';
-
-    constructor(private http: HttpClient) {
+    constructor(protected http: HttpClient) {
+        super(http);
+        this.resourceSearchUrl = SERVER_API_URL + 'entity/api/_search/locations';
+        this.resourceUrl = SERVER_API_URL + 'entity/api/locations';
     }
 
-    create(location: Location): Observable<HttpResponse<Location>> {
-        const copy = this.convert(location);
-        return this.http.post<Location>(this.resourceUrl, copy, {observe: 'response'}).pipe(
-            map((res: HttpResponse<Location>) => this.convertResponse(res)));
-    }
-
-    update(location: Location): Observable<HttpResponse<Location>> {
-        const copy = this.convert(location);
-        return this.http.put<Location>(this.resourceUrl, copy, {observe: 'response'}).pipe(
-            map((res: HttpResponse<Location>) => this.convertResponse(res)));
-    }
-
-    find(id: number): Observable<HttpResponse<Location>> {
-        return this.http.get<Location>(`${this.resourceUrl}/${id}`, {observe: 'response'}).pipe(
-            map((res: HttpResponse<Location>) => this.convertResponse(res)));
-    }
-
-    query(req?: any): Observable<HttpResponse<Location[]>> {
-        const options = createRequestOption(req);
-        return this.http.get<Location[]>(this.resourceUrl, {params: options, observe: 'response'}).pipe(
-            map((res: HttpResponse<Location[]>) => this.convertArrayResponse(res)));
-    }
-
-    delete(id: number): Observable<HttpResponse<any>> {
-        return this.http.delete<any>(`${this.resourceUrl}/${id}`, {observe: 'response'});
-    }
-
-    search(req?: any): Observable<HttpResponse<Location[]>> {
-        const options = createRequestOption(req);
-        return this.http.get<Location[]>(this.resourceSearchUrl, {params: options, observe: 'response'}).pipe(
-            map((res: HttpResponse<Location[]>) => this.convertArrayResponse(res)));
-    }
-
-    private convertResponse(res: HttpResponse<Location>): HttpResponse<Location> {
-        const body: Location = this.convertItemFromServer(res.body);
-        return res.clone({body});
-    }
-
-    private convertArrayResponse(res: HttpResponse<Location[]>): HttpResponse<Location[]> {
-        const jsonResponse: Location[] = res.body;
-        const body: Location[] = [];
-        for (let i = 0; i < jsonResponse.length; i++) {
-            body.push(this.convertItemFromServer(jsonResponse[i]));
-        }
-        return res.clone({body});
-    }
-
-    /**
-     * Convert a returned JSON object to Location.
-     */
-    private convertItemFromServer(location: Location): Location {
-        const copy: Location = Object.assign({}, location);
-        return copy;
-    }
-
-    /**
-     * Convert a Location to a JSON which can be sent to the server.
-     */
-    private convert(location: Location): Location {
-        const copy: Location = Object.assign({}, location);
-        return copy;
-    }
 }

--- a/src/app/xm-entity/shared/rating.service.ts
+++ b/src/app/xm-entity/shared/rating.service.ts
@@ -1,90 +1,29 @@
-import { HttpClient, HttpResponse } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { JhiDateUtils } from 'ng-jhipster';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
-
-import { createRequestOption } from '../../shared/model/request-util';
 import { SERVER_API_URL } from '../../xm.constants';
 import { Rating } from './rating.model';
+import { dateParse, RestfulBase, toDate } from './restful-base';
 
 @Injectable()
-export class RatingService {
+export class RatingService extends RestfulBase<Rating> {
 
-    private resourceUrl = SERVER_API_URL + 'entity/api/ratings';
-    private resourceSearchUrl = SERVER_API_URL + 'entity/api/_search/ratings';
-
-    constructor(private http: HttpClient, private dateUtils: JhiDateUtils) {
+    constructor(protected http: HttpClient) {
+        super(http);
+        this.resourceUrl = SERVER_API_URL + 'entity/api/ratings';
+        this.resourceSearchUrl = SERVER_API_URL + 'entity/api/_search/ratings';
     }
 
-    create(rating: Rating): Observable<HttpResponse<Rating>> {
-        const copy = this.convert(rating);
-        return this.http.post<Rating>(this.resourceUrl, copy, {observe: 'response'}).pipe(
-            map((res: HttpResponse<Rating>) => this.convertResponse(res)));
+    protected convertFromServer(data: Rating): Rating {
+        data.startDate = dateParse(data.startDate);
+        data.endDate = dateParse(data.endDate);
+        return data;
     }
 
-    update(rating: Rating): Observable<HttpResponse<Rating>> {
-        const copy = this.convert(rating);
-        return this.http.put<Rating>(this.resourceUrl, copy, {observe: 'response'}).pipe(
-            map((res: HttpResponse<Rating>) => this.convertResponse(res)));
+    protected convertForServer(data: Rating): Rating {
+        data = Object.assign({}, data);
+        data.startDate = toDate(data.startDate);
+        data.endDate = toDate(data.endDate);
+        return data;
     }
 
-    find(id: number): Observable<HttpResponse<Rating>> {
-        return this.http.get<Rating>(`${this.resourceUrl}/${id}`, {observe: 'response'}).pipe(
-            map((res: HttpResponse<Rating>) => this.convertResponse(res)));
-    }
-
-    query(req?: any): Observable<HttpResponse<Rating[]>> {
-        const options = createRequestOption(req);
-        return this.http.get<Rating[]>(this.resourceUrl, {params: options, observe: 'response'}).pipe(
-            map((res: HttpResponse<Rating[]>) => this.convertArrayResponse(res)));
-    }
-
-    delete(id: number): Observable<HttpResponse<any>> {
-        return this.http.delete<any>(`${this.resourceUrl}/${id}`, {observe: 'response'});
-    }
-
-    search(req?: any): Observable<HttpResponse<Rating[]>> {
-        const options = createRequestOption(req);
-        return this.http.get<Rating[]>(this.resourceSearchUrl, {params: options, observe: 'response'}).pipe(
-            map((res: HttpResponse<Rating[]>) => this.convertArrayResponse(res)));
-    }
-
-    private convertResponse(res: HttpResponse<Rating>): HttpResponse<Rating> {
-        const body: Rating = this.convertItemFromServer(res.body);
-        return res.clone({body});
-    }
-
-    private convertArrayResponse(res: HttpResponse<Rating[]>): HttpResponse<Rating[]> {
-        const jsonResponse: Rating[] = res.body;
-        const body: Rating[] = [];
-        for (let i = 0; i < jsonResponse.length; i++) {
-            body.push(this.convertItemFromServer(jsonResponse[i]));
-        }
-        return res.clone({body});
-    }
-
-    /**
-     * Convert a returned JSON object to Rating.
-     */
-    private convertItemFromServer(rating: Rating): Rating {
-        const copy: Rating = Object.assign({}, rating);
-        copy.startDate = this.dateUtils
-            .convertDateTimeFromServer(rating.startDate);
-        copy.endDate = this.dateUtils
-            .convertDateTimeFromServer(rating.endDate);
-        return copy;
-    }
-
-    /**
-     * Convert a Rating to a JSON which can be sent to the server.
-     */
-    private convert(rating: Rating): Rating {
-        const copy: Rating = Object.assign({}, rating);
-
-        copy.startDate = this.dateUtils.toDate(rating.startDate);
-
-        copy.endDate = this.dateUtils.toDate(rating.endDate);
-        return copy;
-    }
 }

--- a/src/app/xm-entity/shared/restful-base.ts
+++ b/src/app/xm-entity/shared/restful-base.ts
@@ -1,0 +1,145 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { OnDestroy } from '@angular/core';
+import { BehaviorSubject, Observable, Subject } from 'rxjs';
+import { finalize, map } from 'rxjs/operators';
+
+type QueryParams = HttpParams | {
+    [param: string]: (string | string[] | number) | any;
+};
+
+type Extra = { xTotalCount: number } | any;
+
+export const X_TOTAL_HEADER = 'X-Total-Count';
+
+export function dateParse(date: string | any): Date {
+    if (date) {
+        return new Date(date);
+    }
+    return date;
+}
+
+export function toDate(date: Date | any): string {
+    if (date) {
+        return date.toISOString();
+    }
+    return date;
+}
+
+type ObjWithDates = { [key: string]: Date | string } | null;
+
+/**
+ * Convert fields with a type of Date to the ISO strings
+ */
+export function convertDates<T extends ObjWithDates>(obj: T | any): T {
+
+    for (const prop in obj) {
+        if (obj.hasOwnProperty(prop) && obj[prop] instanceof Date) {
+            obj[prop] = toDate(obj[prop]);
+        }
+    }
+
+    return obj;
+}
+
+export abstract class RestfulBase<T> implements OnDestroy {
+
+    public loading$: Observable<boolean>;
+
+    protected resourceUrl: string;
+    protected resourceSearchUrl: string;
+
+    private _$loading: Subject<boolean>;
+
+    constructor(protected http: HttpClient) {
+        this._$loading = new BehaviorSubject(false);
+        this.loading$ = this._$loading.asObservable();
+    }
+
+    public add(entity: T): Observable<T> {
+        this._$loading.next(true);
+        return this.http.post<T>(this.resourceUrl, this.convertForServer(entity)).pipe(
+            finalize(() => this._$loading.next(false)),
+            map(this.convertFromServer.bind(this)));
+    }
+
+    public create(entity: T): Observable<T> {
+        return this.add(entity);
+    }
+
+    public update(entity: T): Observable<T> {
+        this._$loading.next(true);
+        return this.http.put<T>(this.resourceUrl, this.convertForServer(entity)).pipe(
+            finalize(() => this._$loading.next(false)),
+            map(this.convertFromServer.bind(this)));
+    }
+
+    public getAll(): Observable<T[]> {
+        this._$loading.next(true);
+        return this.http.get<T>(this.resourceUrl).pipe(
+            finalize(() => this._$loading.next(false)),
+            map(this.convertArrayFromServer.bind(this)));
+    }
+
+    public find(key: number | string): Observable<T> {
+        return this.getById(key);
+    }
+
+    public getById(key: number | string): Observable<T> {
+        this._$loading.next(true);
+        return this.http.get<T>(`${this.resourceUrl}/${key}`).pipe(
+            finalize(() => this._$loading.next(false)),
+            map(this.convertFromServer.bind(this)));
+    }
+
+    public delete(key: number | string): Observable<undefined> {
+        this._$loading.next(true);
+        return this.http.delete<undefined>(`${this.resourceUrl}/${key}`).pipe(
+            finalize(() => this._$loading.next(false)));
+    }
+
+    public query<R extends QueryParams>(params?: R): Observable<T[] & Extra> {
+        return this._querySearchRequest(this.resourceUrl, params);
+    }
+
+    public search<R extends QueryParams>(params?: R): Observable<T[] & Extra> {
+        return this._querySearchRequest(this.resourceSearchUrl, params);
+    }
+
+    public ngOnDestroy(): void {
+        this._$loading.complete();
+    }
+
+    /**
+     * Convert a returned JSON object to T.
+     */
+    protected convertFromServer(entity: T): T {
+        return entity;
+    }
+
+    /**
+     * Convert a T to a JSON which can be sent to the server.
+     */
+    protected convertForServer(entity: T): T {
+        entity = Object.assign({}, entity);
+        entity = convertDates<any>(entity);
+        return entity;
+    }
+
+    protected convertArrayFromServer(entity: T[]): T[] {
+        if (entity && Array.isArray(entity)) {
+            entity = entity.map(this.convertFromServer.bind(this));
+        }
+        return entity;
+    }
+
+    private _querySearchRequest(url: string, params: QueryParams): Observable<T[] & Extra> {
+        this._$loading.next(true);
+        return this.http.get<T[]>(url, {params, observe: 'response'}).pipe(
+            finalize(() => this._$loading.next(false)),
+            map((res) => {
+                const body: T[] & Extra = this.convertArrayFromServer(res.body);
+                body.xTotalCount = parseInt(res.headers.get(X_TOTAL_HEADER), 10);
+                return body;
+            }));
+    }
+}

--- a/src/app/xm-entity/shared/tag.service.ts
+++ b/src/app/xm-entity/shared/tag.service.ts
@@ -1,86 +1,27 @@
-import { HttpClient, HttpResponse } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { JhiDateUtils } from 'ng-jhipster';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
-
-import { createRequestOption } from '../../shared/model/request-util';
 import { SERVER_API_URL } from '../../xm.constants';
+import { dateParse, RestfulBase, toDate } from './restful-base';
 import { Tag } from './tag.model';
 
 @Injectable()
-export class TagService {
+export class TagService extends RestfulBase<Tag> {
 
-    private resourceUrl = SERVER_API_URL + 'entity/api/tags';
-    private resourceSearchUrl = SERVER_API_URL + 'entity/api/_search/tags';
-
-    constructor(private http: HttpClient, private dateUtils: JhiDateUtils) {
+    constructor(protected http: HttpClient) {
+        super(http);
+        this.resourceUrl = SERVER_API_URL + 'entity/api/tags';
+        this.resourceSearchUrl = SERVER_API_URL + 'entity/api/_search/tags';
     }
 
-    create(tag: Tag): Observable<HttpResponse<Tag>> {
-        const copy = this.convert(tag);
-        return this.http.post<Tag>(this.resourceUrl, copy, {observe: 'response'}).pipe(
-            map((res: HttpResponse<Tag>) => this.convertResponse(res)));
+    protected convertFromServer(data: Tag): Tag {
+        data.startDate = dateParse(data.startDate);
+        return data;
     }
 
-    update(tag: Tag): Observable<HttpResponse<Tag>> {
-        const copy = this.convert(tag);
-        return this.http.put<Tag>(this.resourceUrl, copy, {observe: 'response'}).pipe(
-            map((res: HttpResponse<Tag>) => this.convertResponse(res)));
+    protected convertForServer(data: Tag): Tag {
+        data = Object.assign({}, data);
+        data.startDate = toDate(data.startDate);
+        return data;
     }
 
-    find(id: number): Observable<HttpResponse<Tag>> {
-        return this.http.get<Tag>(`${this.resourceUrl}/${id}`, {observe: 'response'}).pipe(
-            map((res: HttpResponse<Tag>) => this.convertResponse(res)));
-    }
-
-    query(req?: any): Observable<HttpResponse<Tag[]>> {
-        const options = createRequestOption(req);
-        return this.http.get<Tag[]>(this.resourceUrl, {params: options, observe: 'response'}).pipe(
-            map((res: HttpResponse<Tag[]>) => this.convertArrayResponse(res)));
-    }
-
-    delete(id: number): Observable<HttpResponse<any>> {
-        return this.http.delete<any>(`${this.resourceUrl}/${id}`, {observe: 'response'});
-    }
-
-    search(req?: any): Observable<HttpResponse<Tag[]>> {
-        const options = createRequestOption(req);
-        return this.http.get<Tag[]>(this.resourceSearchUrl, {params: options, observe: 'response'}).pipe(
-            map((res: HttpResponse<Tag[]>) => this.convertArrayResponse(res)));
-    }
-
-    private convertResponse(res: HttpResponse<Tag>): HttpResponse<Tag> {
-        const body: Tag = this.convertItemFromServer(res.body);
-        return res.clone({body});
-    }
-
-    private convertArrayResponse(res: HttpResponse<Tag[]>): HttpResponse<Tag[]> {
-        const jsonResponse: Tag[] = res.body;
-        const body: Tag[] = [];
-        for (let i = 0; i < jsonResponse.length; i++) {
-            body.push(this.convertItemFromServer(jsonResponse[i]));
-        }
-        return res.clone({body});
-    }
-
-    /**
-     * Convert a returned JSON object to Tag.
-     */
-    private convertItemFromServer(tag: Tag): Tag {
-        const copy: Tag = Object.assign({}, tag);
-        copy.startDate = this.dateUtils
-            .convertDateTimeFromServer(tag.startDate);
-        return copy;
-    }
-
-    /**
-     * Convert a Tag to a JSON which can be sent to the server.
-     */
-    private convert(tag: Tag): Tag {
-        const copy: Tag = Object.assign({}, tag);
-
-        copy.startDate = this.dateUtils.toDate(tag.startDate);
-        return copy;
-    }
 }

--- a/src/app/xm-entity/shared/tsconfig.json
+++ b/src/app/xm-entity/shared/tsconfig.json
@@ -1,0 +1,19 @@
+// Configuration for IDEs only.
+{
+    "extends": "../../../tsconfig.app",
+    "compilerOptions": {
+        "rootDir": "..",
+        "baseUrl": ".",
+        "paths": {
+            "@xm-webapp/entity": [
+                "../shared"
+            ],
+            "@xm-webapp/entity/*": [
+                "../shared/*"
+            ]
+        }
+    },
+    "include": [
+        "./**/*.ts"
+    ]
+}

--- a/src/app/xm-entity/shared/vote.service.ts
+++ b/src/app/xm-entity/shared/vote.service.ts
@@ -1,86 +1,27 @@
-import { HttpClient, HttpResponse } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { JhiDateUtils } from 'ng-jhipster';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
-
-import { createRequestOption } from '../../shared/model/request-util';
 import { SERVER_API_URL } from '../../xm.constants';
+import { dateParse, RestfulBase, toDate } from './restful-base';
 import { Vote } from './vote.model';
 
 @Injectable()
-export class VoteService {
+export class VoteService extends RestfulBase<Vote> {
 
-    private resourceUrl = SERVER_API_URL + 'entity/api/votes';
-    private resourceSearchUrl = SERVER_API_URL + 'entity/api/_search/votes';
-
-    constructor(private http: HttpClient, private dateUtils: JhiDateUtils) {
+    constructor(protected http: HttpClient) {
+        super(http);
+        this.resourceUrl = SERVER_API_URL + 'entity/api/votes';
+        this.resourceSearchUrl = SERVER_API_URL + 'entity/api/_search/votes';
     }
 
-    create(vote: Vote): Observable<HttpResponse<Vote>> {
-        const copy = this.convert(vote);
-        return this.http.post<Vote>(this.resourceUrl, copy, {observe: 'response'}).pipe(
-            map((res: HttpResponse<Vote>) => this.convertResponse(res)));
+    protected convertFromServer(data: Vote): Vote {
+        data.entryDate = dateParse(data.entryDate);
+        return data;
     }
 
-    update(vote: Vote): Observable<HttpResponse<Vote>> {
-        const copy = this.convert(vote);
-        return this.http.put<Vote>(this.resourceUrl, copy, {observe: 'response'}).pipe(
-            map((res: HttpResponse<Vote>) => this.convertResponse(res)));
+    protected convertForServer(data: Vote): Vote {
+        data = Object.assign({}, data);
+        data.entryDate = toDate(data.entryDate);
+        return data;
     }
 
-    find(id: number): Observable<HttpResponse<Vote>> {
-        return this.http.get<Vote>(`${this.resourceUrl}/${id}`, {observe: 'response'}).pipe(
-            map((res: HttpResponse<Vote>) => this.convertResponse(res)));
-    }
-
-    query(req?: any): Observable<HttpResponse<Vote[]>> {
-        const options = createRequestOption(req);
-        return this.http.get<Vote[]>(this.resourceUrl, {params: options, observe: 'response'}).pipe(
-            map((res: HttpResponse<Vote[]>) => this.convertArrayResponse(res)));
-    }
-
-    delete(id: number): Observable<HttpResponse<any>> {
-        return this.http.delete<any>(`${this.resourceUrl}/${id}`, {observe: 'response'});
-    }
-
-    search(req?: any): Observable<HttpResponse<Vote[]>> {
-        const options = createRequestOption(req);
-        return this.http.get<Vote[]>(this.resourceSearchUrl, {params: options, observe: 'response'}).pipe(
-            map((res: HttpResponse<Vote[]>) => this.convertArrayResponse(res)));
-    }
-
-    private convertResponse(res: HttpResponse<Vote>): HttpResponse<Vote> {
-        const body: Vote = this.convertItemFromServer(res.body);
-        return res.clone({body});
-    }
-
-    private convertArrayResponse(res: HttpResponse<Vote[]>): HttpResponse<Vote[]> {
-        const jsonResponse: Vote[] = res.body;
-        const body: Vote[] = [];
-        for (let i = 0; i < jsonResponse.length; i++) {
-            body.push(this.convertItemFromServer(jsonResponse[i]));
-        }
-        return res.clone({body});
-    }
-
-    /**
-     * Convert a returned JSON object to Vote.
-     */
-    private convertItemFromServer(vote: Vote): Vote {
-        const copy: Vote = Object.assign({}, vote);
-        copy.entryDate = this.dateUtils
-            .convertDateTimeFromServer(vote.entryDate);
-        return copy;
-    }
-
-    /**
-     * Convert a Vote to a JSON which can be sent to the server.
-     */
-    private convert(vote: Vote): Vote {
-        const copy: Vote = Object.assign({}, vote);
-
-        copy.entryDate = this.dateUtils.toDate(vote.entryDate);
-        return copy;
-    }
 }

--- a/src/app/xm-entity/shared/xm-entity-spec-wrapper.service.ts
+++ b/src/app/xm-entity/shared/xm-entity-spec-wrapper.service.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import {defaultIfEmpty, filter, flatMap, map, shareReplay} from 'rxjs/operators';
+import { defaultIfEmpty, filter, flatMap, map, shareReplay } from 'rxjs/operators';
 
+import { environment } from '../../../environments/environment';
 import { Spec } from './spec.model';
+import { XmEntitySpec } from './xm-entity-spec.model';
 import { XmEntitySpecService } from './xm-entity-spec.service';
-import {environment} from '../../../environments/environment';
-import {XmEntitySpec} from './xm-entity-spec.model';
 
 const CACHE_SIZE = 1;
 
@@ -23,9 +23,11 @@ export class XmEntitySpecWrapperService {
         }
     }
 
-    spec(force?: boolean, mockSpec?: boolean): Promise<Spec> {
+    public spec(force?: boolean, mockSpec?: boolean): Promise<Spec> {
         if (!force && this.promise) {
-            if (!environment.production) {console.log('DBG Promise from cache')}
+            if (!environment.production) {
+                console.log('DBG Promise from cache');
+            }
             return this.promise;
         } else {
             return this.promise = new Promise((resolve, reject) => {
@@ -41,13 +43,15 @@ export class XmEntitySpecWrapperService {
                     return;
                 }
 
-                if (!environment.production) {console.log('DBG New Promise')}
+                if (!environment.production) {
+                    console.log('DBG New Promise');
+                }
 
                 // retrieve the spec data from the server, update the _spec object, and then resolve.
                 this.xmEntitySpecService.get().toPromise().then((spec) => {
                     this.promise = null;
-                    if (spec.body) {
-                        this._spec = { types: spec.body };
+                    if (spec) {
+                        this._spec = {types: spec};
                     } else {
                         this._spec = null;
                     }
@@ -66,25 +70,27 @@ export class XmEntitySpecWrapperService {
         }
     }
 
-    specv2(force?: boolean): Observable<Spec> {
+    public specv2(force?: boolean): Observable<Spec> {
         if (!this.cache$) {
-            if (!environment.production) {console.log('DBG from cache$')}
+            if (!environment.production) {
+                console.log('DBG from cache$');
+            }
             this.cache$ = this.requestSpec().pipe(
-                shareReplay(CACHE_SIZE)
-            )
+                shareReplay(CACHE_SIZE),
+            );
         }
         return this.cache$;
     }
 
-    xmSpecByKey(typeKey: string): Observable<XmEntitySpec> {
+    public xmSpecByKey(typeKey: string): Observable<XmEntitySpec> {
         return this.specv2().pipe(
             defaultIfEmpty({types: []}),
             flatMap((spec) => spec.types),
-            filter(xmSpec => typeKey === xmSpec.key)
-        )
+            filter((xmSpec) => typeKey === xmSpec.key),
+        );
     }
 
-    clear() {
+    public clear(): void {
         if (!environment.production) {
             console.log(`DBG XmEntitySpecWrapperService.clear`);
         }
@@ -99,7 +105,9 @@ export class XmEntitySpecWrapperService {
 
     private requestSpec(): Observable<Spec> {
         return this.xmEntitySpecService.get().pipe(
-            map(httpResp => { return { types: httpResp.body }}));
+            map((httpResp) => {
+                return {types: httpResp};
+            }));
     }
 
 }

--- a/src/app/xm-entity/shared/xm-entity-spec.service.ts
+++ b/src/app/xm-entity/shared/xm-entity-spec.service.ts
@@ -1,27 +1,28 @@
-import { HttpClient, HttpResponse } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
+import { environment } from '../../../environments/environment';
 import { SERVER_API_URL } from '../../xm.constants';
 import { XmEntitySpec } from './xm-entity-spec.model';
-import {environment} from '../../../environments/environment';
 
 @Injectable()
 export class XmEntitySpecService {
 
-    private resourceUrl = SERVER_API_URL + 'entity/api/xm-entity-specs';
+    private resourceUrl: string = SERVER_API_URL + 'entity/api/xm-entity-specs';
 
     constructor(private http: HttpClient) {
     }
 
-    get(): Observable<HttpResponse<XmEntitySpec[]>> {
-        if (!environment.production) {console.log(`getting ${this.resourceUrl}`)}
-        return this.http.get<XmEntitySpec[]>(this.resourceUrl, {observe: 'response'});
+    public get(): Observable<XmEntitySpec[]> {
+        if (!environment.production) {
+            console.log(`getting ${this.resourceUrl}`);
+        }
+        return this.http.get<XmEntitySpec[]>(this.resourceUrl);
     }
 
-    generateXmEntity(typeKey: string): Observable<HttpResponse<any>> {
-        return this.http.post(`${this.resourceUrl}//generate-xm-entity?rootTypeKey=${typeKey}`, null,
-            {observe: 'response'});
+    public generateXmEntity(typeKey: string): Observable<any> {
+        return this.http.post(`${this.resourceUrl}//generate-xm-entity?rootTypeKey=${typeKey}`, null);
     }
 
 }

--- a/src/app/xm-entity/shared/xm-entity.module.ts
+++ b/src/app/xm-entity/shared/xm-entity.module.ts
@@ -1,0 +1,42 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { AttachmentService } from './attachment.service';
+import { CalendarService } from './calendar.service';
+import { CommentService } from './comment.service';
+import { ContentService } from './content.service';
+import { EventService } from './event.service';
+import { FunctionContextService } from './function-context.service';
+import { FunctionService } from './function.service';
+import { LinkService } from './link.service';
+import { LocationService } from './location.service';
+import { RatingService } from './rating.service';
+import { TagService } from './tag.service';
+import { VoteService } from './vote.service';
+import { XmEntitySpecWrapperService } from './xm-entity-spec-wrapper.service';
+import { XmEntitySpecService } from './xm-entity-spec.service';
+import { XmEntityService } from './xm-entity.service';
+
+@NgModule({
+    imports: [
+        CommonModule,
+    ],
+    providers: [
+        AttachmentService,
+        CalendarService,
+        CommentService,
+        ContentService,
+        EventService,
+        FunctionService,
+        FunctionContextService,
+        LinkService,
+        LocationService,
+        RatingService,
+        TagService,
+        VoteService,
+        XmEntityService,
+        XmEntitySpecService,
+        XmEntitySpecWrapperService,
+    ],
+})
+export class XmEntityModule {
+}

--- a/src/app/xm-entity/shared/xm-entity.service.ts
+++ b/src/app/xm-entity/shared/xm-entity.service.ts
@@ -1,183 +1,113 @@
-import { HttpClient, HttpResponse } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { JhiDateUtils } from 'ng-jhipster';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import { createRequestOption } from '../../shared/model/request-util';
 import { SERVER_API_URL } from '../../xm.constants';
 import { Link } from './link.model';
+import { dateParse, RestfulBase, toDate } from './restful-base';
 import { XmEntity } from './xm-entity.model';
 
-import { environment } from '../../../environments/environment';
-
 @Injectable()
-export class XmEntityService {
+export class XmEntityService extends RestfulBase<XmEntity> {
 
-    private v2ResourceUrl = SERVER_API_URL + 'entity/api/v2/xm-entities';
-    private resourceUrl = SERVER_API_URL + 'entity/api/xm-entities';
-    private resourceSearchUrl = SERVER_API_URL + 'entity/api/_search/xm-entities';
-    private resourceAvatarUrl = SERVER_API_URL + 'entity/api/storage/objects';
-    private resourceProfileUrl = SERVER_API_URL + 'entity/api/profile';
-    private resourceSearchTemplateUrl = SERVER_API_URL + 'entity/api/_search-with-template/xm-entities';
-    private getEntitiesByIdUrl = `entity/api/xm-entities-by-ids`;
+    protected v2ResourceUrl: string = SERVER_API_URL + 'entity/api/v2/xm-entities';
+    protected resourceUrl: string = SERVER_API_URL + 'entity/api/xm-entities';
+    protected resourceSearchUrl: string = SERVER_API_URL + 'entity/api/_search/xm-entities';
+    protected resourceAvatarUrl: string = SERVER_API_URL + 'entity/api/storage/objects';
+    protected resourceProfileUrl: string = SERVER_API_URL + 'entity/api/profile';
+    protected resourceSearchTemplateUrl: string = SERVER_API_URL + 'entity/api/_search-with-template/xm-entities';
+    protected getEntitiesByIdUrl = `entity/api/xm-entities-by-ids`;
 
-    constructor(private http: HttpClient, private dateUtils: JhiDateUtils) {
+    constructor(protected http: HttpClient) {
+        super(http);
     }
 
-    create(xmEntity: XmEntity): Observable<HttpResponse<XmEntity>> {
-        const copy = this.convert(xmEntity);
-        return this.http.post<XmEntity>(this.resourceUrl, copy, {observe: 'response'}).pipe(
-            map((res: HttpResponse<XmEntity>) => this.convertResponse(res)));
+    public find(id: number, req?: any): Observable<XmEntity> {
+        const params = createRequestOption(req);
+        return this.http.get<XmEntity>(`${this.resourceUrl}/${id}`, {params}).pipe(
+            map(this.convertFromServer.bind(this)));
     }
 
-    update(xmEntity: XmEntity): Observable<HttpResponse<XmEntity>> {
-        const copy = this.convert(xmEntity);
-        return this.http.put<XmEntity>(this.resourceUrl, copy, {observe: 'response'}).pipe(
-            map((res: HttpResponse<XmEntity>) => this.convertResponse(res)));
-    }
-
-    find(id: number, req?: any): Observable<HttpResponse<XmEntity>> {
-        const options = createRequestOption(req);
-        if (!environment.production) {
-            console.log(`[dbg] find for ${id} with req %o`, req);
-        }
-        return this.http.get<XmEntity>(`${this.resourceUrl}/${id}`, {params: options, observe: 'response'}).pipe(
-            map((res: HttpResponse<XmEntity>) => this.convertResponse(res)));
-    }
-
-    getEntitiesByIds(req?: any): Observable<HttpResponse<XmEntity[]>> {
-        const options = createRequestOption(req);
-        return this.http.get<XmEntity[]>(this.getEntitiesByIdUrl, {params: options, observe: 'response'}).pipe(
-            map((res: HttpResponse<XmEntity[]>) => this.convertArrayResponse(res)));
-    }
-
-    query(req?: any): Observable<HttpResponse<XmEntity[]>> {
-        const options = createRequestOption(req);
-        return this.http.get<XmEntity[]>(this.resourceUrl, {params: options, observe: 'response'}).pipe(
-            map((res: HttpResponse<XmEntity[]>) => this.convertArrayResponse(res)));
-    }
-
-    delete(id: number): Observable<HttpResponse<any>> {
-        return this.http.delete<any>(`${this.resourceUrl}/${id}`, {observe: 'response'});
-    }
-
-    search(req?: any): Observable<HttpResponse<XmEntity[]>> {
-        const options = createRequestOption(req);
-        return this.http.get<XmEntity[]>(this.resourceSearchUrl, {params: options, observe: 'response'}).pipe(
-            map((res: HttpResponse<XmEntity[]>) => this.convertArrayResponse(res)));
+    public getEntitiesByIds(req?: any): Observable<XmEntity[]> {
+        const params = createRequestOption(req);
+        return this.http.get<XmEntity[]>(this.getEntitiesByIdUrl, {params}).pipe(
+            map(this.convertArrayFromServer.bind(this)));
     }
 
     /**
      *  template  (sting) - a template identifier from the search-templates.yml.
      *  templateParams ([]|{}) - a named parameters for the template.
-     * */
-    searchByTemplate(req?: any): Observable<HttpResponse<XmEntity[]>> {
-        const options = createRequestOption(req);
-        return this.http.get<XmEntity[]>(this.resourceSearchTemplateUrl, {params: options, observe: 'response'}).pipe(
-            map((res: HttpResponse<XmEntity[]>) => this.convertArrayResponse(res)));
+     */
+    public searchByTemplate(req?: any): Observable<XmEntity[]> {
+        const params = createRequestOption(req);
+        return this.http.get<XmEntity[]>(this.resourceSearchTemplateUrl, {params}).pipe(
+            map(this.convertArrayFromServer.bind(this)));
     }
 
-    getProfile(req?: any): Observable<HttpResponse<XmEntity>> {
-        const options = createRequestOption(req);
-        return this.http.get<XmEntity>(this.resourceProfileUrl, {params: options, observe: 'response'}).pipe(
-            map((res: HttpResponse<XmEntity>) => this.convertResponse(res)));
+    public getProfile(req?: any): Observable<XmEntity> {
+        const params = createRequestOption(req);
+        return this.http.get<XmEntity>(this.resourceProfileUrl, {params}).pipe(
+            map(this.convertArrayFromServer.bind(this)));
     }
 
-    getProfileByKey(key: string, req?: any): Observable<HttpResponse<XmEntity>> {
-        const options = createRequestOption(req);
-        return this.http.get<XmEntity>(`${this.resourceProfileUrl}/${key}`, {params: options, observe: 'response'}).pipe(
-            map((res: HttpResponse<XmEntity>) => this.convertResponse(res)));
+    public getProfileByKey(key: string | number, req?: any): Observable<XmEntity> {
+        const params = createRequestOption(req);
+        return this.http.get<XmEntity>(`${this.resourceProfileUrl}/${key}`, {params}).pipe(
+            map(this.convertFromServer.bind(this)));
     }
 
-    changeState(id: number, stateKey: string, inputContext?: any): Observable<HttpResponse<XmEntity>> {
-        const copy = inputContext ? this.convertFormData(inputContext) : null;
-        return this.http.put<XmEntity>(`${this.resourceUrl}/${id}/states/${stateKey}`, copy, {observe: 'response'}).pipe(
-            map((res: HttpResponse<XmEntity>) => this.convertResponse(res)));
+    public changeState(id: number, stateKey: string, inputContext?: XmEntity): Observable<XmEntity> {
+        const copy = inputContext ? this.convertForServer(inputContext) : null;
+        return this.http.put<XmEntity>(`${this.resourceUrl}/${id}/states/${stateKey}`, copy).pipe(
+            map(this.convertFromServer.bind(this)));
     }
 
-    createAvatar(file: File | Blob): Observable<string> {
+    public createAvatar(file: File | Blob): Observable<string> {
         const formData = new FormData();
         formData.append('file', file);
         return this.http.post(this.resourceAvatarUrl, formData, {responseType: 'text'});
     }
 
-    findLinkTargets(id: number, linkTypeKey: string, req?: any): Observable<HttpResponse<Link[]>> {
-        const options = createRequestOption(req);
-        return this.http.get<Link[]>(`${this.resourceUrl}/${id}/links/targets?typeKey=${linkTypeKey}`,
-            {params: options, observe: 'response'});
+    public findLinkTargets(id: number, linkTypeKey: string, req?: any): Observable<Link[]> {
+        const params = createRequestOption(req);
+        return this.http.get<Link[]>(`${this.resourceUrl}/${id}/links/targets?typeKey=${linkTypeKey}`, {params});
     }
 
-    findLinkSources(id: number, linkTypeKey: string, req?: any): Observable<HttpResponse<Link[]>> {
-        const options = createRequestOption(req);
-        return this.http.get<Link[]>(`${this.resourceUrl}/${id}/links/sources?typeKey=${linkTypeKey}`,
-            {params: options, observe: 'response'});
+    public findLinkSources(id: number, linkTypeKey: string, req?: any): Observable<Link[]> {
+        const params = createRequestOption(req);
+        return this.http.get<Link[]>(`${this.resourceUrl}/${id}/links/sources?typeKey=${linkTypeKey}`, {params});
     }
 
-    findLinkSourcesInverted(idOrKey: string, linkTypeKey: string[], req?: any): Observable<HttpResponse<Link[]>> {
-        const options = createRequestOption(req);
-        return this.http.get<Link[]>(`${this.v2ResourceUrl}/${idOrKey}/links/sources?typeKeys=${linkTypeKey}`,
-            {params: options, observe: 'response'});
+    public findLinkSourcesInverted(idOrKey: string, linkTypeKey: string[], req?: any): Observable<Link[]> {
+        const params = createRequestOption(req);
+        return this.http.get<Link[]>(`${this.v2ResourceUrl}/${idOrKey}/links/sources?typeKeys=${linkTypeKey}`, {params});
     }
 
-    fileExport(exportType: string, typeKey: string): Observable<Blob> {
+    public fileExport(exportType: string, typeKey: string): Observable<Blob> {
         return this.http.get(`${this.resourceUrl}/export/`, {
             responseType: 'blob',
             params: {
                 fileFormat: exportType ? exportType : 'csv',
-                typeKey: typeKey
-            }
+                typeKey,
+            },
         });
     }
 
-    private convertResponse(res: HttpResponse<XmEntity>): HttpResponse<XmEntity> {
-        const body: XmEntity = this.convertItemFromServer(res.body);
-        return res.clone({body});
+    protected convertFromServer(data: XmEntity): XmEntity {
+        data.startDate = dateParse(data.startDate);
+        data.updateDate = dateParse(data.updateDate);
+        data.endDate = dateParse(data.endDate);
+        return data;
     }
 
-    private convertArrayResponse(res: HttpResponse<XmEntity[]>): HttpResponse<XmEntity[]> {
-        const jsonResponse: XmEntity[] = res.body;
-        const body: XmEntity[] = [];
-        for (let i = 0; i < jsonResponse.length; i++) {
-            body.push(this.convertItemFromServer(jsonResponse[i]));
-        }
-        return res.clone({body});
-    }
-
-    /**
-     * Convert a returned JSON object to XmEntity.
-     */
-    private convertItemFromServer(xmEntity: XmEntity): XmEntity {
-        const copy: XmEntity = Object.assign({}, xmEntity);
-        copy.startDate = this.dateUtils
-            .convertDateTimeFromServer(xmEntity.startDate);
-        copy.updateDate = this.dateUtils
-            .convertDateTimeFromServer(xmEntity.updateDate);
-        copy.endDate = this.dateUtils
-            .convertDateTimeFromServer(xmEntity.endDate);
-        return copy;
-    }
-
-    /**
-     * Convert a XmEntity to a JSON which can be sent to the server.
-     */
-    private convert(xmEntity: XmEntity): XmEntity {
-        const copy: XmEntity = Object.assign({}, xmEntity);
-
-        copy.startDate = xmEntity.startDate instanceof Date ? xmEntity.startDate : this.dateUtils.toDate(xmEntity.startDate);
-
-        copy.updateDate = xmEntity.updateDate instanceof Date ? xmEntity.updateDate : this.dateUtils.toDate(xmEntity.updateDate);
-
-        copy.endDate = xmEntity.endDate instanceof Date ? xmEntity.endDate : this.dateUtils.toDate(xmEntity.endDate);
-        return copy;
-    }
-
-    /**
-     * Convert a InputContext to a JSON which can be sent to the server.
-     */
-    private convertFormData(inputContext: any): any {
-        const copy = Object.assign({}, inputContext);
-        return copy;
+    protected convertForServer(data: XmEntity): XmEntity {
+        data = Object.assign({}, data);
+        data.startDate = toDate(data.startDate);
+        data.updateDate = toDate(data.updateDate);
+        data.endDate = toDate(data.endDate);
+        return data;
     }
 
 }

--- a/src/app/xm-entity/tag-list-section/tag-list-section.component.ts
+++ b/src/app/xm-entity/tag-list-section/tag-list-section.component.ts
@@ -55,10 +55,10 @@ export class TagListSectionComponent implements OnInit, OnChanges, OnDestroy {
             }
             return
         }
-        this.xmEntityService.find(this.xmEntityId, { 'embed': 'tags' }).subscribe((xmEntity: HttpResponse<XmEntity>) => {
-            this.xmEntity = xmEntity.body;
-            if (xmEntity.body.tags) {
-                this.tags = [...xmEntity.body.tags];
+        this.xmEntityService.find(this.xmEntityId, { 'embed': 'tags' }).subscribe((xmEntity: XmEntity) => {
+            this.xmEntity = xmEntity;
+            if (xmEntity.tags) {
+                this.tags = [...xmEntity.tags];
             }
         });
     }

--- a/src/app/xm-notifications/shared/notifications.service.ts
+++ b/src/app/xm-notifications/shared/notifications.service.ts
@@ -2,7 +2,7 @@ import { HttpClient, HttpResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { JhiEventManager } from 'ng-jhipster';
 import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { map, tap } from 'rxjs/operators';
 
 import { Principal } from '../../shared/auth/principal.service';
 import { I18nNamePipe } from '../../shared/language/i18n-name.pipe';
@@ -47,20 +47,20 @@ export class NotificationsService {
             }));
     }
 
-    public markRead(id: number, config: NotificationUiConfig): Observable<any> {
+    public markRead(id: number, config: NotificationUiConfig): Observable<boolean> {
         const targetState = config.changeStateName;
         const targetFunction = config.changeStateFunction;
 
-        const action$ = targetFunction ?
+        const action$ = (targetFunction ?
             this.functionService.callWithEntityId(id, targetFunction) :
-            this.entityService.changeState(id, targetState);
+            this.entityService.changeState(id, targetState)) as Observable<any>;
 
         return action$.pipe(
-            map((response: HttpResponse<any>) => {
+            tap(() => {
                 this.eventManager.broadcast({name: 'notificationListUpdated'});
                 this.totalCount--;
-                return true;
-            }));
+            }),
+            map((a: any) => true));
     }
 
     byString(o, s) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,10 @@
       "es2018",
       "dom"
     ],
+    "paths": {
+      "xm-webapp/entity": ["src/app/xm-entity/shared"],
+      "xm-webapp/entity/*": ["src/app/xm-entity/shared/*"]
+    },
     "inlineSources": true,
     "module": "esnext",
     "stripInternal": false,


### PR DESCRIPTION
### Features
* **entity:** `class RestfulBase<T>` for creating a new instance of the entity
* **entity:** `loading$` for managing of the loading process
* **entity:** `@xm-webapp/entity` is a new way to resolve paths

### BREAKING CHANGES
* **entity:** remove the `.body` field from all entity services
* **entity:** replace `headers.get('X-Total-Count')` by the `xTotalCount` filed