### PR TITLE
feat(function-list-section): set auto width for curr state column

### DIFF
--- a/src/app/xm-entity/function-list-section/function-list-section.component.html
+++ b/src/app/xm-entity/function-list-section/function-list-section.component.html
@@ -24,7 +24,7 @@
     <ng-container>
       <div class="container-fluid">
         <div class="row mt-3 mb-3 text-left">
-          <div *ngIf="xmEntity && nextStates?.length" [class.limetedWidth]="nextStates?.length" class="col">
+          <div *ngIf="xmEntity && nextStates?.length" class="col-sm-auto">
             <p class="mb-2">{{'xm-entity.function-list-card.current-state' | translate}}</p>
             <div class="mb-1">
               <xm-entity-state [stateSpec]="getCurrentStateSpec()"></xm-entity-state>
@@ -32,7 +32,7 @@
           </div>
 
           <ng-container *xmPermitted="['XMENTITY.STATE']">
-            <div *ngIf="nextStates?.length" class="col flex-grow-1">
+            <div *ngIf="nextStates?.length" class="col">
               <p class="mb-2">{{'xm-entity.function-list-card.next-states' | translate}}</p>
               <div (click)="onChangeState(nextState.key)"
                    *ngFor="let nextState of nextStates"

--- a/src/app/xm-entity/function-list-section/function-list-section.component.scss
+++ b/src/app/xm-entity/function-list-section/function-list-section.component.scss
@@ -1,11 +1,3 @@
-.limetedWidth {
-    max-width: 160px;
-
-    @media screen and (max-width: 420px) {
-        max-width: 100%;
-    }
-}
-
 .no-wrap {
     white-space:   nowrap;
     max-width:     100%;


### PR DESCRIPTION
set auto width for current entity state column to prevent text overflow