### PR TITLE
feat(25529): added logic to handle "readOnlyConfig" flag in UI specification

### DIFF
--- a/src/app/admin-config/specification-mng/specification-mng.component.html
+++ b/src/app/admin-config/specification-mng/specification-mng.component.html
@@ -16,10 +16,10 @@
         <div class="card">
           <div class="card-body">
             <div class="text-center pb-3">
-              <button (click)="updateUiConfig();"
+              <button (click)="!readOnlyConfig && updateUiConfig();"
                       *ngIf="isUiSpecValid"
                       [class.loading]="uiSpecificationProgress"
-                      [disabled]="uiSpecificationProgress"
+                      [disabled]="uiSpecificationProgress || readOnlyConfig"
                       class="btn btn-primary"
                       type="button">
                 {{'admin-config.specification-mng.ui.save' | translate}}
@@ -27,7 +27,8 @@
               <button (click)="validateUiSpecification();"
                       *ngIf="!isUiSpecValid"
                       class="btn btn-primary"
-                      type="button">
+                      type="button"
+                      [disabled]="readOnlyConfig">
                 {{'admin-config.specification-mng.validate' | translate}}
               </button>
 
@@ -61,12 +62,14 @@
             <div class="text-center pb-3">
               <button (click)="validateXmEntitySpec();" *ngIf="!isXmEntitySpecValid" class="btn btn-primary mr-2"
                       jhiTranslate="admin-config.specification-mng.validate"
-                      type="submit">
+                      type="submit"
+                      [disabled]="readOnlyConfig">
                 Validate
               </button>
               <button (click)="updateEntityConfig();" *ngIf="isXmEntitySpecValid" class="btn btn-primary mr-2"
                       jhiTranslate="admin-config.specification-mng.entity.save"
-                      type="submit">
+                      type="submit"
+                      [disabled]="readOnlyConfig">
                 Update Entity specification
               </button>
 
@@ -111,12 +114,14 @@
             <div class="text-center pb-3">
               <button (click)="validateTimelineConfig();" *ngIf="!isTimelineSpecValid" class="btn btn-primary"
                       jhiTranslate="admin-config.specification-mng.validate"
-                      type="submit">
+                      type="submit"
+                      [disabled]="readOnlyConfig">
                 Validate
               </button>
               <button (click)="updateTimelineConfig();" *ngIf="isTimelineSpecValid" class="btn btn-primary"
                       jhiTranslate="admin-config.specification-mng.timeline.save"
-                      type="submit">
+                      type="submit"
+                      [disabled]="readOnlyConfig">
                 Save Timeline specification
               </button>
               <div class="text-center">
@@ -148,12 +153,14 @@
             <div class="text-center pb-3">
               <button (click)="validateLoginsSpecification();" *ngIf="!isUaaLoginSpecValid" class="btn btn-primary"
                       jhiTranslate="admin-config.specification-mng.validate"
-                      type="submit">
+                      type="submit"
+                      [disabled]="readOnlyConfig">
                 Validate
               </button>
               <button (click)="updateLoginsSpecification();" *ngIf="isUaaLoginSpecValid" class="btn btn-primary"
                       jhiTranslate="admin-config.specification-mng.uaa-login.save"
-                      type="submit">
+                      type="submit"
+                      [disabled]="readOnlyConfig">
                 Save Login specification
               </button>
               <div class="text-center">
@@ -185,12 +192,14 @@
             <div class="text-center pb-3">
               <button (click)="validateUaaSpecification();" *ngIf="!isUaaSpecValid" class="btn btn-primary"
                       jhiTranslate="admin-config.specification-mng.validate"
-                      type="submit">
+                      type="submit"
+                      [disabled]="readOnlyConfig">
                 Validate
               </button>
               <button (click)="updateUaaSpecification();" *ngIf="isUaaSpecValid" class="btn btn-primary"
                       jhiTranslate="admin-config.specification-mng.uaa.save"
-                      type="submit">
+                      type="submit"
+                      [disabled]="readOnlyConfig">
                 Save UAA specification
               </button>
               <div class="text-center">
@@ -225,13 +234,15 @@
                       [class.loading]="tenantSpecificationProgress"
                       [disabled]="tenantSpecificationProgress"
                       class="btn btn-primary"
-                      type="button">
+                      type="button"
+                      [disabled]="readOnlyConfig">
                 {{'admin-config.specification-mng.tenant.save' | translate}}
               </button>
               <button (click)="validateTenantSpecification();"
                       *ngIf="!isTenantSpecValid"
                       class="btn btn-primary"
-                      type="button">
+                      type="button"
+                      [disabled]="readOnlyConfig">
                 {{'admin-config.specification-mng.validate' | translate}}
               </button>
 
@@ -265,7 +276,7 @@
               <button (click)="updatePrivateUiConfig();"
                       *ngIf="isUiPrivateSpecValid"
                       [class.loading]="uiPrivateSpecificationProgress"
-                      [disabled]="uiPrivateSpecificationProgress"
+                      [disabled]="uiPrivateSpecificationProgress || readOnlyConfig"
                       class="btn btn-primary"
                       type="button">
                 {{'admin-config.specification-mng.privateui.save' | translate}}
@@ -273,7 +284,8 @@
               <button (click)="validatePrivateUiSpecification();"
                       *ngIf="!isUiPrivateSpecValid"
                       class="btn btn-primary"
-                      type="button">
+                      type="button"
+                      [disabled]="readOnlyConfig">
                 {{'admin-config.specification-mng.validate' | translate}}
               </button>
 

--- a/src/app/admin-config/specification-mng/specification-mng.component.html
+++ b/src/app/admin-config/specification-mng/specification-mng.component.html
@@ -16,10 +16,10 @@
         <div class="card">
           <div class="card-body">
             <div class="text-center pb-3">
-              <button (click)="!readOnlyConfig && updateUiConfig();"
+              <button (click)="updateUiConfig();"
                       *ngIf="isUiSpecValid"
                       [class.loading]="uiSpecificationProgress"
-                      [disabled]="uiSpecificationProgress || readOnlyConfig"
+                      [disabled]="uiSpecificationProgress || readOnlyMode"
                       class="btn btn-primary"
                       type="button">
                 {{'admin-config.specification-mng.ui.save' | translate}}
@@ -28,7 +28,7 @@
                       *ngIf="!isUiSpecValid"
                       class="btn btn-primary"
                       type="button"
-                      [disabled]="readOnlyConfig">
+                      [disabled]="readOnlyMode">
                 {{'admin-config.specification-mng.validate' | translate}}
               </button>
 
@@ -63,13 +63,13 @@
               <button (click)="validateXmEntitySpec();" *ngIf="!isXmEntitySpecValid" class="btn btn-primary mr-2"
                       jhiTranslate="admin-config.specification-mng.validate"
                       type="submit"
-                      [disabled]="readOnlyConfig">
+                      [disabled]="readOnlyMode">
                 Validate
               </button>
               <button (click)="updateEntityConfig();" *ngIf="isXmEntitySpecValid" class="btn btn-primary mr-2"
                       jhiTranslate="admin-config.specification-mng.entity.save"
                       type="submit"
-                      [disabled]="readOnlyConfig">
+                      [disabled]="readOnlyMode">
                 Update Entity specification
               </button>
 
@@ -115,13 +115,13 @@
               <button (click)="validateTimelineConfig();" *ngIf="!isTimelineSpecValid" class="btn btn-primary"
                       jhiTranslate="admin-config.specification-mng.validate"
                       type="submit"
-                      [disabled]="readOnlyConfig">
+                      [disabled]="readOnlyMode">
                 Validate
               </button>
               <button (click)="updateTimelineConfig();" *ngIf="isTimelineSpecValid" class="btn btn-primary"
                       jhiTranslate="admin-config.specification-mng.timeline.save"
                       type="submit"
-                      [disabled]="readOnlyConfig">
+                      [disabled]="readOnlyMode">
                 Save Timeline specification
               </button>
               <div class="text-center">
@@ -154,13 +154,13 @@
               <button (click)="validateLoginsSpecification();" *ngIf="!isUaaLoginSpecValid" class="btn btn-primary"
                       jhiTranslate="admin-config.specification-mng.validate"
                       type="submit"
-                      [disabled]="readOnlyConfig">
+                      [disabled]="readOnlyMode">
                 Validate
               </button>
               <button (click)="updateLoginsSpecification();" *ngIf="isUaaLoginSpecValid" class="btn btn-primary"
                       jhiTranslate="admin-config.specification-mng.uaa-login.save"
                       type="submit"
-                      [disabled]="readOnlyConfig">
+                      [disabled]="readOnlyMode">
                 Save Login specification
               </button>
               <div class="text-center">
@@ -193,13 +193,13 @@
               <button (click)="validateUaaSpecification();" *ngIf="!isUaaSpecValid" class="btn btn-primary"
                       jhiTranslate="admin-config.specification-mng.validate"
                       type="submit"
-                      [disabled]="readOnlyConfig">
+                      [disabled]="readOnlyMode">
                 Validate
               </button>
               <button (click)="updateUaaSpecification();" *ngIf="isUaaSpecValid" class="btn btn-primary"
                       jhiTranslate="admin-config.specification-mng.uaa.save"
                       type="submit"
-                      [disabled]="readOnlyConfig">
+                      [disabled]="readOnlyMode">
                 Save UAA specification
               </button>
               <div class="text-center">
@@ -232,17 +232,16 @@
               <button (click)="updateTenantConfig();"
                       *ngIf="isTenantSpecValid"
                       [class.loading]="tenantSpecificationProgress"
-                      [disabled]="tenantSpecificationProgress"
+                      [disabled]="tenantSpecificationProgress || readOnlyMode"
                       class="btn btn-primary"
-                      type="button"
-                      [disabled]="readOnlyConfig">
+                      type="button">
                 {{'admin-config.specification-mng.tenant.save' | translate}}
               </button>
               <button (click)="validateTenantSpecification();"
                       *ngIf="!isTenantSpecValid"
                       class="btn btn-primary"
                       type="button"
-                      [disabled]="readOnlyConfig">
+                      [disabled]="readOnlyMode">
                 {{'admin-config.specification-mng.validate' | translate}}
               </button>
 
@@ -276,7 +275,7 @@
               <button (click)="updatePrivateUiConfig();"
                       *ngIf="isUiPrivateSpecValid"
                       [class.loading]="uiPrivateSpecificationProgress"
-                      [disabled]="uiPrivateSpecificationProgress || readOnlyConfig"
+                      [disabled]="uiPrivateSpecificationProgress || readOnlyMode"
                       class="btn btn-primary"
                       type="button">
                 {{'admin-config.specification-mng.privateui.save' | translate}}
@@ -285,7 +284,7 @@
                       *ngIf="!isUiPrivateSpecValid"
                       class="btn btn-primary"
                       type="button"
-                      [disabled]="readOnlyConfig">
+                      [disabled]="readOnlyMode">
                 {{'admin-config.specification-mng.validate' | translate}}
               </button>
 

--- a/src/app/admin-config/specification-mng/specification-mng.component.ts
+++ b/src/app/admin-config/specification-mng/specification-mng.component.ts
@@ -11,7 +11,6 @@ import { ConfigVisualizerDialogComponent } from './config-visualizer-dialog/conf
 import { Principal } from '../../shared';
 
 const TENANT_SPEC_PATH = '/tenant-config.yml';
-declare const YAML: any;
 
 @Component({
     selector: 'xm-specification-mng',
@@ -89,7 +88,7 @@ export class SpecificationMngComponent implements OnInit {
     public uaaSpecificationOut: string;
     public uaaValidation: any;
 
-    public readOnlyConfig: boolean;
+    public readOnlyMode: boolean;
 
     constructor(private activatedRoute: ActivatedRoute,
                 private modalService: NgbModal,
@@ -124,10 +123,6 @@ export class SpecificationMngComponent implements OnInit {
         this.service.getConfig('/webapp/settings-public.yml').subscribe((result) => {
             this.uiSpecificationIn = result;
             this.uiSpecificationOut = result;
-
-            if (YAML.parse(result).readOnlyConfig) {
-                this.readOnlyConfig = true;
-            }
         });
         this.service.getConfig(TENANT_SPEC_PATH).subscribe((result) => {
             this.tenantSpecificationIn = result;
@@ -142,6 +137,9 @@ export class SpecificationMngComponent implements OnInit {
                 this.uiPrivateSpecificationIn = result;
                 this.uiPrivateSpecificationOut = result;
             });
+        });
+        this.service.getUiConfig().subscribe(result => {
+            this.readOnlyMode = result.readOnlyConfig;
         });
     }
 

--- a/src/app/admin-config/specification-mng/specification-mng.component.ts
+++ b/src/app/admin-config/specification-mng/specification-mng.component.ts
@@ -11,6 +11,7 @@ import { ConfigVisualizerDialogComponent } from './config-visualizer-dialog/conf
 import { Principal } from '../../shared';
 
 const TENANT_SPEC_PATH = '/tenant-config.yml';
+declare const YAML: any;
 
 @Component({
     selector: 'xm-specification-mng',
@@ -88,6 +89,8 @@ export class SpecificationMngComponent implements OnInit {
     public uaaSpecificationOut: string;
     public uaaValidation: any;
 
+    public readOnlyConfig: boolean;
+
     constructor(private activatedRoute: ActivatedRoute,
                 private modalService: NgbModal,
                 private principal: Principal,
@@ -121,6 +124,10 @@ export class SpecificationMngComponent implements OnInit {
         this.service.getConfig('/webapp/settings-public.yml').subscribe((result) => {
             this.uiSpecificationIn = result;
             this.uiSpecificationOut = result;
+
+            if (YAML.parse(result).readOnlyConfig) {
+                this.readOnlyConfig = true;
+            }
         });
         this.service.getConfig(TENANT_SPEC_PATH).subscribe((result) => {
             this.tenantSpecificationIn = result;

--- a/src/app/admin/roles-management/roles-management-detail.component.html
+++ b/src/app/admin/roles-management/roles-management-detail.component.html
@@ -68,7 +68,7 @@
 
             <div class="col"></div>
             <div class="col-auto">
-              <button (click)="onSave()" class="btn btn-sm mat-raised-button btn-primary" type="button">
+              <button (click)="onSave()" class="btn btn-sm mat-raised-button btn-primary" type="button" [disabled]="readOnlyMode">
                 <span class="fa fa-save"></span>&nbsp;<span jhiTranslate="entity.action.save">Save</span>
               </button>
             </div>
@@ -77,7 +77,8 @@
           <div class="row">
             <div class="col">
               <mat-slide-toggle (change)="onCheckAll()"
-                                [(ngModel)]="checkAll">
+                                [(ngModel)]="checkAll"
+                                [disabled]="readOnlyMode">
                 {{'rolesManagement.permission.checkAll' | translate}}
               </mat-slide-toggle>
             </div>
@@ -114,11 +115,11 @@
                 </td>
                 <td>{{item.msName}}</td>
                 <td>
-                  <mat-checkbox [(ngModel)]="item.enabled" color="primary"></mat-checkbox>
+                  <mat-checkbox [(ngModel)]="item.enabled" color="primary" [disabled]="readOnlyMode"></mat-checkbox>
                 </td>
                 <td>
                   <mat-form-field class="slim-select">
-                    <mat-select [(ngModel)]="item.reactionStrategy">
+                    <mat-select [(ngModel)]="item.reactionStrategy" [disabled]="readOnlyMode">
                       <mat-option *ngFor="let value of forbids" [value]="value">
                         {{value}}
                       </mat-option>
@@ -127,18 +128,29 @@
                 </td>
                 <td>
                   <span>{{item.resourceCondition}}</span>
-                  <a (click)="onEditResource(item)"
-                     *ngIf="item.resources?.length"
-                     class="pull-right"
-                     href="javascript: void(0);">
-                    <i class="material-icons">edit</i>
-                  </a>
+                  <button
+                    mat-icon-button
+                    color="primary"
+                    (click)="onEditResource(item)"
+                    *ngIf="item.resources?.length"
+                    class="pull-right"
+                    [disabled]="readOnlyMode"
+                  >
+                    <mat-icon>edit</mat-icon>
+                  </button>
                 </td>
                 <td>
                   <span>{{item.envCondition}}</span>
-                  <a (click)="onEditEnv(item)" *ngIf="hasEnv" class="pull-right" href="javascript: void(0);">
-                    <i class="material-icons">edit</i>
-                  </a>
+                  <button
+                    mat-icon-button
+                    color="primary"
+                    (click)="onEditEnv(item)"
+                    *ngIf="hasEnv"
+                    class="pull-right"
+                    [disabled]="readOnlyMode"
+                  >
+                    <mat-icon>edit</mat-icon>
+                  </button>
                 </td>
               </tr>
               </tbody>
@@ -154,7 +166,7 @@
             </div>
             <div class="col-sm"></div>
             <div class="col-auto">
-              <button (click)="onSave()" class="btn btn-sm mat-raised-button btn-primary" type="button">
+              <button (click)="onSave()" class="btn btn-sm mat-raised-button btn-primary" type="button" [disabled]="readOnlyMode">
                 <span class="fa fa-save"></span>&nbsp;<span jhiTranslate="entity.action.save">Save</span>
               </button>
             </div>

--- a/src/app/admin/roles-management/roles-management-detail.component.html
+++ b/src/app/admin/roles-management/roles-management-detail.component.html
@@ -129,6 +129,7 @@
                 <td>
                   <span>{{item.resourceCondition}}</span>
                   <button
+                    type="button"
                     mat-icon-button
                     color="primary"
                     (click)="onEditResource(item)"
@@ -142,6 +143,7 @@
                 <td>
                   <span>{{item.envCondition}}</span>
                   <button
+                    type="button"
                     mat-icon-button
                     color="primary"
                     (click)="onEditEnv(item)"

--- a/src/app/admin/roles-management/roles-management-detail.component.ts
+++ b/src/app/admin/roles-management/roles-management-detail.component.ts
@@ -12,6 +12,7 @@ import { Permission } from '../../shared/role/permission.model';
 import { Role } from '../../shared/role/role.model';
 import { RoleService } from '../../shared/role/role.service';
 import { RoleConditionDialogComponent } from './roles-management-condition-dialog.component';
+import { XmConfigService } from "../../shared";
 
 @Component({
     selector: 'xm-role-mgmt-datail',
@@ -50,13 +51,16 @@ export class RoleMgmtDetailComponent implements OnInit, OnDestroy {
     private isSort: boolean;
     private routeParamsSubscription: Subscription;
     private routeDataSubscription: Subscription;
+    public readOnlyMode: boolean;
 
     constructor(private jhiLanguageHelper: JhiLanguageHelper,
                 private roleService: RoleService,
                 private alertService: JhiAlertService,
                 private activatedRoute: ActivatedRoute,
                 private orderByPipe: JhiOrderByPipe,
-                private modalService: NgbModal) {
+                private modalService: NgbModal,
+                private configService: XmConfigService,
+    ) {
         this.routeDataSubscription = this.activatedRoute.data
             .pipe(takeUntil(instanceDestroyed(this)))
             .subscribe((data) => this.routeData = data);
@@ -70,6 +74,10 @@ export class RoleMgmtDetailComponent implements OnInit, OnDestroy {
                 this.load(roleKey);
                 this.jhiLanguageHelper.updateTitle();
             }
+        });
+
+        this.configService.getUiConfig().subscribe(result => {
+            this.readOnlyMode = result.readOnlyConfig;
         });
     }
 

--- a/src/app/admin/roles-management/roles-management.component.html
+++ b/src/app/admin/roles-management/roles-management.component.html
@@ -40,6 +40,7 @@
                 <td>{{item.updatedDate | xmDateTime}}</td>
                 <td class="text-right nowrap">
                   <button
+                    type="button"
                     mat-icon-button
                     color="primary"
                     (click)="onEdit(item)"
@@ -49,6 +50,7 @@
                     <mat-icon>edit</mat-icon>
                   </button>
                   <button
+                    type="button"
                     mat-icon-button
                     color="primary"
                     (click)="onDelete(item)"

--- a/src/app/admin/roles-management/roles-management.component.html
+++ b/src/app/admin/roles-management/roles-management.component.html
@@ -39,16 +39,24 @@
                 <td>{{item.updatedBy}}</td>
                 <td>{{item.updatedDate | xmDateTime}}</td>
                 <td class="text-right nowrap">
-                  <a (click)="onEdit(item)"
-                     *permitted="'ROLE.UPDATE'"
-                     href="javascript: void(0);">
-                    <i class="material-icons">edit</i>
-                  </a>
-                  <a (click)="onDelete(item)" *permitted="'ROLE.DELETE'"
-                     class="ml-1"
-                     href="javascript: void(0);">
-                    <i class="material-icons">close</i>
-                  </a>
+                  <button
+                    mat-icon-button
+                    color="primary"
+                    (click)="onEdit(item)"
+                    *permitted="'ROLE.UPDATE'"
+                    [disabled]="readOnlyMode"
+                  >
+                    <mat-icon>edit</mat-icon>
+                  </button>
+                  <button
+                    mat-icon-button
+                    color="primary"
+                    (click)="onDelete(item)"
+                    *permitted="'ROLE.DELETE'"
+                    [disabled]="readOnlyMode"
+                  >
+                    <mat-icon>close</mat-icon>
+                  </button>
                   <!--<a [routerLink]="[{ outlets: { popup: 'role-management/'+ item.roleKey + '/edit'} }]"-->
                   <!--replaceUrl="true" *permitted="'ROLE.UPDATE'">-->
                   <!--<i class="material-icons">edit</i>-->
@@ -77,7 +85,6 @@
                               [collectionSize]="totalItems"
                               [maxSize]="5"
                               [pageSize]="itemsPerPage">
-
               </ngb-pagination>
             </div>
           </div>
@@ -93,7 +100,8 @@
   <button (click)="onAdd()"
           *permitted="'ROLE.CREATE'"
           class="btn btn-primary btn-icon btn-just-icon btn-round btn-lg"
-          mat-raised-button>
+          mat-raised-button
+          [disabled]="readOnlyMode">
     <i class="material-icons">add</i>
   </button>
 </div>

--- a/src/app/admin/roles-management/roles-management.component.ts
+++ b/src/app/admin/roles-management/roles-management.component.ts
@@ -9,6 +9,7 @@ import { Role } from '../../shared/role/role.model';
 import { RoleService } from '../../shared/role/role.service';
 import { RoleMgmtDeleteDialogComponent } from './roles-management-delete-dialog.component';
 import { RoleMgmtDialogComponent } from './roles-management-dialog.component';
+import { XmConfigService } from '../../shared';
 
 @Component({
     selector: 'xm-roles-mgmt',
@@ -28,6 +29,7 @@ export class RolesMgmtComponent implements OnInit, OnDestroy {
     public reverse: boolean = true;
     public showLoader: boolean;
     private eventSubscriber: Subscription;
+    public readOnlyMode: boolean;
 
     constructor(
         private roleService: RoleService,
@@ -36,6 +38,7 @@ export class RolesMgmtComponent implements OnInit, OnDestroy {
         private eventManager: JhiEventManager,
         private orderByPipe: JhiOrderByPipe,
         private modalService: NgbModal,
+        private configService: XmConfigService,
     ) {
         this.itemsPerPage = ITEMS_PER_PAGE;
         this.registerChangeInRoles();
@@ -44,6 +47,10 @@ export class RolesMgmtComponent implements OnInit, OnDestroy {
     public ngOnInit(): void {
         this.principal.identity().then(() => {
             this.loadAll();
+        });
+
+        this.configService.getUiConfig().subscribe(result => {
+            this.readOnlyMode = result.readOnlyConfig;
         });
     }
 
@@ -97,12 +104,12 @@ export class RolesMgmtComponent implements OnInit, OnDestroy {
         this.modalService.open(RoleMgmtDialogComponent, {backdrop: 'static'});
     }
 
-    public onEdit(role: string): void {
+    public onEdit(role: Role): void {
         const modalRef = this.modalService.open(RoleMgmtDialogComponent, {backdrop: 'static'});
         modalRef.componentInstance.selectedRole = role;
     }
 
-    public onDelete(role: string): void {
+    public onDelete(role: Role): void {
         const modalRef = this.modalService.open(RoleMgmtDeleteDialogComponent, {backdrop: 'static'});
         modalRef.componentInstance.selectedRole = role;
     }

--- a/src/app/admin/roles-matrix/roles-matrix.component.html
+++ b/src/app/admin/roles-matrix/roles-matrix.component.html
@@ -65,7 +65,7 @@
             </button>
             <button (click)="onSave()"
                     *permitted="'DASHBOARD.UPDATE'"
-                    [disabled]="!hasChanges"
+                    [disabled]="readOnlyMode || !hasChanges"
                     class="btn btn-primary btn-sm mat-raised-button"
                     type="button">
               <span class="fa fa-save"></span>&nbsp;<span jhiTranslate="entity.action.save">Save</span>
@@ -104,7 +104,7 @@
                   <span class="material-icons">close</span>
                 </a>
                 <div class="text-center">
-                  <mat-slide-toggle (change)="onCheckAll(i); isChanged(permissions);" [(ngModel)]="checkAll[i]">
+                  <mat-slide-toggle (change)="onCheckAll(i); isChanged(permissions);" [(ngModel)]="checkAll[i]" [disabled]="readOnlyMode">
                     {{'rolesManagement.permission.checkAll' | translate}}
                   </mat-slide-toggle>
                 </div>
@@ -123,7 +123,9 @@
               <td *ngFor="let role of item.roles; index as i" [ngClass]="'col-' + i" class="text-center align-middle">
                 <mat-checkbox (change)="isChanged(permissions)"
                               [(ngModel)]="role.value"
-                              class="no-label-margin"></mat-checkbox>
+                              class="no-label-margin"
+                              [disabled]="readOnlyMode"
+                ></mat-checkbox>
               </td>
             </tr>
             </tbody>
@@ -157,7 +159,7 @@
             </button>
             <button (click)="onSave()"
                     *permitted="'DASHBOARD.UPDATE'"
-                    [disabled]="!hasChanges"
+                    [disabled]="readOnlyMode || !hasChanges"
                     class="btn btn-primary btn-sm mat-raised-button"
                     type="button">
               <span class="fa fa-save"></span>&nbsp;<span jhiTranslate="entity.action.save">Save</span>

--- a/src/app/admin/roles-matrix/roles-matrix.component.ts
+++ b/src/app/admin/roles-matrix/roles-matrix.component.ts
@@ -1,7 +1,7 @@
 import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { JhiAlertService, JhiOrderByPipe } from 'ng-jhipster';
 import { finalize } from 'rxjs/operators';
-import { Principal } from '../../shared';
+import { Principal, XmConfigService } from '../../shared';
 
 import { ITEMS_PER_PAGE } from '../../shared/constants/pagination.constants';
 import { RoleMatrix, RoleMatrixPermission } from '../../shared/role/role.model';
@@ -40,18 +40,24 @@ export class RolesMatrixComponent implements OnInit {
     ];
     private permissionsSort: RoleMatrixPermission[];
     private isSort: boolean;
+    public readOnlyMode: boolean;
 
     constructor(
         private principal: Principal,
         private roleService: RoleService,
         private alertService: JhiAlertService,
         private orderByPipe: JhiOrderByPipe,
+        private configService: XmConfigService,
     ) {
         this.itemsPerPage = ITEMS_PER_PAGE;
     }
 
     public ngOnInit(): void {
         this.principal.identity().then(() => this.load());
+
+        this.configService.getUiConfig().subscribe(result => {
+            this.readOnlyMode = result.readOnlyConfig;
+        })
     }
 
     public load(): void {


### PR DESCRIPTION
When flag is TRUE actions (except filters, sort, pagination, etc.) will be blocked for next components:

- specification-mng
- roles-matrix
- roles-management
- roles-management-detail