### PR TITLE
feat(list-fab, detail-fab): added check for permission for render add/edit btn for EXACT entity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "2.0.20",
+  "version": "2.0.21",
   "private": true,
   "description": "Xm-webapp",
   "homepage": "https://github.com/xm-online/xm-webapp",

--- a/src/app/application/application.component.html
+++ b/src/app/application/application.component.html
@@ -8,5 +8,5 @@
   </div>
 </div>
 
-<xm-entity-list-fab *ngIf="entityType && spec" [spec]="spec" [xmEntitySpec]="entityType">
+<xm-entity-list-fab *ngIf="entityType && spec" [spec]="spec" [xmEntitySpec]="entityType" [uiConfig]="uiConfig">
 </xm-entity-list-fab>

--- a/src/app/ext-commons/ext-common-entity/entity-widget/entity-widget.component.html
+++ b/src/app/ext-commons/ext-common-entity/entity-widget/entity-widget.component.html
@@ -99,6 +99,7 @@
       [spec]="spec"
       [xmEntitySpec]="xmEntitySpec"
       [xmEntity]="fetchedXmEntity"
+      [entityUiConfig]="entityUiConfig"
     ></xm-entity-detail-fab>
   </ng-template>
 

--- a/src/app/shared/spec/xm-ui-config-model.ts
+++ b/src/app/shared/spec/xm-ui-config-model.ts
@@ -34,6 +34,8 @@ export type EntityDetailLayout = 'DEFAULT' | 'ALL-IN-ROW' | 'COMPACT';
 
 export interface EntityUiConfig {
     typeKey: string;
+    addButtonPermission?: string;
+    editButtonPermission?: string;
     detailLayoutType: EntityDetailLayout;
     fields?: FieldOptions[]; // TODO: FieldOptions is a UI config item. It can be moved here to keep all in one place.
     attachments?: EntityAttachmentsUiConfig;

--- a/src/app/xm-entity/entity-detail-fab/entity-detail-fab.component.html
+++ b/src/app/xm-entity/entity-detail-fab/entity-detail-fab.component.html
@@ -26,12 +26,14 @@
     </button>
   </div>
 
-  <button (click)="onEdit()"
-          *xmPermitted="['ENTITY.UPDATE']; context: xmEditContext()"
-          class="btn btn-primary xm-fab-button fab-main-button">
-    <i class="material-icons">edit</i>
-    <span class="fab-title">{{ "xm-entity.entity-detail-fab.edit-entity" | translate }}</span>
-  </button>
+  <div *ngIf="showEditButton">
+    <button (click)="onEdit()"
+            *xmPermitted="['ENTITY.UPDATE']; context: xmEditContext()"
+            class="btn btn-primary xm-fab-button fab-main-button">
+      <i class="material-icons">edit</i>
+      <span class="fab-title">{{ "xm-entity.entity-detail-fab.edit-entity" | translate }}</span>
+    </button>
+  </div>
 
   <button *ngIf="!showEditOptions && showEditSubOptions" class="btn btn-primary xm-fab-button fab-main-button">
     <i class="material-icons">more_vert</i>

--- a/src/app/xm-entity/entity-list-fab/entity-list-fab.component.html
+++ b/src/app/xm-entity/entity-list-fab/entity-list-fab.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="xmEntitySpec" class="xm-fab">
+<div *ngIf="xmEntitySpec && showAddButton" class="xm-fab">
   <div class="xm-fab-drop">
     <button (click)="onGenerateNew()" *xmPermitted="['XMENTITY_SPEC.GENERATE']" class="xm-fab-option">
       <i class="material-icons">plus_one</i>


### PR DESCRIPTION
For UI Config now it's possible to add keys `addButtonPermission` and `editButtonPermission`, with some permission string in value, like:
```
entities: 
 - typeKey: ''SOME-ENTITY"
   addButtonPermission: "SOME-ENTITY.BTN.ADD"
```

In this example, if `addButtonPermission` exists in entity config, and user haven't specified privilege key, button won't render for this entity.

If entity config doesn't have `addButtonPermission` or `editButtonPermission` key, default logic goes here.