### PR TITLE
Fix/remove unused/data params

### DIFF
--- a/packages/administration/src/metrics/metrics.component.html
+++ b/packages/administration/src/metrics/metrics.component.html
@@ -78,8 +78,6 @@
 
                 <button (click)="refreshThreadDumpData()"
                         class="btn btn-sm btn-icon btn-just-icon btn-link action abs-link"
-                        data-target="#threadDump"
-                        data-toggle="modal"
                         mat-button
                         type="button">
                   <mat-icon [color]="'primary'">visibility</mat-icon>


### PR DESCRIPTION
The data-target property of scrollspy in bootstrap versions on or above 4.0.0-alpha and before 4.1.2 are vulnerable to Cross-Site Scripting(XSS) attacks.