### PR TITLE
feat(api-docs): get api list from config option

### DIFF
--- a/packages/administration/src/docs/docs.component.ts
+++ b/packages/administration/src/docs/docs.component.ts
@@ -8,6 +8,11 @@ import SwaggerUI from 'swagger-ui';
 interface SwaggerResource {
     location: string;
     name: string;
+    swaggerVersion: string;
+}
+
+interface JhiDocsComponentConfig {
+    swaggerResources: SwaggerResource[];
 }
 
 @Component({
@@ -28,6 +33,7 @@ interface SwaggerResource {
 })
 export class JhiDocsComponent implements AfterViewInit {
 
+    public config: JhiDocsComponentConfig;
     public swaggerResources: SwaggerResource[];
     public currentResource: string;
 
@@ -38,13 +44,19 @@ export class JhiDocsComponent implements AfterViewInit {
     }
 
     public ngAfterViewInit(): void {
-        this.http
-            .get<SwaggerResource[]>('/swagger-resources')
-            .subscribe((data: SwaggerResource[]) => {
-                this.swaggerResources = data;
-                this.currentResource = this.swaggerResources[0].location;
-                this.updateSwagger(this.currentResource);
-            });
+        if (!this.config?.swaggerResources) {
+            this.http
+                .get<SwaggerResource[]>('/swagger-resources')
+                .subscribe((data: SwaggerResource[]) => {
+                    this.swaggerResources = data;
+                    this.currentResource = this.swaggerResources[0].location;
+                    this.updateSwagger(this.currentResource);
+                });
+        } else {
+            this.swaggerResources = this.config?.swaggerResources;
+            this.currentResource = this.swaggerResources[0].location;
+            this.updateSwagger(this.currentResource);
+        }
     }
 
     public updateSwagger(resource: string): void {


### PR DESCRIPTION
Get API list from config option to show swagger UI. It will be useful in case, when platform deployed w/o gate and there isn't API to get microservices list dynamically.

Widget configuration example:
```json
{
  "swaggerResources": [
    {
      "location": "/entity/v2/api-docs",
      "name": "entity",
      "swaggerVersion": "2.0"
    }
  ]
}
```

Signed-off-by: Ihor Shkurko <ishkurko@gmail.com>