### PR TITLE
feat(xm-date-range-filter-control): set option first day of week

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "3.6.57",
+  "version": "3.6.58",
   "release": "3.6.0",
   "private": true,
   "description": "Xm-webapp",

--- a/packages/components/date/xm-date-range-filter-control.ts
+++ b/packages/components/date/xm-date-range-filter-control.ts
@@ -35,6 +35,7 @@ export interface IDateOptions {
     initValue?: DateInitValues;
     required?: boolean;
     useUtc?: boolean;
+    firstDayOfWeek?: number;
 }
 
 type DateValue = string[] | Date[];
@@ -69,7 +70,7 @@ type DateValue = string[] | Date[];
 
             <mat-icon [owlDateTimeTrigger]="dt1" class="icon">date_range</mat-icon>
 
-            <owl-date-time #dt1 [startAt]="options?.start" [pickerType]="'calendar'"></owl-date-time>
+            <owl-date-time #dt1 [startAt]="options?.start" [firstDayOfWeek]="options?.firstDayOfWeek" [pickerType]="'calendar'"></owl-date-time>
 
             <mat-hint [hint]="options.hint"></mat-hint>
         </mat-form-field>


### PR DESCRIPTION
Component options settings have been expanded. An optional firstDayOfWeek field has been added to the IDateOptions interface, which now allows you to set the day from which the week will start. The value of the firstDayOfWeek field must be of type number. Valid value is from 0 to 6. 0: Sunday ~ 6: Saturday