### PR TITLE
Feat/xm multi language component extension of functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "3.6.71",
+  "version": "3.6.72",
   "release": "3.6.0",
   "private": true,
   "description": "Xm-webapp",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "3.6.69",
+  "version": "3.6.70",
   "release": "3.6.0",
   "private": true,
   "description": "Xm-webapp",

--- a/packages/components/multilanguage/xm-multi-language.component.ts
+++ b/packages/components/multilanguage/xm-multi-language.component.ts
@@ -194,10 +194,17 @@ export class MultiLanguageComponent extends NgModelWrapper<MultiLanguageModel>
 
     public viewToModel(value: string): void {
         if (this.transformAsObject()) {
-            this.value = {
-                ...this.value,
-                [this.selectedLng]: value,
-            };
+            if (!value) {
+                delete this.value[this.selectedLng];
+            } else {
+                this.value = {
+                    ...this.value,
+                    [this.selectedLng]: value,
+                };
+            }
+            if(_.isEmpty(this.value)) {
+                this.value = null;
+            }
         } else {
             const oldValue = (this.getValue<'array'>() ?? []);
             const langValue = { languageKey: this.selectedLng, name: value };


### PR DESCRIPTION
It was:
  - the initial value of control - null. If you add text to the input and then delete it, the value of the control will already be - the 
    object in which the key will be selected language, and the value of this field - an empty string.

Became:
    - Now if you add some text to the control and then delete it, instead of the object, the initial removal will be added to this 
      control. That is, null.  Made to make it possible to add a required validator to the shape created with this component.