### PR TITLE
feat(xm-unix-time-stamp-to-spent-time-format): added convert unix tim…

### DIFF
--- a/packages/components/date/index.ts
+++ b/packages/components/date/index.ts
@@ -33,3 +33,8 @@ export {
     XmDateViewOptions,
     XmDateViewModule,
 } from './xm-date-view';
+
+export {
+    XmUnixTimeStampToSpentTimeFormatComponent,
+    XmUnixTimeStampToSpentTimeFormatModule,
+} from './xm-unix-time-stamp-to-spent-time-format';

--- a/packages/components/date/xm-unix-time-stamp-to-spent-time-format.ts
+++ b/packages/components/date/xm-unix-time-stamp-to-spent-time-format.ts
@@ -1,0 +1,62 @@
+import { Component, Input, NgModule, OnInit, Type } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { defaults } from 'lodash';
+
+interface XmTimeStamp {
+    type?: string;
+}
+
+@Component({
+    selector: 'xm-unix-time-stamp-to-spent-time',
+    template: `
+        <span *ngIf="value && options?.type === 'SPENT-TIME'">{{ formatDate }}</span>
+
+        <span *ngIf="value && options?.type === 'DATE'">{{ formatDate | date:"dd.MM.yyyy HH:mm" }}</span>
+    `,
+})
+export class XmUnixTimeStampToSpentTimeFormatComponent implements OnInit {
+    @Input() public value: number;
+
+    protected _options: XmTimeStamp = {};
+
+    @Input()
+    public set options(value: XmTimeStamp) {
+        this._options = defaults(value, {});
+    }
+
+    public get options(): XmTimeStamp {
+        return this._options;
+    }
+
+    public formatDate = '';
+
+    public ngOnInit(): void {
+        if (this.options?.type === 'SPENT-TIME') {
+            this.timeStampToHoursMinutes();
+        }
+
+        if (this.options?.type === 'DATE') {
+            this.timeStampToHumanReadableDate();
+        }
+    }
+
+    public timeStampToHoursMinutes(): void {
+        const hours = Math.floor((this.value % (24*60*60*1000)) / (60*60*1000));
+        const minutes = Math.floor((this.value % (60*60*1000)) / (60*1000));
+
+        this.formatDate = `${ hours }h ${ minutes }m`;
+    }
+
+    public timeStampToHumanReadableDate(): void {
+        this.formatDate = new Date(this.value).toISOString();
+    }
+}
+
+@NgModule({
+    exports: [XmUnixTimeStampToSpentTimeFormatComponent],
+    declarations: [XmUnixTimeStampToSpentTimeFormatComponent],
+    imports: [CommonModule],
+})
+export class XmUnixTimeStampToSpentTimeFormatModule {
+    public entry: Type<XmUnixTimeStampToSpentTimeFormatComponent> = XmUnixTimeStampToSpentTimeFormatComponent;
+}

--- a/src/registries/xm.registry.ts
+++ b/src/registries/xm.registry.ts
@@ -125,4 +125,8 @@ export const XM_ELEMENTS: XmDynamicEntries = [
         selector: '@xm-ngx/components/hint-switch',
         loadChildren: () => import('@xm-ngx/components/hint/hint-switch/hint-switch.module').then(m => m.HintSwitchModule),
     },
+    {
+        selector: '@xm-ngx/components/unix-time-stamp-to-spent-time',
+        loadChildren: () => import('@xm-ngx/components/date/xm-unix-time-stamp-to-spent-time-format').then(m => m.XmUnixTimeStampToSpentTimeFormatModule),
+    },
 ];


### PR DESCRIPTION
A new component has been added. What can:
- accepts a date in unix timestamp format.

- count and display date in time summary format which was spent on some action. To get this option, for options.type should be 
  set to SPENT TIME.

- convert Unix timestamp to dd.MM.yyyy HH:mm format. To get this option, you need to set options.type DATE value.