### PR TITLE
feat(dynamic): add specification generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,8 @@ lerna-debug.log*
 # compdoc out
 /documentation/
 
+# xm-ngx dynamic-specification
+/src/assets/specification/
+
+
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "3.6.106",
+  "version": "3.6.108",
   "release": "3.6.0",
   "private": true,
   "description": "Xm-webapp",
@@ -28,7 +28,7 @@
     "dev": "npm run prebuild && node --max_old_space_size=4096 ./node_modules/@angular/cli/bin/ng serve --proxy-config local.proxy.conf.js --live-reload --host=0.0.0.0",
     "dev-idp": "npm run prebuild && node --max_old_space_size=4096 ./node_modules/@angular/cli/bin/ng serve --proxy-config local.proxy.conf.js --live-reload --host=0.0.0.0 --disable-host-check  -c idp",
     "dev:aot": "npm run prebuild && ng serve --proxy-config local.proxy.conf.js --live-reload  --host=0.0.0.0 --configuration production --aot=true",
-    "prebuild": "xm-ngx ext-install && xm-ngx ext-lazy-module && xm-ngx ext-assets && xm-ngx ext-i18n && xm-ngx ext-theming && xm-ngx ext-themes && npm run import-jsf-exts",
+    "prebuild": "xm-ngx ext-install && xm-ngx ext-lazy-module && xm-ngx ext-assets && xm-ngx ext-i18n && xm-ngx ext-theming && xm-ngx ext-themes && xm-ngx dynamic-specification && npm run import-jsf-exts",
     "build": "ng build --stats-json",
     "prebuild:prod": "npm run prebuild",
     "build:prod": "ng build --configuration production",
@@ -212,6 +212,7 @@
     "ng-packagr": "12.0.8",
     "protractor": "7.0.0",
     "sass": "1.32.13",
+    "ts-morph": "16.0.0",
     "ts-node": "9.1.1",
     "typescript": "4.2.4"
   }

--- a/packages/administration/src/dashboards-config/dashboards.module.ts
+++ b/packages/administration/src/dashboards-config/dashboards.module.ts
@@ -20,6 +20,8 @@ import { SelectorTextControlComponent } from './widget-edit/selector-text-contro
 import { EDIT_WIDGET_EVENT, WidgetEditComponent } from './widget-edit/widget-edit.component';
 import { DragDropModule } from '@angular/cdk/drag-drop';
 import { XmExpansionIndicatorModule } from '@xm-ngx/components/expansion-indicator';
+import { SchemaEditorComponent } from './widget-edit/schema-editor/schema-editor.component';
+import {JsonSchemaFormModule} from '@ajsf/core';
 
 @NgModule({
     imports: [
@@ -34,6 +36,7 @@ import { XmExpansionIndicatorModule } from '@xm-ngx/components/expansion-indicat
         XmDocExamplesModule,
         DragDropModule,
         XmExpansionIndicatorModule,
+        JsonSchemaFormModule
     ],
     exports: [
         DashboardsConfigComponent,
@@ -47,6 +50,7 @@ import { XmExpansionIndicatorModule } from '@xm-ngx/components/expansion-indicat
         DashboardsListComponent,
         DashboardsListExpandComponent,
         SelectorTextControlComponent,
+        SchemaEditorComponent,
     ],
     providers: [
         DashboardCollection,

--- a/packages/administration/src/dashboards-config/widget-edit/schema-editor/schema-editor.component.html
+++ b/packages/administration/src/dashboards-config/widget-edit/schema-editor/schema-editor.component.html
@@ -1,0 +1,7 @@
+<json-schema-form (onChanges)="changeBridge($event)"
+                  [data]="value"
+                  [framework]="'material-design'"
+                  [schema]="schema"
+                  class="json-form-hide-submit">
+</json-schema-form>
+  

--- a/packages/administration/src/dashboards-config/widget-edit/schema-editor/schema-editor.component.ts
+++ b/packages/administration/src/dashboards-config/widget-edit/schema-editor/schema-editor.component.ts
@@ -1,0 +1,65 @@
+import {Component, Input, OnChanges, OnInit, Optional, Self, SimpleChanges} from '@angular/core';
+import {NgControlAccessor} from '@xm-ngx/components/ng-accessor';
+import {NgControl} from '@angular/forms';
+import {HttpClient} from '@angular/common/http';
+import {DynamicComponentSpecEntity} from '@xm-ngx/cli';
+import * as _ from 'lodash';
+
+export interface SchemaEditorOptions {
+    selector: string;
+}
+
+@Component({
+    selector: 'xm-schema-editor',
+    templateUrl: './schema-editor.component.html',
+    styleUrls: ['./schema-editor.component.scss']
+})
+export class SchemaEditorComponent
+    extends NgControlAccessor<object>
+    implements OnInit, OnChanges {
+
+    @Input() public options: SchemaEditorOptions;
+    public componentSpecification: DynamicComponentSpecEntity[] = [];
+
+    public schema: object;
+
+    constructor(
+        @Optional() @Self() public ngControl: NgControl,
+        protected readonly httpClient: HttpClient
+    ) {
+        super(ngControl);
+    }
+
+    public ngOnInit(): void {
+        this.httpClient.get<DynamicComponentSpecEntity[]>('/assets/specification/dynamic_components_spec_output.json')
+            .subscribe(res => {
+                this.componentSpecification = res;
+                this.ngOnChanges({});
+            });
+    }
+
+    public ngOnChanges(changes: SimpleChanges): void {
+        if (changes.options) {
+            if (this.options.selector) {
+                this.schema = this.componentSpecification
+                    .find(i => i.selector == this.options.selector)
+                    ?.configurationSchema;
+            } else
+                this.schema = null;
+        }
+    }
+
+    public changeBridge(value: object): void {
+        // WORKAROUND: AJSF has a bug. After the data change it set `{}` with `value` interchangeable 5 times.
+        if (_.isEmpty(value)) {
+            return;
+        }
+
+        if (_.isEqual(this.value, value)) {
+            return;
+        }
+
+        this.change(value);
+    }
+
+}

--- a/packages/administration/src/dashboards-config/widget-edit/widget-edit.component.html
+++ b/packages/administration/src/dashboards-config/widget-edit/widget-edit.component.html
@@ -78,10 +78,20 @@
 
     <xm-selector-text-control [(ngModel)]="formGroup.selector"
                               [disabled]="disabled"
+                              (valueChange)="ngOnChanges({})"
                               [options]="{ title: TRS.selector }"
                               name="selector"></xm-selector-text-control>
 
     <mat-tab-group>
+      <mat-tab [label]="'Editor'">
+        <xm-schema-editor
+          [options]="jsonEditorOptions"
+          [ngModel]="formGroup.config"
+          (ngModelChange)="formGroup.config = $event"
+          [ngModelOptions]="{standalone: true}"
+        ></xm-schema-editor>
+      </mat-tab>
+
       <mat-tab [label]="'Config'">
         <xm-ace-editor-control [(ngModel)]="formGroup.config"
                                [disabled]="disabled"

--- a/packages/administration/src/dashboards-config/widget-edit/widget-edit.component.spec.ts
+++ b/packages/administration/src/dashboards-config/widget-edit/widget-edit.component.spec.ts
@@ -16,9 +16,10 @@ import { XmToasterService } from '@xm-ngx/toaster';
 import { XmTranslationTestingModule } from '@xm-ngx/translation/testing';
 
 import { WidgetEditComponent } from './widget-edit.component';
+import {JsonSchemaFormModule} from '@ajsf/core';
 
 @Component({
-    selector: 'xm-text-control, xm-selector-text-control, xm-ace-editor-control',
+    selector: 'xm-schema-editor, xm-text-control, xm-selector-text-control, xm-ace-editor-control',
     template: '',
     providers: [
         {
@@ -41,6 +42,7 @@ describe('WidgetEditComponent', () => {
                 XmTranslationTestingModule,
                 HttpClientTestingModule,
                 FormsModule,
+                JsonSchemaFormModule
             ],
             declarations: [WidgetEditComponent, MockXmTextControlComponent],
             providers: [

--- a/packages/administration/src/dashboards-config/widget-edit/widget-edit.component.ts
+++ b/packages/administration/src/dashboards-config/widget-edit/widget-edit.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostListener, Input, Type } from '@angular/core';
+import {Component, HostListener, Input, OnChanges, SimpleChanges, Type } from '@angular/core';
 import { XmAlertService } from '@xm-ngx/alert';
 import { XmEventManager } from '@xm-ngx/core';
 import { DashboardWidget } from '@xm-ngx/dashboard';
@@ -10,6 +10,7 @@ import { DASHBOARDS_TRANSLATES } from '../const';
 import { EditType } from '../dashboard-edit/dashboard-edit.component';
 import { DashboardEditorService } from '../dashboard-editor.service';
 import { DashboardCollection, DashboardConfig, WidgetCollection } from '../injectors';
+import { SchemaEditorOptions } from './schema-editor/schema-editor.component';
 
 export const EDIT_WIDGET_EVENT = 'EDIT_WIDGET_EVENT';
 
@@ -18,7 +19,7 @@ export const EDIT_WIDGET_EVENT = 'EDIT_WIDGET_EVENT';
     templateUrl: './widget-edit.component.html',
     styleUrls: ['./widget-edit.component.scss'],
 })
-export class WidgetEditComponent {
+export class WidgetEditComponent implements OnChanges {
     public TRS: typeof DASHBOARDS_TRANSLATES = DASHBOARDS_TRANSLATES;
     public EditType: typeof EditType = EditType;
     public formGroup: DashboardWidget = {
@@ -34,6 +35,8 @@ export class WidgetEditComponent {
     public aceEditorOptions: { title: string; height: string } = { title: '', height: 'calc(100vh - 280px)' };
 
     public editType: EditType;
+
+    public jsonEditorOptions: SchemaEditorOptions = { selector: null };
 
     constructor(
         protected readonly widgetService: WidgetCollection,
@@ -61,6 +64,13 @@ export class WidgetEditComponent {
         } else {
             this.editType = EditType.Create;
         }
+        this.ngOnChanges({});
+    }
+
+    public ngOnChanges(changes: SimpleChanges): void {
+        this.jsonEditorOptions.selector = this.value.selector;
+        // WORKAROUND: Trigger change detection
+        this.jsonEditorOptions = {...this.jsonEditorOptions};
     }
 
     public onCancel(): void {

--- a/packages/administration/src/navbar-dashboard-edit-widget/navbar-dashboard-edit-widget.module.ts
+++ b/packages/administration/src/navbar-dashboard-edit-widget/navbar-dashboard-edit-widget.module.ts
@@ -12,7 +12,6 @@ import {
 } from './navbar-dashboard-edit-widget.component';
 import { XmSharedModule } from '@xm-ngx/shared';
 
-
 @NgModule({
     imports: [XmSharedModule, DashboardsModule],
     exports: [NavbarDashboardEditWidgetComponent],

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -10,6 +10,7 @@ import { ExtThemesCommand } from './ext-themes-command';
 import { ExtThemingCommand } from './ext-theming-command';
 import { HelpCommand } from './help-command';
 import { ReplaceCommand } from './replace-command';
+import { DynamicSpecificationCommand } from './dynamic-specification/dynamic-specification-command';
 
 export function cli(terminalArgs: string[]): void {
     if (!terminalArgs) {
@@ -37,6 +38,10 @@ export function cli(terminalArgs: string[]): void {
         }
         case 'doc': {
             new DocCommand().execute();
+            break;
+        }
+        case 'dynamic-specification': {
+            new DynamicSpecificationCommand().execute();
             break;
         }
         case 'ext-routing': {

--- a/packages/cli/src/command.ts
+++ b/packages/cli/src/command.ts
@@ -11,6 +11,7 @@ export type CliCommands = 'ext-assets'
     | 'ext-lazy-module'
     | 'replace'
     | 'doc'
+    | 'dynamic-specification'
     | 'ext-routing'
     | 'ext-theming'
     | 'ext-themes';

--- a/packages/cli/src/dynamic-specification/dynamic-specification-command.ts
+++ b/packages/cli/src/dynamic-specification/dynamic-specification-command.ts
@@ -1,0 +1,252 @@
+import {Command} from '../command';
+import {ClassDeclaration, Node, Project, SymbolFlags, SyntaxKind, Type} from 'ts-morph';
+import fs from 'fs';
+
+export interface DynamicComponentSpecEntity {
+    name: string;
+    selector: string;
+    compatibles: string[];
+    configurationSchema: object;
+}
+
+function isDynamicComponent(classDeclaration: ClassDeclaration): boolean {
+    const hasConfigProperty = classDeclaration.getProperties().some(i => i.getName() == 'config');
+    const hasConfigSetter = classDeclaration.getSetAccessors().some(i => i.getName() == 'config');
+    if (!hasConfigProperty && !hasConfigSetter) {
+        return false;
+    }
+
+    const decoratorDeclaration = classDeclaration.getDecorator('Component');
+    if (!decoratorDeclaration) {
+        return false;
+    }
+
+    return true;
+}
+
+function getName(classDeclaration: ClassDeclaration): string {
+    return classDeclaration.getName() || '';
+}
+
+function getSelector(classDeclaration: ClassDeclaration): string {
+    const decoratorDeclaration = classDeclaration.getDecorator('Component');
+    if (!decoratorDeclaration) {
+        return '';
+    }
+
+    const componentDeclaration = decoratorDeclaration.getArguments()[0];
+    if (!componentDeclaration) {
+        return '';
+    }
+    if (!Node.isObjectLiteralExpression(componentDeclaration)) {
+        return '';
+    }
+
+    const property = componentDeclaration.getProperty('selector');
+    if (!property) {
+        return '';
+    }
+    if (!Node.isPropertyAssignment(property)) {
+        return '';
+    }
+    const stringLiteral = property.getFirstChildByKind(SyntaxKind.StringLiteral);
+    if (!stringLiteral) {
+        return '';
+    }
+
+    const selector = stringLiteral.getLiteralValue();
+    if (!selector) {
+        return '';
+    }
+
+    const file = classDeclaration.getSourceFile();
+    const path = file.getFilePath();
+    const invertedPath = path.split('/').reverse();
+
+    let prefix;
+    if (invertedPath.includes('ext')) {
+        const index = invertedPath.indexOf('ext');
+        prefix = invertedPath[index - 1].replace('-webapp-ext', '');
+    } else {
+        const index = invertedPath.indexOf('packages');
+        prefix = '@xm-ngx/' + invertedPath[index - 1];
+    }
+
+    return prefix + '/' + selector;
+}
+
+function getCompatibleTypes(classDeclaration: ClassDeclaration): string[] {
+    const interfaceDeclarations = classDeclaration.getImplements();
+    if (interfaceDeclarations.length == 0) {
+        return [];
+    }
+
+    const names = interfaceDeclarations.map(i => i
+        .getExpressionIfKindOrThrow(SyntaxKind.Identifier)
+        .getSymbolOrThrow()
+        .getName());
+
+    const types = [
+        'XmDynamicConfig',
+        'XmDynamicWidget',
+        'XmDynamicPresentation',
+        'XmDynamicControl',
+        'XmDynamicCell'
+    ];
+    const compatibles: string[] = [];
+
+    for (const type of types) {
+        if (names.includes(type)) {
+            compatibles.push(type);
+        }
+    }
+
+    return compatibles;
+}
+
+function getConfigurationSchema(classDeclaration: ClassDeclaration): object {
+    const definitions: any = {};
+
+    function getSchema(type: Type): object {
+        const nonNullableType = type.getNonNullableType();
+
+        if (nonNullableType.isArray() && nonNullableType.getArrayElementType()) {
+            return {
+                title: nonNullableType.getSymbol()?.getName(),
+                type: 'array',
+                items: getSchema(nonNullableType.getArrayElementTypeOrThrow())
+            };
+        } else if (nonNullableType.isBoolean()) {
+            return {
+                title: nonNullableType.getSymbol()?.getName(),
+                type: nonNullableType.getText()
+            };
+        } else if (nonNullableType.isNumber()) {
+            return {
+                title: nonNullableType.getSymbol()?.getName(),
+                type: nonNullableType.getText()
+            };
+        } else if (nonNullableType.isString()) {
+            return {
+                title: nonNullableType.getSymbol()?.getName(),
+                type: nonNullableType.getText()
+            };
+        } else if (
+            nonNullableType.isClass() ||
+            nonNullableType.isIntersection() ||
+            nonNullableType.isObject() && nonNullableType.getSymbolOrThrow().getDeclarations().some(i =>
+                i.isKind(SyntaxKind.ClassDeclaration) ||
+                i.isKind(SyntaxKind.InterfaceDeclaration))
+        ) {
+            const name = nonNullableType.getSymbol()?.getName() + '';
+            if (!definitions[name]) {
+                // WORKAROUND: to mark property as a defined for recursion
+                definitions[name] = {'__mock__': '__mock__'};
+                definitions[name] = {
+                    title: nonNullableType.getSymbol()?.getName(),
+                    type: 'object',
+                    properties: nonNullableType.getProperties()
+                        .filter(i => {
+                            const isGetter = i.hasFlags(SymbolFlags.GetAccessor);
+                            const isValuable = i.getValueDeclaration();
+                            const isTraceable = !isGetter && isValuable;
+                            if (isTraceable) return isTraceable;
+                            console.warn('Skip Type', i.getName(), classDeclaration.getName());
+                            return true;
+                        })
+                        .map(i => i.getValueDeclarationOrThrow())
+                        .map(i => ({[i.getSymbol()?.getName() || '']: getSchema(i.getType())}))
+                        .reduce((p, c) => (Object.assign(p, c)), {})
+                };
+            }
+            return {
+                title: name,
+                type: 'object',
+                '$ref': '#/definitions/' + name,
+            };
+        } else if (nonNullableType.isObject()) {
+            return {
+                title: nonNullableType.getSymbol()?.getName(),
+                type: 'object',
+                properties: nonNullableType.getProperties()
+                    .filter(i => {
+                        const isGetter = i.hasFlags(SymbolFlags.GetAccessor);
+                        const isValuable = i.getValueDeclaration();
+                        const isTraceable = !isGetter && isValuable;
+                        if (isTraceable) return isTraceable;
+                        console.warn('Skip Type', i.getName(), classDeclaration.getName());
+                        return true;
+                    })
+                    .map(i => i.getValueDeclarationOrThrow())
+                    .map(i => ({[i.getSymbolOrThrow().getName()]: getSchema(i.getType())}))
+                    .reduce((p, c) => (Object.assign(p, c)), {})
+            };
+        } else if (nonNullableType.isEnum()) {
+            return {
+                title: nonNullableType.getSymbol()?.getName(),
+                type: 'string',
+                enum: nonNullableType.getUnionTypes()
+                    .map(t => t.getLiteralValueOrThrow())
+            };
+        } else if (nonNullableType.isUnion()) {
+            return {
+                title: nonNullableType.getSymbol()?.getName(),
+                'type': 'object',
+                'oneOf': nonNullableType.getUnionTypes()
+                    .map(i => getSchema(i))
+            };
+        } else if (nonNullableType.isIntersection()) {
+            return {
+                title: nonNullableType.getSymbol()?.getName(),
+                'type': 'object',
+                'allOf': nonNullableType.getIntersectionTypes()
+                    .map(i => getSchema(i))
+            };
+        }
+
+        console.warn('Unknown type', nonNullableType.getText(), classDeclaration.getName());
+        return {
+            title: nonNullableType.getSymbol()?.getName() || 'Unknown type!',
+            'type': 'string',
+            'default': 'Unknown type!',
+            'readOnly': true
+        };
+    }
+
+    const config = classDeclaration.getProperty('config');
+    if (!config) {
+        return {};
+    }
+    const schema = Object.assign({properties: {}}, getSchema(config.getType()));
+    return Object.assign(schema, {definitions});
+}
+
+export class DynamicSpecificationCommand implements Command {
+    public execute(): void {
+        const project = new Project({
+            tsConfigFilePath: 'tsconfig.json',
+        });
+
+        const sourceFiles = project.getSourceFiles();
+
+        const dynamicComponentSpecs: DynamicComponentSpecEntity[] = [];
+        for (const sourceFile of sourceFiles) {
+
+            const dynamicClases = sourceFile.getClasses()
+                .filter(i => isDynamicComponent(i));
+
+            for (const dynamicClase of dynamicClases) {
+                dynamicComponentSpecs.push({
+                    name: getName(dynamicClase),
+                    selector: getSelector(dynamicClase),
+                    compatibles: getCompatibleTypes(dynamicClase),
+                    configurationSchema: getConfigurationSchema(dynamicClase)
+                });
+            }
+        }
+        fs.writeFileSync(
+            'src/assets/specification/dynamic_components_spec_output.json',
+            JSON.stringify(dynamicComponentSpecs, undefined, 2)
+        );
+    }
+}

--- a/packages/cli/src/dynamic-specification/dynamic-specification-command.ts
+++ b/packages/cli/src/dynamic-specification/dynamic-specification-command.ts
@@ -152,7 +152,7 @@ function getConfigurationSchema(classDeclaration: ClassDeclaration): object {
                             const isTraceable = !isGetter && isValuable;
                             if (isTraceable) return isTraceable;
                             console.warn('Skip Type', i.getName(), classDeclaration.getName());
-                            return true;
+                            return false;
                         })
                         .map(i => i.getValueDeclarationOrThrow())
                         .map(i => ({[i.getSymbol()?.getName() || '']: getSchema(i.getType())}))
@@ -175,7 +175,7 @@ function getConfigurationSchema(classDeclaration: ClassDeclaration): object {
                         const isTraceable = !isGetter && isValuable;
                         if (isTraceable) return isTraceable;
                         console.warn('Skip Type', i.getName(), classDeclaration.getName());
-                        return true;
+                        return false;
                     })
                     .map(i => i.getValueDeclarationOrThrow())
                     .map(i => ({[i.getSymbolOrThrow().getName()]: getSchema(i.getType())}))

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,1 +1,2 @@
 export { cli } from './cli';
+export { DynamicComponentSpecEntity } from './dynamic-specification/dynamic-specification-command';

--- a/src/app/ext/example-webapp-ext/module/example-presentational/example-presentation.module.ts
+++ b/src/app/ext/example-webapp-ext/module/example-presentational/example-presentation.module.ts
@@ -1,0 +1,17 @@
+import {CommonModule} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {XmDynamicConstructor, XmDynamicPresentationEntryModule} from '@xm-ngx/dynamic';
+import {ExamplePresentationalComponent} from './example-presentational.component';
+
+
+@NgModule({
+    declarations: [ExamplePresentationalComponent],
+    exports: [ExamplePresentationalComponent],
+    imports: [CommonModule],
+})
+export class ExamplePresentationModule implements XmDynamicPresentationEntryModule {
+    /**
+     * Specifying the entry point for XmDynamicModule
+     */
+    public entry: XmDynamicConstructor<ExamplePresentationalComponent> = ExamplePresentationalComponent;
+}

--- a/src/app/ext/example-webapp-ext/module/example-presentational/example-presentational.component.html
+++ b/src/app/ext/example-webapp-ext/module/example-presentational/example-presentational.component.html
@@ -1,0 +1,1 @@
+<h1>{{config.title}}</h1>

--- a/src/app/ext/example-webapp-ext/module/example-presentational/example-presentational.component.spec.ts
+++ b/src/app/ext/example-webapp-ext/module/example-presentational/example-presentational.component.spec.ts
@@ -1,0 +1,23 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {ExamplePresentationalComponent} from './example-presentational.component';
+
+describe('ExamplePresentationalComponent', () => {
+    let component: ExamplePresentationalComponent;
+    let fixture: ComponentFixture<ExamplePresentationalComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [ExamplePresentationalComponent]
+        })
+            .compileComponents();
+
+        fixture = TestBed.createComponent(ExamplePresentationalComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/src/app/ext/example-webapp-ext/module/example-presentational/example-presentational.component.ts
+++ b/src/app/ext/example-webapp-ext/module/example-presentational/example-presentational.component.ts
@@ -1,0 +1,26 @@
+import {Component, Input} from '@angular/core';
+import {XmDynamicPresentation} from '@xm-ngx/dynamic';
+import {Translate} from '@xm-ngx/translation';
+import {Defaults} from '@xm-ngx/shared/operators';
+
+export interface ExamplePresentationalComponentConfig {
+    title: Translate
+}
+
+export const EXAMPLE_PRESENTATIONAL_COMPONENT_DEFAULT_CONFIG: ExamplePresentationalComponentConfig = {
+    title: 'Example presentational',
+};
+
+@Component({
+    selector: 'xm-example-presentational',
+    templateUrl: './example-presentational.component.html',
+    styleUrls: ['./example-presentational.component.scss']
+})
+export class ExamplePresentationalComponent implements XmDynamicPresentation<null, ExamplePresentationalComponentConfig> {
+    @Input() @Defaults(null)
+    public value: null;
+
+    @Input() @Defaults(EXAMPLE_PRESENTATIONAL_COMPONENT_DEFAULT_CONFIG)
+    public config: ExamplePresentationalComponentConfig;
+    public options: ExamplePresentationalComponentConfig;
+}

--- a/src/app/ext/example-webapp-ext/module/example-presentational/index.ts
+++ b/src/app/ext/example-webapp-ext/module/example-presentational/index.ts
@@ -1,0 +1,3 @@
+export {
+    ExamplePresentationModule,
+} from './example-presentation.module';

--- a/src/app/ext/example-webapp-ext/module/example-webapp-ext.module.ts
+++ b/src/app/ext/example-webapp-ext/module/example-webapp-ext.module.ts
@@ -6,6 +6,10 @@ import { XmDynamicModule } from '@xm-ngx/dynamic';
         /** XmDynamicModule used for creating lazy dynamic components. */
         XmDynamicModule.forChild([
             {
+                selector: 'example',
+                loadChildren: () => import('./example-presentational').then(m => m.ExamplePresentationModule),
+            },
+            {
                 selector: 'example-widget',
                 loadChildren: () => import('./example-widget').then(m => m.ExampleWidgetModule),
             },

--- a/src/assets/specification/.gitkeep
+++ b/src/assets/specification/.gitkeep
@@ -1,0 +1,1 @@
+# xm-ngx dynamic-specification

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -69,6 +69,6 @@
     "newLine": "lf",
     "strictFunctionTypes": true,
     "noFallthroughCasesInSwitch": true,
-    "resolveJsonModule": true,
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
### Description

Generates json schema form for ui widget editor, based on field "config" type. Use `xm-ngx dynamic-specification`.
Generated component-spec located at `src/assets/specification/dynamic_components_spec_output.json`.

### Future tasks(Feel free to implement):
- IMPORTANT: add `OneOff` and other, implement own jsf;
- add pipeline component-spec validator;
- add switcher between editor and code and remove tab at widget-editor ;
- add webpack plugin to angular and update spec on file change;
- split spec into multiple files;
- build extension specs to extension folder;
- add support for `XmLayout[]` and recursive spec({selector: "sub-component"});
- decorator `[min, max]`;
- description from `tsdoc`;
- generate registry file;
- add `require[]` based on `:?`.

Example of parser for swagger:
// SOURCE: https://github.com/yantrab/strongly/blob/master/src/utils/typescript-service.ts