### PR TITLE
chorn: improve text fields and selects view based on the material design

### DIFF
--- a/packages/account/src/user-login-widget/login/user-login-form.component.html
+++ b/packages/account/src/user-login-widget/login/user-login-form.component.html
@@ -2,7 +2,7 @@
 
 <form #editForm="ngForm" (ngSubmit)="save()" class="m-0" name="editForm" novalidate>
   <div *ngFor="let login of userLogins" class="form-group">
-    <mat-form-field>
+    <mat-form-field appearance="fill">
       <input [(ngModel)]="login.value"
              id="{{login.key}}"
              matInput

--- a/packages/account/src/user-security-settings/xm-user-security-settings.component.html
+++ b/packages/account/src/user-security-settings/xm-user-security-settings.component.html
@@ -21,7 +21,7 @@
           {{'settings.security.autoLogout' | translate}}
         </mat-checkbox>
 
-        <mat-form-field>
+        <mat-form-field appearance="fill">
           <input [(ngModel)]="autoLogoutTime"
                  [disabled]="!autoLogoutEnabled"
                  [placeholder]="'settings.security.seconds' | translate"

--- a/packages/account/src/user-settings-widget/xm-user-settings-widget.component.html
+++ b/packages/account/src/user-settings-widget/xm-user-settings-widget.component.html
@@ -6,7 +6,7 @@
 
       <div *ngIf="success" [innerHTML]="'settings.messages.success' | translate" class="alert alert-success"></div>
 
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <input #firstNameInput="ngModel"
                [(ngModel)]="settingsAccount.firstName"
                id="firstName"
@@ -28,7 +28,7 @@
         </mat-error>
       </mat-form-field>
 
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <input #lastNameInput="ngModel"
                [(ngModel)]="settingsAccount.lastName"
                id="lastName"
@@ -50,11 +50,11 @@
         </mat-error>
       </mat-form-field>
 
-      <mat-form-field *ngIf="languages$ | async as languages">
+      <mat-form-field appearance="fill" *ngIf="languages$ | async as languages">
+        <mat-label>{{'global.form.language' | translate}}</mat-label>
         <mat-select [(ngModel)]="settingsAccount.langKey"
                     id="langKey"
                     name="langKey"
-                    placeholder="{{'global.form.language' | translate}}"
                     required>
           <mat-option *ngFor="let language of languages"
                       [value]="language">

--- a/packages/administration/src/architecture/architecture.component.html
+++ b/packages/administration/src/architecture/architecture.component.html
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-sm-3 offset-3">
-    <mat-form-field>
+    <mat-form-field appearance="fill">
       <mat-label>{{'admin-webapp-ext.common.project' | translate}}</mat-label>
       <mat-select>
         <mat-option (onSelectionChange)="onProjectSelectionChange({isUserInput: true})"

--- a/packages/administration/src/audits/audits.component.html
+++ b/packages/administration/src/audits/audits.component.html
@@ -5,7 +5,7 @@
     <h6>{{ 'audits.filter.title' | translate }}</h6>
     <div class="row">
       <div class="col-sm-2">
-        <mat-form-field>
+        <mat-form-field appearance="fill">
           <input (ngModelChange)="onChangeDate()"
                  [(ngModel)]="fromDate"
                  [matDatepicker]="fromDatePicker"
@@ -17,7 +17,7 @@
         </mat-form-field>
       </div>
       <div class="col-sm-2">
-        <mat-form-field>
+        <mat-form-field appearance="fill">
           <input (ngModelChange)="onChangeDate()"
                  [(ngModel)]="toDate"
                  [matDatepicker]="toDatePicker"

--- a/packages/administration/src/client-management/client-management-dialog.component.html
+++ b/packages/administration/src/client-management/client-management-dialog.component.html
@@ -7,7 +7,7 @@
   <div mat-dialog-content>
     <xm-loader [showLoader]="showLoader"></xm-loader>
     <div class="form-group">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <input matInput
                id="clientId"
                type="text"
@@ -31,7 +31,7 @@
       </mat-form-field>
     </div>
     <div class="form-group">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <input matInput
                id="clientSecret"
                type="password"
@@ -43,11 +43,11 @@
       </mat-form-field>
     </div>
     <div class="form-group">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
+        <mat-label>{{'clientManagement.role' | translate}}</mat-label>
         <mat-select [(ngModel)]="client.roleKey"
                     #clientAuthority="ngModel"
                     name="authority"
-                    placeholder="{{'clientManagement.role' | translate}}"
                     required>
           <mat-option *ngFor="let authority of authorities" [value]="authority">
             {{authority}}
@@ -59,7 +59,7 @@
       </mat-form-field>
     </div>
     <div class="form-group">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <input matInput
                id="validityPeriod"
                type="text"
@@ -77,7 +77,7 @@
       </mat-form-field>
     </div>
     <div class="form-group">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <input matInput
                id="description"
                type="text"
@@ -88,7 +88,7 @@
       </mat-form-field>
     </div>
     <div class="form-group">
-        <mat-form-field class="xm-sources-tags">
+        <mat-form-field appearance="fill" class="xm-sources-tags">
           <mat-chip-list #chipList [attr.aria-label]="'clientManagement.scopes-add' | translate">
             <mat-chip
               color="primary"

--- a/packages/administration/src/client-management/client-management.component.html
+++ b/packages/administration/src/client-management/client-management.component.html
@@ -10,7 +10,7 @@
           action=""
           class="col-12 px-0 col-md-3 d-flex flex-nowrap align-items-center"
           novalidate>
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <input
           [(ngModel)]="clientId"
           matInput

--- a/packages/administration/src/dashboards-config/widget-edit/selector-text-control/selector-text-control.component.html
+++ b/packages/administration/src/dashboards-config/widget-edit/selector-text-control/selector-text-control.component.html
@@ -1,4 +1,4 @@
-<mat-form-field>
+<mat-form-field appearance="fill">
   <mat-label>{{options.title | translate}}</mat-label>
   <input (ngModelChange)="change($event)"
          [formControl]="control"

--- a/packages/administration/src/docs/docs.component.html
+++ b/packages/administration/src/docs/docs.component.html
@@ -10,7 +10,7 @@
 
       <div class="col-6">
         <div class="swagger-ui">
-          <mat-form-field>
+          <mat-form-field appearance="fill">
             <mat-select (selectionChange)="updateSwagger(currentResource)"
                         [(ngModel)]="currentResource"
                         name='swagRes'>

--- a/packages/administration/src/form-playground/form-playground.component.html
+++ b/packages/administration/src/form-playground/form-playground.component.html
@@ -7,10 +7,10 @@
       <div class="card-body">
         <div class="form-group">
 
-          <mat-form-field>
+          <mat-form-field appearance="fill">
+            <mat-label>{{'rolesManagement.permission.msName' | translate}}</mat-label>
             <mat-select #file
-                        (selectionChange)="loadSelectedExample($event, file.value)"
-                        placeholder="{{'rolesManagement.permission.msName' | translate}}">
+                        (selectionChange)="loadSelectedExample($event, file.value)">
               <mat-option disabled>
                 {{'formPlayground.selectSchema' | translate}}
               </mat-option>
@@ -21,7 +21,7 @@
           </mat-form-field>
 
           <div *ngIf="isXmForm">
-            <mat-form-field *ngIf="specs$ | async as fetchedSpecs;">
+            <mat-form-field appearance="fill" *ngIf="specs$ | async as fetchedSpecs;">
               <ng-container
                 *ngIf="fetchedSpecs; then resultData; else noData"
               ></ng-container>
@@ -48,7 +48,7 @@
               </ng-template>
             </mat-form-field>
 
-            <mat-form-field *ngIf="xmEntityForms$ | async as fetchedSpecs;">
+            <mat-form-field appearance="fill" *ngIf="xmEntityForms$ | async as fetchedSpecs;">
               <ng-container
                 *ngIf="fetchedSpecs; then resultData; else noData"
               ></ng-container>

--- a/packages/administration/src/health/health.component.html
+++ b/packages/administration/src/health/health.component.html
@@ -4,10 +4,10 @@
 
     <div class="row align-items-center">
       <div class="col-sm-3">
-        <mat-form-field>
+        <mat-form-field appearance="fill">
+          <mat-label>{{'metrics.options.service-name' | translate}}</mat-label>
           <mat-select (selectionChange)="onServiceSelect()"
-                      [(ngModel)]="selectedService"
-                      placeholder="{{'metrics.options.service-name' | translate}}">
+                      [(ngModel)]="selectedService">
             <mat-option *ngFor="let s of services" [value]="s.name">
               {{s.name}}
             </mat-option>
@@ -16,10 +16,10 @@
       </div>
 
       <div class="col-sm-3">
-        <mat-form-field>
+        <mat-form-field appearance="fill">
+          <mat-label>{{'metrics.options.instance-name' | translate}}</mat-label>
           <mat-select (selectionChange)="mapHealthCheck(selectedInstance)"
-                      [(ngModel)]="selectedInstance"
-                      placeholder="{{'metrics.options.instance-name' | translate}}">
+                      [(ngModel)]="selectedInstance">
             <mat-option *ngFor="let i of instances" [value]="i.id">
               {{i.address}}:{{i.port}} ({{i.id}})
             </mat-option>

--- a/packages/administration/src/logs/logs.component.html
+++ b/packages/administration/src/logs/logs.component.html
@@ -2,17 +2,17 @@
   <h4>{{'logs.title' | translate}}</h4>
 
   <div class="d-md-flex">
-    <mat-form-field class="mr-3">
+    <mat-form-field appearance="fill" class="mr-3">
+      <mat-label>{{'metrics.options.service-name' | translate}}</mat-label>
       <mat-select (selectionChange)="getLoggers()"
-                  [(ngModel)]="selectedService"
-                  [placeholder]="'metrics.options.service-name' | translate">
+                  [(ngModel)]="selectedService">
         <mat-option *ngFor="let s of services" [value]="s.name">
           {{s.name}}
         </mat-option>
       </mat-select>
     </mat-form-field>
 
-    <mat-form-field>
+    <mat-form-field appearance="fill">
       <input (keyup)="applyFilter($event)" [placeholder]="'logs.filter' | translate" matInput type="text">
     </mat-form-field>
   </div>

--- a/packages/administration/src/metrics/metrics.component.html
+++ b/packages/administration/src/metrics/metrics.component.html
@@ -7,10 +7,10 @@
     <div class="row">
       <div class="col-sm-3">
         <div class="form-group">
-          <mat-form-field>
+          <mat-form-field appearance="fill">
+            <mat-label>{{'metrics.options.service-name' | translate}}</mat-label>
             <mat-select (selectionChange)="onServiceSelect()"
-                        [(ngModel)]="selectedService"
-                        placeholder="{{'metrics.options.service-name' | translate}}">
+                        [(ngModel)]="selectedService">
               <mat-option *ngFor="let s of services" [value]="s.name">
                 {{s.name}}
               </mat-option>
@@ -20,11 +20,11 @@
       </div>
       <div class="col-sm-3">
         <div class="form-group">
-          <mat-form-field>
+          <mat-form-field appearance="fill">
+            <mat-label>{{'metrics.options.instance-name' | translate}}</mat-label>
             <mat-select (selectionChange)="mapMetrics(selectedInstance)"
                         [(ngModel)]="selectedInstance"
-                        [disabled]="!(instances && instances.length)"
-                        placeholder="{{'metrics.options.instance-name' | translate}}">
+                        [disabled]="!(instances && instances.length)">
               <mat-option *ngFor="let i of instances" [value]="i.id">
                 {{i.address}}:{{i.port}} ({{i.id}})
               </mat-option>

--- a/packages/administration/src/roles-management-detail/roles-management-condition-dialog.component.html
+++ b/packages/administration/src/roles-management-detail/roles-management-condition-dialog.component.html
@@ -11,7 +11,7 @@
     <p>{{transInfo|translate}}</p>
 
     <div class="form-group">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <input [value]="permission.privilegeKey"
                disabled
                matInput
@@ -21,7 +21,7 @@
     </div>
 
     <div class="form-group">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
             <textarea [(ngModel)]="condition"
                       [wordAutocomplete]="variables"
                       id="condition"

--- a/packages/administration/src/roles-management-detail/roles-management-detail.component.html
+++ b/packages/administration/src/roles-management-detail/roles-management-detail.component.html
@@ -10,10 +10,10 @@
     <div class="row align-items-center">
       <div class="col-sm-4 col-md-2">
         <div class="form-group">
-          <mat-form-field>
+          <mat-form-field appearance="fill">
+            <mat-label>{{'rolesManagement.permission.msName' | translate}}</mat-label>
             <mat-select (selectionChange)="onChangeSort()"
-                        [(ngModel)]="sortBy.msName"
-                        placeholder="{{'rolesManagement.permission.msName' | translate}}">
+                        [(ngModel)]="sortBy.msName">
               <mat-option *ngFor="let item of entities" [value]="item">{{item}}</mat-option>
             </mat-select>
           </mat-form-field>
@@ -22,7 +22,7 @@
 
       <div class="col-sm-4 col-md-2">
         <div class="form-group">
-          <mat-form-field>
+          <mat-form-field appearance="fill">
             <input (change)="onChangeSort()"
                    [(ngModel)]="sortBy.query"
                    matInput
@@ -35,10 +35,10 @@
 
       <div class="col-sm-4 col-md-2">
         <div class="form-group">
-          <mat-form-field>
+          <mat-form-field appearance="fill">
+            <mat-label>{{'rolesManagement.permission.permit' | translate}}</mat-label>
             <mat-select (selectionChange)="onChangeSort()"
-                        [(ngModel)]="sortBy.enabled"
-                        placeholder="{{'rolesManagement.permission.permit' | translate}}">
+                        [(ngModel)]="sortBy.enabled">
               <mat-option *ngFor="let item of permits" [value]="item.value">
                 <span *ngIf="item.trans">{{'rolesManagement.permission.'+item.trans|translate}}</span>
               </mat-option>
@@ -49,10 +49,10 @@
 
       <div class="col-sm-4 col-md-2">
         <div class="form-group">
-          <mat-form-field>
+          <mat-form-field appearance="fill">
+            <mat-label>{{'rolesManagement.permission.resourceCondition' | translate}}</mat-label>
             <mat-select (selectionChange)="onChangeSort()"
-                        [(ngModel)]="sortBy.condition"
-                        placeholder="{{'rolesManagement.permission.resourceCondition' | translate}}">
+                        [(ngModel)]="sortBy.condition">
               <mat-option *ngFor="let item of resourceConditions" [value]="item.value">
                 <span *ngIf="item.trans">{{'rolesManagement.permission.'+item.trans|translate}}</span>
               </mat-option>
@@ -130,7 +130,7 @@
             {{'rolesManagement.permission.onForbid' | translate}}
           </th>
           <td mat-cell *matCellDef="let permission" class="text-center">
-            <mat-form-field class="slim-select">
+            <mat-form-field appearance="fill" class="slim-select">
               <mat-select [(ngModel)]="permission.reactionStrategy" [disabled]="readOnlyMode">
                 <mat-option *ngFor="let value of forbids" [value]="value">
                   {{value}}

--- a/packages/administration/src/roles-management/roles-management-dialog.component.html
+++ b/packages/administration/src/roles-management/roles-management-dialog.component.html
@@ -11,7 +11,7 @@
     <xm-loader [showLoader]="showLoader"></xm-loader>
 
     <div class="form-group">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <input #fieldRoleKey="ngModel"
                [(ngModel)]="role.roleKey"
                [disabled]="!isAddMode"
@@ -33,10 +33,10 @@
 
 
     <div *ngIf="isAddMode" class="form-group">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
+        <mat-label>{{'rolesManagement.basedOn' | translate}}</mat-label>
         <mat-select [(ngModel)]="role.basedOn"
-                    name="authority"
-                    placeholder="{{'rolesManagement.basedOn' | translate}}">
+                    name="authority">
           <mat-option readonly>{{'rolesManagement.chooseRole' | translate}}</mat-option>
           <mat-option *ngFor="let item of roles" [value]="item">{{item}}</mat-option>
         </mat-select>
@@ -44,7 +44,7 @@
     </div>
 
     <div class="form-group">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
             <textarea [(ngModel)]="role.description"
                       id="field_desc"
                       matInput

--- a/packages/administration/src/roles-matrix/roles-matrix.component.html
+++ b/packages/administration/src/roles-matrix/roles-matrix.component.html
@@ -7,17 +7,17 @@
   <div mat-card-content>
     <div class="d-flex align-items-center flex-md-nowrap flex-wrap">
       <div class="d-flex flex-grow-1 flex-wrap align-items-center mb-2">
-        <mat-form-field class="mr-4">
+        <mat-form-field appearance="fill" class="mr-4">
+          <mat-label>{{'rolesManagement.permission.msName' | translate}}</mat-label>
           <mat-select (selectionChange)="onChangeSort()"
-                      [(ngModel)]="sortBy.msName"
-                      placeholder="{{'rolesManagement.permission.msName' | translate}}">
+                      [(ngModel)]="sortBy.msName">
             <mat-option *ngFor="let item of entities" [value]="item">
               {{item}}
             </mat-option>
           </mat-select>
         </mat-form-field>
 
-        <mat-form-field class="mr-4">
+        <mat-form-field appearance="fill" class="mr-4">
           <input (change)="onChangeSort()"
                  [(ngModel)]="sortBy.query"
                  matInput
@@ -26,10 +26,10 @@
                  type="text">
         </mat-form-field>
 
-        <mat-form-field class="mr-4">
+        <mat-form-field appearance="fill" class="mr-4">
+          <mat-label>{{'rolesManagement.permission.privilegeKey' | translate}}</mat-label>
           <mat-select (selectionChange)="onChangeSort()"
-                      [(ngModel)]="sortBy.permitted_filter"
-                      placeholder="{{'rolesManagement.permission.privilegeKey' | translate}}">
+                      [(ngModel)]="sortBy.permitted_filter">
             <mat-option *ngFor="let item of permittedFilter" [value]="item.value">
               <span *ngIf="item.trans">{{'rolesManagement.permission.' + item.trans|translate}}</span>
             </mat-option>

--- a/packages/administration/src/specification-management/entity-spec-editor/entity-spec-editor.component.html
+++ b/packages/administration/src/specification-management/entity-spec-editor/entity-spec-editor.component.html
@@ -33,7 +33,7 @@
     </mat-expansion-panel-header>
 
     <div *ngIf="openedEntitySpec === index">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <input [(ngModel)]="entitySpec.key"
                [placeholder]="('admin-config.specification-mng.editor.key' | translate)"
                matInput
@@ -64,9 +64,9 @@
           </mat-checkbox>
         </div>
         <div class="col-4">
-          <mat-form-field>
-            <mat-select [(ngModel)]="entitySpec.icon"
-                        [placeholder]="('admin-config.specification-mng.editor.icon' | translate)">
+          <mat-form-field appearance="fill">
+            <mat-label>{{'admin-config.specification-mng.editor.icon' | translate}}</mat-label>
+            <mat-select [(ngModel)]="entitySpec.icon">
               <mat-select-trigger>
                 {{entitySpec.icon}}
               </mat-select-trigger>

--- a/packages/administration/src/specification-management/entity-spec-editor/states-editor/states-editor.component.html
+++ b/packages/administration/src/specification-management/entity-spec-editor/states-editor/states-editor.component.html
@@ -28,7 +28,7 @@
     </mat-expansion-panel-header>
 
     <div *ngIf="openedStateSpec === index">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <input matInput
                type="text"
                [placeholder]="('admin-config.specification-mng.editor.key' | translate)"
@@ -45,7 +45,7 @@
         <div class="col-4">
         </div>
         <div class="col-4">
-          <mat-form-field>
+          <mat-form-field appearance="fill">
             <input matInput
                    type="text"
                    [placeholder]="('admin-config.specification-mng.editor.color' | translate)"
@@ -53,9 +53,9 @@
           </mat-form-field>
         </div>
         <div class="col-4">
-          <mat-form-field>
-            <mat-select [placeholder]="('admin-config.specification-mng.editor.icon' | translate)"
-                        [(ngModel)]="state.icon">
+          <mat-form-field appearance="fill">
+            <mat-label>{{'admin-config.specification-mng.editor.icon' | translate}}</mat-label>
+            <mat-select [(ngModel)]="state.icon">
               <mat-select-trigger>
                 {{state.icon}}
               </mat-select-trigger>

--- a/packages/administration/src/style-guide/style-guide.component.html
+++ b/packages/administration/src/style-guide/style-guide.component.html
@@ -29,12 +29,12 @@
       <h4>Text fields</h4>
 
       <form [formGroup]="group" class="example-form">
-        <mat-form-field>
+        <mat-form-field appearance="fill">
           <mat-label>Default</mat-label>
           <input [formControl]="group.controls.default" matInput placeholder="Default Placeholder" type="email">
         </mat-form-field>
 
-        <mat-form-field>
+        <mat-form-field appearance="fill">
           <mat-label>Email with error</mat-label>
           <input [formControl]="group.controls.email" matInput placeholder="Ex. pat@example.com" type="email">
           <mat-error *ngIf="group.controls.email.hasError('email') && !group.controls.email.hasError('required')">

--- a/packages/administration/src/translations/keys-view/keys-view.component.html
+++ b/packages/administration/src/translations/keys-view/keys-view.component.html
@@ -26,7 +26,7 @@
             <div class="keys-view__col">
                 <mat-icon class="keys-view__warning-icon" *ngIf="!translationKey[1]" color="warn">warning</mat-icon>
                 <form (ngSubmit)="changeTranslate(translationKey[0])">
-                    <mat-form-field class="keys-view__input" [floatLabel]="'never'">
+                    <mat-form-field appearance="fill" class="keys-view__input" [floatLabel]="'never'">
                         <input #input="ngModel"
                                matInput
                                required

--- a/packages/administration/src/user-management/user-management-dialog/user-management-dialog.component.html
+++ b/packages/administration/src/user-management/user-management-dialog/user-management-dialog.component.html
@@ -8,7 +8,7 @@
     <xm-loader [showLoader]="showLoader"></xm-loader>
 
     <div class="form-group">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <input [(ngModel)]="user.id"
                disabled
                id="id"
@@ -20,7 +20,7 @@
     </div>
 
     <div class="form-group">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <input [(ngModel)]="user.userKey"
                disabled
                id="userKey"
@@ -36,7 +36,7 @@
     </div>
 
     <div class="form-group">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <input #firstNameInput="ngModel"
                [(ngModel)]="user.firstName"
                id="firstName"
@@ -52,7 +52,7 @@
     </div>
 
     <div class="form-group">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <input #lastNameInput="ngModel"
                [(ngModel)]="user.lastName"
                id="lastName"
@@ -90,11 +90,11 @@
     </div>
 
     <div *ngIf="languages && languages.length > 0" class="form-group">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
+        <mat-label>{{'userManagement.langKey' | translate}}</mat-label>
         <mat-select [(ngModel)]="user.langKey"
                     id="langKey"
-                    name="langKey"
-                    placeholder="{{'userManagement.langKey' | translate}}">
+                    name="langKey">
           <mat-option *ngFor="let language of languages" [value]="language">
             {{language | findLanguageFromKey}}
           </mat-option>
@@ -103,13 +103,13 @@
     </div>
 
     <div class="form-group" *ngIf="userRoles !== undefined">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
+        <mat-label>{{'userManagement.role' | translate}}</mat-label>
         <mat-select id="authority"
                     [value]="userRoles"
                     [multiple]="isMultiRole"
                     (selectionChange)="roleSelect($event.value)"
-                    name="authority"
-                    placeholder="{{'userManagement.role' | translate}}">
+                    name="authority">
           <mat-option *ngFor="let authority of authorities" [value]="authority">
             {{authority}}
           </mat-option>

--- a/packages/administration/src/user-management/user-management.component.html
+++ b/packages/administration/src/user-management/user-management.component.html
@@ -25,7 +25,7 @@
       <form (ngSubmit)="searchByLogin()" action="" novalidate>
         <div class="d-flex flex-nowrap align-items-center">
           <div class="pr-1">
-            <mat-form-field>
+            <mat-form-field appearance="fill">
               <input
                 [(ngModel)]="login"
                 matInput

--- a/packages/components/array-control/array-control/xm-array-control.component.html
+++ b/packages/components/array-control/array-control/xm-array-control.component.html
@@ -1,4 +1,4 @@
-<mat-form-field>
+<mat-form-field appearance="fill">
   <mat-label>{{options.title | translate}}</mat-label>
   <mat-chip-list #chipList [disabled]="control.disabled" [attr.aria-label]="options.ariaLabel">
     <mat-chip

--- a/packages/components/bool/control/xm-bool-control.ts
+++ b/packages/components/bool/control/xm-bool-control.ts
@@ -14,10 +14,10 @@ import { Translate, XmTranslationModule } from '@xm-ngx/translation';
 @Component({
     selector: 'xm-bool-control',
     template: `
-        <mat-form-field>
+        <mat-form-field appearance="fill">
+            <mat-label>{{options?.title | translate}}</mat-label>
             <mat-select [formControl]="control"
                         [disabled]="disabled"
-                        [placeholder]="options?.title | translate"
                         (ngModelChange)="change($event)">
 
                 <mat-select-trigger>

--- a/packages/components/date/xm-date-control.ts
+++ b/packages/components/date/xm-date-control.ts
@@ -38,7 +38,7 @@ const DEFAULT_CONFIG: XmDateControlOptions = {
 @Component({
     selector: 'xm-date-control',
     template: `
-        <mat-form-field>
+        <mat-form-field appearance="fill">
             <mat-label>{{options?.title | translate}}</mat-label>
 
             <input matInput

--- a/packages/components/date/xm-date-range-control.ts
+++ b/packages/components/date/xm-date-range-control.ts
@@ -54,7 +54,7 @@ export const XM_DATE_RANGE_CONTROL_OPTIONS: XmDateRangeControlOptions = {
 @Component({
     selector: 'xm-date-range-control',
     template: `
-        <mat-form-field>
+        <mat-form-field appearance="fill">
             <mat-label>{{options?.title | translate}}</mat-label>
             <mat-date-range-input [formGroup]="group"
                                   [rangePicker]="picker">

--- a/packages/components/date/xm-date-range-filter-control.ts
+++ b/packages/components/date/xm-date-range-filter-control.ts
@@ -45,7 +45,7 @@ type DateValue = string[] | Date[];
 @Component({
     selector: 'xm-date-range-filter-control',
     template: `
-        <mat-form-field class="xm-custom-input-icon">
+        <mat-form-field appearance="fill" class="xm-custom-input-icon">
             <div class="to-display" *ngIf="value && value.length > 0">
                 <xm-date [value]="value[0]" [options]="options"></xm-date>
                 ~

--- a/packages/components/date/xm-datetime-control.ts
+++ b/packages/components/date/xm-datetime-control.ts
@@ -39,7 +39,7 @@ type XmDateTimeControlValue = moment.Moment | string;
 @Component({
     selector: 'xm-datetime-control',
     template: `
-        <mat-form-field>
+        <mat-form-field appearance="fill">
             <mat-label>{{options?.title | translate}}</mat-label>
 
             <input [formControl]="control"

--- a/packages/components/date/xm-string-date-control.ts
+++ b/packages/components/date/xm-string-date-control.ts
@@ -24,7 +24,7 @@ export interface XmStringDateControlOptions {
 @Component({
     selector: 'xm-string-date-control',
     template: `
-        <mat-form-field>
+        <mat-form-field appearance="fill">
             <mat-label>{{options?.title | translate}}</mat-label>
 
             <input (dateChange)="changeDateControl($event)"

--- a/packages/components/enum/control/xm-enum-control.component.ts
+++ b/packages/components/enum/control/xm-enum-control.component.ts
@@ -40,12 +40,12 @@ export const XM_ENUM_CONTROL_OPTIONS_DEFAULT: XmEnumControlOptions = {
 @Component({
     selector: 'xm-enum-control',
     template: `
-        <mat-form-field>
+        <mat-form-field appearance="fill">
+            <mat-label>{{options?.title | translate}}</mat-label>
             <mat-select [formControl]="control"
                         [required]="options.required"
                         [id]="options.id"
-                        [attr.data-qa]="options.dataQa"
-                        [placeholder]="options?.title | translate">
+                        [attr.data-qa]="options.dataQa">
                 <mat-select-trigger>
                     <ng-container *ngIf="itemsMap && itemsMap[value + '']">
                         <mat-icon

--- a/packages/components/enum/multiple-control/xm-multiple-enum-control.component.ts
+++ b/packages/components/enum/multiple-control/xm-multiple-enum-control.component.ts
@@ -26,12 +26,12 @@ export const XM_MULTIPLE_ENUM_CONTROL_OPTIONS_DEFAULT: XmMultipleEnumControlOpti
 @Component({
     selector: 'xm-multiple-enum-control',
     template: `
-        <mat-form-field>
+        <mat-form-field appearance="fill">
+            <mat-label>{{options?.title | translate}}</mat-label>
             <mat-select [formControl]="control"
                         [required]="options.required"
                         [id]="options.id"
                         [attr.data-qa]="options.dataQa"
-                        [placeholder]="options?.title | translate"
                         multiple>
                 <mat-select-trigger>
                     <ng-container *ngIf="itemsMap && itemsMap[value[0] + '']">

--- a/packages/components/file/file-control/file-control.component.ts
+++ b/packages/components/file/file-control/file-control.component.ts
@@ -35,7 +35,7 @@ const XM_FILE_CONTROL_OPTIONS_DEFAULT: XmFileControlOptions = {
 @Component({
     selector: 'xm-file-control',
     template: `
-        <mat-form-field>
+        <mat-form-field appearance="fill">
             <mat-label>{{options.title | translate}}</mat-label>
 
             <input #input

--- a/packages/components/multilanguage/xm-multi-language.component.ts
+++ b/packages/components/multilanguage/xm-multi-language.component.ts
@@ -80,7 +80,7 @@ export const MULTI_LANGUAGE_DEFAULT_OPTIONS: MultiLanguageOptions = {
             </ng-container>
 
             <ng-container *ngSwitchCase="'textarea'">
-                <mat-form-field>
+                <mat-form-field appearance="fill">
                     <textarea
                         matInput
                         type="text"
@@ -95,7 +95,7 @@ export const MULTI_LANGUAGE_DEFAULT_OPTIONS: MultiLanguageOptions = {
             </ng-container>
 
             <ng-container *ngSwitchDefault>
-                <mat-form-field>
+                <mat-form-field appearance="fill">
                     <input
                         matInput
                         type="text"

--- a/packages/components/number-control/xm-number-control.ts
+++ b/packages/components/number-control/xm-number-control.ts
@@ -45,7 +45,7 @@ const XM_NUMBER_CONTROL_DEFAULT_OPTIONS: XmNumberControlOptions = {
 @Component({
     selector: 'xm-number-control',
     template: `
-        <mat-form-field>
+        <mat-form-field appearance="fill">
             <mat-label>{{options.title | translate}}</mat-label>
 
             <input matInput

--- a/packages/components/per-page/xm-per-page.component.html
+++ b/packages/components/per-page/xm-per-page.component.html
@@ -1,6 +1,6 @@
 <div class="xm-per-page">
   <div class="pager-wrapper">
-    <mat-form-field>
+    <mat-form-field appearance="fill">
       <mat-select [(ngModel)]="itemsPerPage"
                   (selectionChange)="onChangeSelect()">
         <mat-option *ngFor="let item of sizes" [value]="item">

--- a/packages/components/phone-number-control/xm-phone-number-control.component.html
+++ b/packages/components/phone-number-control/xm-phone-number-control.component.html
@@ -1,4 +1,4 @@
-<mat-form-field>
+<mat-form-field appearance="fill">
 
   <mat-label>{{ options.title | translate}}</mat-label>
 

--- a/packages/components/text/email-control/xm-email-control.ts
+++ b/packages/components/text/email-control/xm-email-control.ts
@@ -5,7 +5,7 @@ import { XmEmailControlOptions } from './xm-email-control-options';
 @Component({
     selector: 'xm-email-control',
     template: `
-        <mat-form-field>
+        <mat-form-field appearance="fill">
             <mat-label>{{ options?.title | translate}}</mat-label>
 
             <input [formControl]="control"

--- a/packages/components/text/password-control/xm-password-control.ts
+++ b/packages/components/text/password-control/xm-password-control.ts
@@ -14,7 +14,7 @@ export const XM_PASSWORD_OPTIONS_DEFAULT: XmPasswordControlOptions = {
 @Component({
     selector: 'xm-password-control',
     template: `
-        <mat-form-field>
+        <mat-form-field appearance="fill">
             <mat-label>{{ options.title | translate}}</mat-label>
 
             <input [formControl]="control"

--- a/packages/components/text/text-control/xm-text-control.ts
+++ b/packages/components/text/text-control/xm-text-control.ts
@@ -47,7 +47,7 @@ const XM_TEXT_CONTROL_OPTIONS_DEFAULT: XmTextControlOptions = {
 @Component({
     selector: 'xm-text-control',
     template: `
-        <mat-form-field>
+        <mat-form-field appearance="fill">
             <mat-label>{{options.title | translate}}</mat-label>
 
             <input matInput

--- a/packages/components/text/text-range-control/xm-text-range-control.component.ts
+++ b/packages/components/text/text-range-control/xm-text-range-control.component.ts
@@ -35,7 +35,7 @@ const XM_TEXT_RANGE_CONTROL_OPTIONS_DEFAULT: XmTextRangeControlOptions = {
 @Component({
     selector: 'xm-text-range-control',
     template: `
-        <mat-form-field>
+        <mat-form-field appearance="fill">
             <mat-label>{{options.title | translate}}</mat-label>
 
             <textarea [placeholder]="options.placeholder | translate"

--- a/src/app/account/password-reset/finish/password-reset-finish.component.html
+++ b/src/app/account/password-reset/finish/password-reset-finish.component.html
@@ -46,7 +46,7 @@
         <div *ngIf="!keyMissing && !keyExpired && !keyUsed">
           <form *ngIf="!success" name="form" role="form" (ngSubmit)="finishReset()" #passwordForm="ngForm">
             <div class="form-group">
-              <mat-form-field>
+              <mat-form-field appearance="fill">
                 <input matInput
                        type="password"
                        name="password"
@@ -79,7 +79,7 @@
             </div>
 
             <div class="form-group">
-              <mat-form-field>
+              <mat-form-field appearance="fill">
                 <input matInput
                        type="password"
                        name="confirmPassword"

--- a/src/app/account/password-reset/init/password-reset-init.component.html
+++ b/src/app/account/password-reset/init/password-reset-init.component.html
@@ -20,7 +20,7 @@
 
         <form *ngIf="!success" name="form" role="form" (ngSubmit)="requestReset()" #resetRequestForm="ngForm">
           <div class="form-group">
-            <mat-form-field>
+            <mat-form-field appearance="fill">
               <input matInput
                      type="email"
                      name="email"

--- a/src/app/account/password/password.component.html
+++ b/src/app/account/password/password.component.html
@@ -15,7 +15,7 @@
 
     <form #passwordForm="ngForm" (ngSubmit)="changePassword()" name="form" role="form">
       <div class="form-group">
-        <mat-form-field [floatLabel]="'always'">
+        <mat-form-field appearance="fill" [floatLabel]="'always'">
           <input #oldPasswordInput="ngModel"
                  [(ngModel)]="password.oldPassword"
                  [placeholder]="'global.form.oldpassword' | translate"
@@ -39,7 +39,7 @@
       </div>
 
       <div class="form-group">
-        <mat-form-field [floatLabel]="'always'">
+        <mat-form-field appearance="fill" [floatLabel]="'always'">
           <input #passwordInput="ngModel"
                  [(ngModel)]="password.newPassword"
                  [maxlength]="passwordSettings?.maxLength"
@@ -80,7 +80,7 @@
         <xm-password-strength-bar [passwordToCheck]="password.newPassword"></xm-password-strength-bar>
       </div>
       <div class="form-group">
-        <mat-form-field [floatLabel]="'always'">
+        <mat-form-field appearance="fill" [floatLabel]="'always'">
           <input #confirmPasswordInput="ngModel"
                  [(ngModel)]="password.confirmNewPassword"
                  [maxlength]="passwordSettings?.maxLength"

--- a/src/app/ext-commons/ext-common-entity/customer-info-widget/customer-info-widget.component.html
+++ b/src/app/ext-commons/ext-common-entity/customer-info-widget/customer-info-widget.component.html
@@ -15,7 +15,7 @@
       <div class="row">
         <div class="form-group col-md-4">
           <label class="mb-0" for="firstName">{{'global.form.firstname'|translate}}</label>
-          <mat-form-field>
+          <mat-form-field appearance="fill">
             <input formControlName="firstName"
                    id="firstName"
                    matInput
@@ -28,7 +28,7 @@
         </div>
         <div class="form-group col-md-4">
           <label class="mb-0" for="lastName">{{'global.form.lastname'|translate}}</label>
-          <mat-form-field>
+          <mat-form-field appearance="fill">
             <input formControlName="lastName"
                    id="lastName"
                    matInput
@@ -43,7 +43,7 @@
       <div class="row">
         <div class="form-group col-md-4">
           <label class="mb-0" for="countryCode">{{'nemondo.countryCode'|translate}}</label>
-          <mat-form-field>
+          <mat-form-field appearance="fill">
             <mat-select formControlName="countryCode"
                         id="countryCode"
                         required>
@@ -59,7 +59,7 @@
         </div>
         <div class="form-group col-md-4">
           <label class="mb-0" for="locality">{{'nemondo.locality'|translate}}</label>
-          <mat-form-field>
+          <mat-form-field appearance="fill">
             <input formControlName="locality"
                    id="locality"
                    matInput
@@ -72,7 +72,7 @@
         </div>
         <div class="form-group col-md-2">
           <label class="mb-0" for="zip">{{'nemondo.zip'|translate}}</label>
-          <mat-form-field>
+          <mat-form-field appearance="fill">
             <input formControlName="zip"
                    id="zip"
                    matInput
@@ -88,7 +88,7 @@
         <div class="col-md-8">
           <div class="form-group">
             <label for="address1">{{'nemondo.address1'|translate}}</label>
-            <mat-form-field>
+            <mat-form-field appearance="fill">
               <input formControlName="address1"
                      id="address1"
                      matInput
@@ -101,7 +101,7 @@
           </div>
           <div class="form-group">
             <label for="address2">{{'nemondo.address2'|translate}}</label>
-            <mat-form-field>
+            <mat-form-field appearance="fill">
               <input formControlName="address2"
                      id="address2"
                      matInput
@@ -112,7 +112,7 @@
         <div class="col-md-4">
           <div class="form-group">
             <label for="phone">{{'nemondo.phone'|translate}}</label>
-            <mat-form-field>
+            <mat-form-field appearance="fill">
               <input formControlName="phone"
                      id="phone"
                      matInput
@@ -124,7 +124,7 @@
           </div>
           <div *ngIf="showCurrencies" class="form-group">
             <label for="localCurrency">{{'nemondo.localCurrency'|translate}}</label>
-            <mat-form-field>
+            <mat-form-field appearance="fill">
               <mat-select formControlName="localCurrency"
                           id="localCurrency"
                           required>

--- a/src/app/shared/jsf-extention/widgets/content-textarea/content-textarea.component.html
+++ b/src/app/shared/jsf-extention/widgets/content-textarea/content-textarea.component.html
@@ -1,4 +1,4 @@
-<mat-form-field>
+<mat-form-field appearance="fill">
   <mat-label>{{options.title}}</mat-label>
   <div class="content-textarea-wrap">
     <div

--- a/src/app/shared/jsf-extention/widgets/datetime-utc/datetime-utc.component.html
+++ b/src/app/shared/jsf-extention/widgets/datetime-utc/datetime-utc.component.html
@@ -1,4 +1,4 @@
-<mat-form-field>
+<mat-form-field appearance="fill">
   <input matInput
          [name]="controlName"
          type="datetime-local"

--- a/src/app/shared/jsf-extention/widgets/ext-autocomplete/ext-autocomplete.component.html
+++ b/src/app/shared/jsf-extention/widgets/ext-autocomplete/ext-autocomplete.component.html
@@ -1,5 +1,5 @@
 <div class="xm-form-autocomplete" [ngClass]="options?.htmlClass || ''">
-  <mat-form-field>
+  <mat-form-field appearance="fill">
     <input matInput
            type="text"
            #emailRef

--- a/src/app/shared/jsf-extention/widgets/ext-multi-select/ext-multi-select.component.html
+++ b/src/app/shared/jsf-extention/widgets/ext-multi-select/ext-multi-select.component.html
@@ -1,7 +1,7 @@
 <div [class]="options?.htmlClass || ''">
-  <mat-form-field>
+  <mat-form-field appearance="fill">
+    <mat-label>{{options['title'] ? options['title'] : ''}}</mat-label>
     <mat-select [multiple]="true"
-      [placeholder]="options['title'] ? options['title'] : ''"
       [(ngModel)]="elementMultiCtrl"
       (selectionChange)="updateValue($event)"
       [disabled]="options['readonly']"

--- a/src/app/shared/jsf-extention/widgets/ext-query-select/ext-query-select.component.html
+++ b/src/app/shared/jsf-extention/widgets/ext-query-select/ext-query-select.component.html
@@ -1,4 +1,4 @@
-<mat-form-field>
+<mat-form-field appearance="fill">
   <mat-select
     [formControl]="checkedOption"
     [placeholder]="settings.title ? settings.title : ''"

--- a/src/app/shared/jsf-extention/widgets/ext-select/ext-select.component.html
+++ b/src/app/shared/jsf-extention/widgets/ext-select/ext-select.component.html
@@ -1,5 +1,5 @@
 <div [class]="options?.htmlClass || ''">
-  <mat-form-field>
+  <mat-form-field appearance="fill">
     <mat-icon class="deep-link"
       [style.color]="selectLinkOptions?.iconColor"
       [class.disabled]="!(elementCtrl && elementCtrl['object'] && elementCtrl['object'].id)"
@@ -9,9 +9,9 @@
     >
       {{this.selectLinkOptions?.iconName}}
     </mat-icon>
+    <mat-label>{{options.noTitle ? '' : (placeholder | async)}}</mat-label>
     <mat-select [(ngModel)]="elementCtrl"
       (selectionChange)="updateValue($event)"
-      [placeholder]="options.noTitle ? '' : (placeholder | async)"
       [disabled]="(disabled$ | async) || options['readonly']"
       [required]="options?.required"
       #singleSelect

--- a/src/app/shared/jsf-extention/widgets/ext-textarea/ext-textarea.component.html
+++ b/src/app/shared/jsf-extention/widgets/ext-textarea/ext-textarea.component.html
@@ -1,4 +1,4 @@
-<mat-form-field>
+<mat-form-field appearance="fill">
   <textarea matInput
             [style.height]="options.height"
 

--- a/src/app/shared/jsf-extention/widgets/link-field/link-field.component.html
+++ b/src/app/shared/jsf-extention/widgets/link-field/link-field.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="modeEdit">
-  <mat-form-field class="xm-link-field">
+  <mat-form-field appearance="fill" class="xm-link-field">
     <mat-label>{{options.title}}</mat-label>
     <input matInput
            class="abs"

--- a/src/app/shared/jsf-extention/widgets/multilingual-input-v2/multilingual-input-v2.component.html
+++ b/src/app/shared/jsf-extention/widgets/multilingual-input-v2/multilingual-input-v2.component.html
@@ -21,7 +21,7 @@
     </ng-container>
 
     <ng-container *ngSwitchCase="'textarea'">
-        <mat-form-field>
+        <mat-form-field appearance="fill">
                     <textarea matInput
                               type="text"
                               [(ngModel)]="text"
@@ -30,7 +30,7 @@
     </ng-container>
 
     <ng-container *ngSwitchDefault>
-        <mat-form-field>
+        <mat-form-field appearance="fill">
             <input matInput
                    type="text"
                    [(ngModel)]="text"

--- a/src/app/shared/jsf-extention/widgets/multilingual-input/multilingual-input.component.html
+++ b/src/app/shared/jsf-extention/widgets/multilingual-input/multilingual-input.component.html
@@ -14,7 +14,7 @@
   </button>
 </div>
 
-<mat-form-field *ngIf="currentLanguage">
+<mat-form-field appearance="fill" *ngIf="currentLanguage">
   <input matInput
          type="text"
          [(ngModel)]="text"

--- a/src/app/shared/login/login.component.html
+++ b/src/app/shared/login/login.component.html
@@ -11,7 +11,7 @@
 
 <form class="form" role="form" (ngSubmit)="login()" *ngIf="!checkOTP" autocomplete="off">
   <div class="form-group" id="userNameContainer">
-    <mat-form-field [floatLabel]="floatLabel ? 'always' : 'auto'">
+    <mat-form-field appearance="fill" [floatLabel]="floatLabel ? 'always' : 'auto'">
       <input matInput
              type="text"
              name="username"
@@ -25,7 +25,7 @@
   </div>
 
   <div class="form-group" id="userPasswordContainer">
-    <mat-form-field [floatLabel]="floatLabel ? 'always' : 'auto'">
+    <mat-form-field appearance="fill" [floatLabel]="floatLabel ? 'always' : 'auto'">
       <input matInput
              [type]="isShowPassword ? 'text' : 'password'"
              name="password"
@@ -80,7 +80,7 @@
 
 <form class="form" role="form" (ngSubmit)="checkOtp()" *ngIf="checkOTP">
   <div class="form-group">
-    <mat-form-field>
+    <mat-form-field appearance="fill">
       <input matInput
              type="text"
              name="otp"

--- a/src/app/shared/register/register.component.html
+++ b/src/app/shared/register/register.component.html
@@ -24,7 +24,7 @@
 <!--Body-->
 <form name="form" role="form" (ngSubmit)="register()" #registerForm="ngForm">
   <div class="form-group">
-    <mat-form-field>
+    <mat-form-field appearance="fill">
       <input matInput
              type="email"
              name="email"
@@ -57,7 +57,7 @@
   </div>
 
   <div class="form-group">
-    <mat-form-field>
+    <mat-form-field appearance="fill">
       <input matInput
              type="text"
              name="firstName"
@@ -87,7 +87,7 @@
   </div>
 
   <div class="form-group">
-    <mat-form-field>
+    <mat-form-field appearance="fill">
       <input matInput
              type="text"
              name="lastName"
@@ -117,7 +117,7 @@
   </div>
 
   <div class="form-group">
-    <mat-form-field>
+    <mat-form-field appearance="fill">
       <input matInput
              type="password"
              name="password"
@@ -150,7 +150,7 @@
   </div>
 
   <div class="form-group">
-    <mat-form-field>
+    <mat-form-field appearance="fill">
       <input matInput
              type="password"
              name="confirmPassword"

--- a/src/app/xm-entity/attachment-detail-dialog/attachment-detail-dialog.component.html
+++ b/src/app/xm-entity/attachment-detail-dialog/attachment-detail-dialog.component.html
@@ -11,12 +11,12 @@
     <xm-loader [showLoader]="showLoader"></xm-loader>
 
     <div class="form-group">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
+        <mat-label>{{'xm-entity.attachment-detail-dialog.choose-type' | translate}}</mat-label>
         <mat-select #attachmentType="ngModel"
                     [(ngModel)]="attachment.typeKey"
                     [disabled]="attachmentSpecs?.length == 1"
                     name="typeKey"
-                    placeholder="{{'xm-entity.attachment-detail-dialog.choose-type' | translate}}"
                     required>
           <mat-option *ngFor="let attachmentSpec of attachmentSpecs"
                       [value]="attachmentSpec.key">
@@ -30,7 +30,7 @@
     </div>
 
     <div #nameCtrl class="form-group">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <input #attachmentName="ngModel"
                [(ngModel)]="attachment.name"
                [disabled]="readOnlyInputs"
@@ -47,7 +47,7 @@
     </div>
 
     <div class="form-group label-floating">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <textarea [(ngModel)]="attachment.description"
                   id="field_description"
                   matInput

--- a/src/app/xm-entity/calendar-event-dialog/calendar-event-dialog.component.html
+++ b/src/app/xm-entity/calendar-event-dialog/calendar-event-dialog.component.html
@@ -17,11 +17,11 @@
     <xm-loader [showLoader]="showLoader"></xm-loader>
 
     <div class="form-group">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
+        <mat-label>{{'xm-entity.calendar-event-dialog.choose-type' | translate}}</mat-label>
         <mat-select #eventType="ngModel"
                     [(ngModel)]="event.typeKey"
                     name="typeKey"
-                    placeholder="{{'xm-entity.calendar-event-dialog.choose-type' | translate}}"
                     required>
           <mat-option *ngFor="let eventSpec of calendarSpec.events"
                       [value]="eventSpec.key">
@@ -37,7 +37,7 @@
     <div class="row">
       <div class="col-md-6">
         <div class="form-group">
-          <mat-form-field class="xm-datetime-picker">
+          <mat-form-field appearance="fill" class="xm-datetime-picker">
             <input #eventStartDate="ngModel"
                    [owlDateTimeTrigger]="dtStartDate"
                    [owlDateTime]="dtStartDate"
@@ -69,7 +69,7 @@
       </div>
       <div class="col-md-6">
         <div class="form-group">
-          <mat-form-field>
+          <mat-form-field appearance="fill">
             <input #eventEndDate="ngModel"
                    [owlDateTimeTrigger]="dtEndDate"
                    [owlDateTime]="dtEndDate"
@@ -102,7 +102,7 @@
     </div>
 
     <div class="form-group">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <input #eventTitle="ngModel"
                [(ngModel)]="event.title"
                id="field_title"
@@ -118,7 +118,7 @@
     </div>
 
     <div class="form-group">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <textarea [(ngModel)]="event.description"
                   id="field_description"
                   matInput

--- a/src/app/xm-entity/comment-detail-dialog/comment-detail-dialog.component.html
+++ b/src/app/xm-entity/comment-detail-dialog/comment-detail-dialog.component.html
@@ -9,12 +9,12 @@
   <div mat-dialog-content>
     <xm-loader [showLoader]="showLoader"></xm-loader>
     <div [hidden]="!(commentSpecs?.length > 1)" class="form-group">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
+        <mat-label>{{'xm-entity.comment-detail-dialog.choose-type' | translate}}</mat-label>
         <mat-select [(ngModel)]="comment.typeKey"
                     [disabled]="commentSpecs?.length == 1"
                     id="field_typeKey"
-                    name="typeKey"
-                    placeholder="{{'xm-entity.comment-detail-dialog.choose-type' | translate}}">
+                    name="typeKey">
           <mat-option *ngFor="let commentSpec of commentSpecs" [value]="commentSpec.key">
             {{commentSpec.name | translate | uppercase}}
           </mat-option>
@@ -23,7 +23,7 @@
     </div>
 
     <div class="form-group">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <textarea #commentBody="ngModel"
                   [(ngModel)]="comment.message"
                   matInput

--- a/src/app/xm-entity/entity-detail-dialog/entity-detail-dialog.component.html
+++ b/src/app/xm-entity/entity-detail-dialog/entity-detail-dialog.component.html
@@ -31,13 +31,13 @@
     </div>
 
     <div *ngIf="!isEdit" [hidden]="!(availableSpecs?.length > 1)" class="form-group">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
+        <mat-label>{{'xm-entity.entity-detail-dialog.add.choose-type' | translate}}</mat-label>
         <mat-select #entityType="ngModel"
                     (selectionChange)="onChangeEntityType(null, xmEntity.typeKey)"
                     [(ngModel)]="xmEntity.typeKey"
                     id="field_typeKey"
                     name="typeKey"
-                    placeholder="{{'xm-entity.entity-detail-dialog.add.choose-type' | translate}}"
                     required>
           <mat-option *ngFor="let spec of availableSpecs"
                       [value]="spec.key">
@@ -51,7 +51,7 @@
     </div>
 
     <div *ngIf="!jsfAttributes?.entity?.hideNameAndDescription" class="form-group">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <input #entityName="ngModel"
                [(ngModel)]="xmEntity.name"
                [pattern]="nameValidPattern"
@@ -72,7 +72,7 @@
     </div>
 
     <div *ngIf="jsfAttributes?.entity?.showKey" class="form-group">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <input #entityName="ngModel"
                [(ngModel)]="xmEntity.key"
                id="field_key"
@@ -88,7 +88,7 @@
     </div>
 
     <div *ngIf="!jsfAttributes?.entity?.hideNameAndDescription" class="form-group">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <textarea (keyup)="smartDescription.active = false;"
                   [(ngModel)]="smartDescription.value"
                   matInput

--- a/src/app/xm-entity/functions/area/osm-polygon-dialog.component.html
+++ b/src/app/xm-entity/functions/area/osm-polygon-dialog.component.html
@@ -7,7 +7,7 @@
   <div class="row">
     <div class="col">
       <div class="form-group">
-        <mat-form-field>
+        <mat-form-field appearance="fill">
           <input #searchString
                  (change)="search(searchString.value)"
                  matInput

--- a/src/app/xm-entity/link-detail-dialog/link-detail-new-section.component.html
+++ b/src/app/xm-entity/link-detail-dialog/link-detail-new-section.component.html
@@ -10,13 +10,13 @@
     </div>
 
     <div *ngIf="!isEdit" [hidden]="!(availableSpecs?.length > 1)" class="form-group">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
+        <mat-label>{{'xm-entity.entity-detail-dialog.add.choose-type' | translate}}</mat-label>
         <mat-select #entityType="ngModel"
                     (selectionChange)="onChangeEntityType(xmEntity.typeKey)"
                     [(ngModel)]="xmEntity.typeKey"
                     id="field_typeKey"
                     name="typeKey"
-                    placeholder="{{'xm-entity.entity-detail-dialog.add.choose-type' | translate}}"
                     required>
           <mat-option *ngFor="let spec of availableSpecs"
                       [value]="spec.key">
@@ -30,7 +30,7 @@
     </div>
 
     <div *ngIf="!jsfAttributes?.entity?.hideNameAndDescription" class="form-group">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <input #entityName="ngModel"
                [(ngModel)]="xmEntity.name"
                id="field_name"
@@ -46,7 +46,7 @@
     </div>
 
     <div *ngIf="!jsfAttributes?.entity?.hideNameAndDescription" class="form-group">
-      <mat-form-field>
+      <mat-form-field appearance="fill">
         <textarea [(ngModel)]="xmEntity.description"
                   matInput
                   name="description"

--- a/src/app/xm-entity/link-detail-dialog/link-detail-search-section.component.html
+++ b/src/app/xm-entity/link-detail-dialog/link-detail-search-section.component.html
@@ -2,7 +2,7 @@
   <xm-loader [showLoader]="showLoader"></xm-loader>
 
   <div class="form-group">
-    <mat-form-field>
+    <mat-form-field appearance="fill">
       <input #searchField
              matInput
              placeholder="{{'xm-entity.link-detail-dialog.add.build-type-search' | translate}}"

--- a/src/app/xm-entity/location-detail-dialog/location-detail-dialog.component.html
+++ b/src/app/xm-entity/location-detail-dialog/location-detail-dialog.component.html
@@ -25,7 +25,7 @@
 
       <div class="row">
         <div class="col-md-6">
-          <mat-form-field>
+          <mat-form-field appearance="fill">
             <mat-select
               required
               formControlName="typeKey"
@@ -41,7 +41,7 @@
           </mat-form-field>
         </div>
         <div class="col-md-6">
-          <mat-form-field>
+          <mat-form-field appearance="fill">
             <input
               formControlName="name"
               matInput
@@ -58,7 +58,7 @@
 
       <div class="row">
         <div class="col-md-6">
-          <mat-form-field>
+          <mat-form-field appearance="fill">
             <mat-select
               required
               formControlName="countryKey"
@@ -81,7 +81,7 @@
           </mat-form-field>
         </div>
         <div class="col-md-6">
-          <mat-form-field>
+          <mat-form-field appearance="fill">
             <input
               formControlName="zip"
               matInput
@@ -94,7 +94,7 @@
 
       <div class="row">
         <div class="col-md-6">
-          <mat-form-field>
+          <mat-form-field appearance="fill">
             <input
               formControlName="region"
               matInput
@@ -104,7 +104,7 @@
           </mat-form-field>
         </div>
         <div class="col-md-6">
-          <mat-form-field>
+          <mat-form-field appearance="fill">
             <input
               formControlName="city"
               matInput
@@ -117,7 +117,7 @@
 
       <div class="row">
         <div class="col-md-6">
-          <mat-form-field>
+          <mat-form-field appearance="fill">
             <input
               formControlName="addressLine1"
               matInput
@@ -127,7 +127,7 @@
           </mat-form-field>
         </div>
         <div class="col-md-6">
-          <mat-form-field>
+          <mat-form-field appearance="fill">
             <input
               formControlName="addressLine2"
               matInput
@@ -140,7 +140,7 @@
 
       <div class="row">
         <div class="col-md">
-          <mat-form-field>
+          <mat-form-field appearance="fill">
             <input
               formControlName="latitude"
               matInput
@@ -157,7 +157,7 @@
           </mat-form-field>
         </div>
         <div class="col-md">
-          <mat-form-field>
+          <mat-form-field appearance="fill">
             <input
               formControlName="longitude"
               matInput

--- a/src/app/xm-entity/states-management-dialog/states-management-dialog.component.html
+++ b/src/app/xm-entity/states-management-dialog/states-management-dialog.component.html
@@ -13,7 +13,7 @@
     <ng-template #resultData>
       <div class="states-management">
         <div class="states-management__filter">
-          <mat-form-field>
+          <mat-form-field appearance="fill">
             <mat-select
               (selectionChange)="onSaveSelectedSpecKey($event.value)"
               [(ngModel)]="selectedSpec"


### PR DESCRIPTION
Improve text fields and selects view based on the material design best practices.

1. Based on the material design documentation (https://material.io/components/text-fields) there are only two types for style for text fields:
- Filled text fields
- Outlined text fields
Angular material has appearance attribute to use one of the style and w/o attribute used back compatibility and it is incorrect style.
So, I propose by this pull request use one style Filled for all input fields. 

2. Based on the angular material documentation (https://material.angular.io/components/form-field/overview) label should be used and placeholder will move it.
So, I moved all placeholders texts into label. Placeholder could be used additionally if needed.

Please, pay attention and improve style of input fields in your extensions too for better user experience and compline with material design best practices.
