### PR TITLE
refactor(cli): remove ext- prefix

### DIFF
--- a/packages/cli/src/ext-lazy-module-command.ts
+++ b/packages/cli/src/ext-lazy-module-command.ts
@@ -47,8 +47,6 @@ export class ExtLazyModuleCommand implements Command {
             const template = this.template(selector, path, className);
             modules.push(template);
             console.info(`Update xm.module.ts selector: "${selector}", lazyModules: "${path}"`);
-            /** Backward compatibility: ext- will be removed in the next release. */
-            modules.push(this.template('ext-' + selector, path, className));
         });
         return modules.join('');
     }


### PR DESCRIPTION
BREAKING_CHANGES
all selectors starts with `ext-*` should be renamed to module name

Signed-off-by: Yevhenii Kamenskyi <yevhenii.kamenskyi@gmail.com>