### PR TITLE
Get rid of widget 'options'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "4.0.98",
+  "version": "4.0.99",
   "release": "4.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/packages/administration/src/admin.service.ts
+++ b/packages/administration/src/admin.service.ts
@@ -18,7 +18,7 @@ import { NotImplementedException } from '@xm-ngx/shared/exceptions';
 @Directive()
 export class BaseAdminListComponent implements OnInit, OnDestroy {
 
-    public config: {
+    private actualConfig: {
         pageSizeOptions: number[],
         pageSize: number,
         sortDirection: 'asc' | 'desc',
@@ -32,6 +32,24 @@ export class BaseAdminListComponent implements OnInit, OnDestroy {
             sortBy: 'id',
             navigateUrl: [],
         };
+
+
+    public set config(value: any) {
+        this.actualConfig = {
+            ...{
+                pageSizeOptions: TABLE_CONFIG_DEFAULT.pageSizeOptions,
+                pageSize: TABLE_CONFIG_DEFAULT.pageSize,
+                sortDirection: 'desc',
+                sortBy: 'id',
+                navigateUrl: [],
+            },
+            ...value,
+        };
+    }
+    public get config(): any {
+        return this.actualConfig;
+    }
+
     public links: Link[];
     public totalItems: number;
     public queryCount: number;
@@ -118,7 +136,7 @@ export class BaseAdminListComponent implements OnInit, OnDestroy {
         return uniqueData;
     }
 
-    public onError(error: {error: string, message: any}): void {
+    public onError(error: { error: string, message: any }): void {
         this.toasterService.error(error.error, error.message, null);
     }
 

--- a/packages/administration/src/admin.service.ts
+++ b/packages/administration/src/admin.service.ts
@@ -5,6 +5,7 @@ import { XmAlertService } from '@xm-ngx/alert';
 import { QueryParamsPageable } from '@xm-ngx/components/entity-collection';
 
 import { TABLE_CONFIG_DEFAULT } from '@xm-ngx/components/table';
+import { XmTableColumn } from '@xm-ngx/components/table/columns/xm-table-column-dynamic-cell.component';
 import { XmEventManager } from '@xm-ngx/core';
 import { Link } from '@xm-ngx/entity';
 import { XmToasterService } from '@xm-ngx/toaster';
@@ -17,12 +18,13 @@ import { NotImplementedException } from '@xm-ngx/shared/exceptions';
 @Directive()
 export class BaseAdminListComponent implements OnInit, OnDestroy {
 
-    public options: {
+    public config: {
         pageSizeOptions: number[],
         pageSize: number,
         sortDirection: 'asc' | 'desc',
         sortBy: string,
         navigateUrl: string[];
+        columns?: XmTableColumn[]
     } = {
             pageSizeOptions: TABLE_CONFIG_DEFAULT.pageSizeOptions,
             pageSize: TABLE_CONFIG_DEFAULT.pageSize,
@@ -38,9 +40,9 @@ export class BaseAdminListComponent implements OnInit, OnDestroy {
     public showLoader: boolean;
     public pagination: QueryParamsPageable = {
         pageIndex: 0,
-        pageSize: this.options.pageSize,
-        sortBy: this.options.sortBy,
-        sortDirection: this.options.sortDirection,
+        pageSize: this.config.pageSize,
+        sortBy: this.config.sortBy,
+        sortDirection: this.config.sortDirection,
     };
     private previousPage: number;
     private subscription: Subscription;
@@ -55,10 +57,10 @@ export class BaseAdminListComponent implements OnInit, OnDestroy {
         protected router: Router,
     ) {
         this.subscription = this.activatedRoute.queryParams.subscribe((data: QueryParamsPageable) => {
-            this.pagination.pageSize = data.pageSize || this.options.pageSize;
+            this.pagination.pageSize = data.pageSize || this.config.pageSize;
             this.pagination.pageIndex = data.pageIndex || 0;
-            this.pagination.sortOrder = data.sortOrder || this.options.sortDirection;
-            this.pagination.sortBy = data.sortBy || this.options.sortBy;
+            this.pagination.sortOrder = data.sortOrder || this.config.sortDirection;
+            this.pagination.sortBy = data.sortBy || this.config.sortBy;
         });
     }
 
@@ -81,8 +83,8 @@ export class BaseAdminListComponent implements OnInit, OnDestroy {
     }
 
     public sort(): string[] {
-        const result = [this.options.sortBy + ',' + this.options.sortDirection];
-        if (this.options.sortBy !== this.basePredicate) {
+        const result = [this.config.sortBy + ',' + this.config.sortDirection];
+        if (this.config.sortBy !== this.basePredicate) {
             result.push(this.basePredicate);
         }
         return result;
@@ -121,7 +123,7 @@ export class BaseAdminListComponent implements OnInit, OnDestroy {
     }
 
     protected updateRoute(): void {
-        this.router.navigate(this.options.navigateUrl, {
+        this.router.navigate(this.config.navigateUrl, {
             queryParams: {
                 pageSize: this.pagination.pageSize,
                 pageIndex: this.pagination.pageIndex,
@@ -147,8 +149,8 @@ export class BaseAdminListComponent implements OnInit, OnDestroy {
     protected getPageAfterRemove(result: any): number {
         if (result && result.content && result.content.id === 'delete' && this.pagination.pageIndex > 1) {
             this.queryCount--;
-            const length = parseInt((this.queryCount / this.options.pageSize) + '', 10)
-                + (this.queryCount % this.options.pageSize ? 1 : 0);
+            const length = parseInt((this.queryCount / this.config.pageSize) + '', 10)
+                + (this.queryCount % this.config.pageSize ? 1 : 0);
             if (this.pagination.pageIndex > length) {
                 this.previousPage = null;
                 return length;

--- a/packages/administration/src/client-management/client-management.component.html
+++ b/packages/administration/src/client-management/client-management.component.html
@@ -38,8 +38,8 @@
 
     <div class="table-responsive">
       <table [dataSource]="dataSource"
-             [matSortActive]="options.sortBy"
-             [matSortDirection]="options.sortDirection"
+             [matSortActive]="config.sortBy"
+             [matSortDirection]="config.sortDirection"
              class="w-100 table-striped"
              mat-table
              matSort>
@@ -115,7 +115,7 @@
       <no-data [show]="!(dataSource?.data.length > 0) && !showLoader"></no-data>
 
       <mat-paginator [length]="totalItems"
-                     [pageSizeOptions]="options.pageSizeOptions"
+                     [pageSizeOptions]="config.pageSizeOptions"
                      [pageSize]="this.pagination.pageSize"
                      [pageIndex]="this.pagination.pageIndex">
       </mat-paginator>

--- a/packages/administration/src/client-management/client-management.component.ts
+++ b/packages/administration/src/client-management/client-management.component.ts
@@ -1,19 +1,17 @@
-import { Component, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
 import { ActivatedRoute, Router } from '@angular/router';
 import { XmAlertService } from '@xm-ngx/alert';
-import { XmTableColumn } from '@xm-ngx/components/table/columns/xm-table-column-dynamic-cell.component';
 import { XmEventManager } from '@xm-ngx/core';
+import { Client, ClientService } from '@xm-ngx/core/client';
 import { takeUntilOnDestroy, takeUntilOnDestroyDestroy } from '@xm-ngx/shared/operators';
 import { XmToasterService } from '@xm-ngx/toaster';
 import { JhiParseLinks } from 'ng-jhipster';
 import { merge, Observable, Subscription } from 'rxjs';
 import { finalize, map, startWith, switchMap } from 'rxjs/operators';
-
-import { Client, ClientService } from '@xm-ngx/core/client';
 import { BaseAdminListComponent } from '../admin.service';
 import { ClientMgmtDeleteDialogComponent } from './client-management-delete-dialog.component';
 import { ClientMgmtDialogComponent } from './client-management-dialog.component';
@@ -44,7 +42,6 @@ export class ClientMgmtComponent extends BaseAdminListComponent implements OnIni
         'actions',
     ];
     private eventSubscriber: Subscription;
-    @Input() public config: { columns: XmTableColumn[] };
 
     constructor(
         protected clientService: ClientService,
@@ -176,7 +173,7 @@ export class ClientMgmtComponent extends BaseAdminListComponent implements OnIni
     }
 
     protected updateRoute(): void {
-        this.router.navigate(this.options.navigateUrl, {
+        this.router.navigate(this.config.navigateUrl, {
             queryParams: {
                 pageSize: this.pagination.pageSize,
                 pageIndex: this.pagination.pageIndex,

--- a/packages/administration/src/roles-management/roles-management.component.html
+++ b/packages/administration/src/roles-management/roles-management.component.html
@@ -8,8 +8,8 @@
 
     <div class="table-responsive">
       <table [dataSource]="dataSource"
-             [matSortActive]="options.sortBy"
-             [matSortDirection]="options.sortDirection"
+             [matSortActive]="config.sortBy"
+             [matSortDirection]="config.sortDirection"
              class="w-100 table-striped"
              mat-table
              matSort>
@@ -75,7 +75,7 @@
         <tr *matRowDef="let row; columns: displayedColumns;" mat-row></tr>
       </table>
 
-      <mat-paginator [pageSizeOptions]="options.pageSizeOptions"
+      <mat-paginator [pageSizeOptions]="config.pageSizeOptions"
                      [pageSize]="this.pagination.pageSize"
                      [length]="this.pagination.total"
                      [pageIndex]="this.pagination.pageIndex">

--- a/packages/administration/src/roles-management/roles-management.component.ts
+++ b/packages/administration/src/roles-management/roles-management.component.ts
@@ -30,7 +30,7 @@ import { RoleMgmtDialogComponent } from './roles-management-dialog.component';
 })
 export class RolesMgmtComponent implements OnInit, OnDestroy {
 
-    public options: {
+    public config: {
         pageSizeOptions: number[],
         pageSize: number,
         sortDirection: 'asc' | 'desc',
@@ -45,9 +45,9 @@ export class RolesMgmtComponent implements OnInit, OnDestroy {
     public pagination: QueryParamsPageable = {
         total: 0,
         pageIndex: 0,
-        pageSize: this.options.pageSize,
-        sortBy: this.options.sortBy,
-        sortDirection: this.options.sortDirection,
+        pageSize: this.config.pageSize,
+        sortBy: this.config.sortBy,
+        sortDirection: this.config.sortDirection,
     };
 
     public showLoader: boolean;
@@ -77,10 +77,10 @@ export class RolesMgmtComponent implements OnInit, OnDestroy {
     ) {
         this.registerChangeInRoles();
         const data: QueryParamsPageable = this.activatedRoute.snapshot.queryParams;
-        this.pagination.pageSize = data.pageSize || this.options.pageSize;
+        this.pagination.pageSize = data.pageSize || this.config.pageSize;
         this.pagination.pageIndex = data.pageIndex || 0;
-        this.pagination.sortOrder = data.sortOrder || this.options.sortDirection;
-        this.pagination.sortBy = data.sortBy || this.options.sortBy;
+        this.pagination.sortOrder = data.sortOrder || this.config.sortDirection;
+        this.pagination.sortBy = data.sortBy || this.config.sortBy;
     }
 
     public ngOnInit(): void {

--- a/packages/administration/src/roles-matrix/roles-matrix.component.html
+++ b/packages/administration/src/roles-matrix/roles-matrix.component.html
@@ -73,8 +73,8 @@
 
       <div class="table-responsive">
         <table [dataSource]="dataSource"
-               [matSortActive]="options.sortBy"
-               [matSortDirection]="options.sortDirection"
+               [matSortActive]="config.sortBy"
+               [matSortDirection]="config.sortDirection"
                class="w-100 table-striped"
                mat-table
                matSort>
@@ -142,12 +142,12 @@
       <no-data [show]="!(dataSource?.data.length > 0)"></no-data>
 
       <div class="d-flex align-items-center flex-md-nowrap flex-wrap">
-        <ng-container [class.hidden]="!(dataSource?.data.length > 0) || (options.pageSize > totalItems)"
+        <ng-container [class.hidden]="!(dataSource?.data.length > 0) || (config.pageSize > totalItems)"
                       class="me-auto flex-grow-1 flex-nowrap">
           <mat-paginator
             [length]="totalItems"
-            [pageSizeOptions]="options.pageSizeOptions"
-            [pageSize]="options.pageSize">
+            [pageSizeOptions]="config.pageSizeOptions"
+            [pageSize]="config.pageSize">
           </mat-paginator>
         </ng-container>
 

--- a/packages/administration/src/roles-matrix/roles-matrix.component.ts
+++ b/packages/administration/src/roles-matrix/roles-matrix.component.ts
@@ -29,7 +29,7 @@ export class RolesMatrixComponent implements OnInit, OnDestroy {
 
     @ViewChild('table', { static: false }) public table: ElementRef;
 
-    public options: {
+    public config: {
         pageSizeOptions: number[],
         pageSize: number,
         sortDirection: 'asc' | 'desc',
@@ -104,7 +104,7 @@ export class RolesMatrixComponent implements OnInit, OnDestroy {
                                 return { value, valueOrg: value };
                             });
                         });
-                        result.permissions = this.orderByPipe.transform(result.permissions, this.options.sortBy, this.options.sortDirection === 'asc');
+                        result.permissions = this.orderByPipe.transform(result.permissions, this.config.sortBy, this.config.sortDirection === 'asc');
                     }
                     this.hiddenRoles = [];
                     this.matrix = { ...result };

--- a/packages/administration/src/user-management/user-management.component.html
+++ b/packages/administration/src/user-management/user-management.component.html
@@ -56,8 +56,8 @@
 
   <div class="table-responsive">
     <table [dataSource]="dataSource"
-           [matSortActive]="options.sortBy"
-           [matSortDirection]="options.sortDirection"
+           [matSortActive]="config.sortBy"
+           [matSortDirection]="config.sortDirection"
            class="w-100 table-striped"
            mat-table
            matSort>
@@ -149,7 +149,7 @@
     <no-data [show]="!(dataSource?.data.length > 0) && !showLoader"></no-data>
 
     <mat-paginator [length]="totalItems"
-                   [pageSizeOptions]="options.pageSizeOptions"
+                   [pageSizeOptions]="config.pageSizeOptions"
                    [pageIndex]="this.pagination.pageIndex"
                    [pageSize]="this.pagination.pageSize">
     </mat-paginator>

--- a/packages/administration/src/user-management/user-management.component.ts
+++ b/packages/administration/src/user-management/user-management.component.ts
@@ -260,7 +260,7 @@ export class UserMgmtComponent extends BaseAdminListComponent implements OnDestr
     }
 
     protected updateRoute(): void {
-        this.router.navigate(this.options.navigateUrl, {
+        this.router.navigate(this.config.navigateUrl, {
             queryParams: {
                 pageSize: this.pagination.pageSize,
                 pageIndex: this.pagination.pageIndex,


### PR DESCRIPTION
Use `config` instead of `options`.
Added handler for default value of BaseAdminListComponent