### PR TITLE
right-sidebar: correct resize width

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "4.0.98",
+  "version": "4.0.99",
   "release": "4.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/packages/components/sidebar-right/xm-sidebar-right.module.ts
+++ b/packages/components/sidebar-right/xm-sidebar-right.module.ts
@@ -45,10 +45,12 @@ export class XmSidebarRightComponent implements OnInit, OnDestroy {
     @HostListener('document:mousemove', ['$event'])
     public onMouseMove(event: MouseEvent): void {
         if (this.mousePressedOnResizer) {
-            const vw = window.screen.width / 100;
-            const newWidthInPx = window.screen.width - event.x;
+            if (event.stopPropagation) event.stopPropagation();
+            if (event.preventDefault) event.preventDefault();
+            const vw = window.innerWidth / 100;
+            const newWidthInPx = window.innerWidth - event.x;
             const newWidth = newWidthInPx / vw;
-            this.width = newWidth < 30 ? '30vw' : `${newWidth}vw`;
+            this.width = newWidth < 30 ? '30vw' : newWidth > 95 ? '95vw' : `${newWidth}vw`;
         }
     }
 


### PR DESCRIPTION
Calculate right sidebar by page width, not the screen.
Do not propagate event in order to avoid unexpected background text selection.