### PR TITLE
fix(xm-breadcrunb, xm-navbar-arrow-back-widget): fix breadcrumbs layout

### DIFF
--- a/packages/components/breadcrumb/breadcrumb/xm-breadcrumb.component.html
+++ b/packages/components/breadcrumb/breadcrumb/xm-breadcrumb.component.html
@@ -6,6 +6,7 @@
 
     <a *ngIf="!last; else pageTitle"
        [routerLink]="breadcrumb.url"
+       class="xm-breadcrumb-item-link"
        mat-button>{{ breadcrumb.label | translate }}
     </a>
 

--- a/packages/components/breadcrumb/breadcrumb/xm-breadcrumb.component.scss
+++ b/packages/components/breadcrumb/breadcrumb/xm-breadcrumb.component.scss
@@ -1,18 +1,36 @@
-.xm-breadcrumb-item.xm-breadcrumb-item-active {
-  font-weight: bold;
-}
-
-.xm-breadcrumb-item {
-  display: inline;
-  list-style-type: none;
-  font-weight: normal;
-
-  .mat-button {
-    font-weight: inherit;
-  }
-}
-
 .xm-breadcrumb-container {
+  display: flex;
   margin: 0;
   padding: 0;
+
+  .xm-breadcrumb-item {
+    display: flex;
+    align-items: center;
+    list-style-type: none;
+    font-weight: normal;
+
+    h5 {
+      font-weight: 700;
+      font-size: 16px;
+      line-height: 36px;
+      letter-spacing: .15px;
+      color: #666666;
+    }
+
+    .xm-breadcrumb-item-link {
+      font-size: 16px;
+      letter-spacing: .15px;
+      color: #666666;
+      font-weight: 400;
+    }
+
+    mat-icon {
+      color: #666666;
+    }
+
+    .mat-button {
+      font-weight: 400;
+      color: #666666;
+    }
+  }
 }

--- a/packages/components/navbar/back/xm-navbar-arrow-back-widget.component.ts
+++ b/packages/components/navbar/back/xm-navbar-arrow-back-widget.component.ts
@@ -12,11 +12,12 @@ import { MatButtonModule } from '@angular/material/button';
     template: `
         <button (click)="onBack()"
                 *ngIf="isSessionActive$ | async"
-                class="bg-surface rounded-circle shadow-sm"
+                class="bg-surface rounded-circle shadow-sm navbar-arrow-back-button"
                 mat-icon-button>
             <mat-icon>arrow_back</mat-icon>
         </button>
     `,
+    styles: ['.navbar-arrow-back-button { display: flex }'],
     imports: [
         MatIconModule,
         MatButtonModule,


### PR DESCRIPTION
xm-navbar-arrow-back-widget :   the icon is aligned with the center of the button
xm-breadcrunb: elements are aligned with each other, text size, colors and fat content are corrected