### PR TITLE
fix(xm-navbar-dashboard-edit-widget): open close state fixed

### DIFF
--- a/packages/administration/dashboards-config/dashboard-edit/dashboard-edit.component.ts
+++ b/packages/administration/dashboards-config/dashboard-edit/dashboard-edit.component.ts
@@ -79,7 +79,7 @@ export class DashboardEditComponent {
 
     public onCancel(): void {
         this.editorService.close();
-        this.editorService.isEditing(false);
+        this.editorService.changeEditState(false);
     }
 
     public onAdd(): void {

--- a/packages/administration/dashboards-config/dashboard-edit/dashboard-edit.component.ts
+++ b/packages/administration/dashboards-config/dashboard-edit/dashboard-edit.component.ts
@@ -79,6 +79,7 @@ export class DashboardEditComponent {
 
     public onCancel(): void {
         this.editorService.close();
+        this.editorService.isEditing(false);
     }
 
     public onAdd(): void {

--- a/packages/administration/dashboards-config/dashboard-editor.service.ts
+++ b/packages/administration/dashboards-config/dashboard-editor.service.ts
@@ -4,12 +4,12 @@ import { SidebarRightService } from '@xm-ngx/components/sidebar-right';
 import { Dashboard, DashboardWidget } from '@xm-ngx/core/dashboard';
 import { IId } from '@xm-ngx/interfaces';
 import { XmToasterService } from '@xm-ngx/toaster';
-import { Subject } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
 
 @Injectable()
 export class DashboardEditorService {
 
-    public isEdit: Subject<boolean> = new Subject<boolean>();
+    private isEdit: Subject<boolean> = new Subject<boolean>();
     constructor(public layoutService: SidebarRightService,
                 protected router: Router,
                 protected activatedRoute: ActivatedRoute,
@@ -22,8 +22,9 @@ export class DashboardEditorService {
         sessionStorage.removeItem('NAVBAR_DASHBOARD_EDIT_STORAGE_KEY');
     }
 
-    public isEditing(isEditing?: boolean): void {
+    public changeEditState(isEditing?: boolean): Observable<boolean> {
         this.isEdit.next(isEditing);
+        return this.isEdit;
     }
 
     public editDashboard<T>(ref: Type<T>, item: Dashboard): void {

--- a/packages/administration/dashboards-config/dashboard-editor.service.ts
+++ b/packages/administration/dashboards-config/dashboard-editor.service.ts
@@ -4,10 +4,12 @@ import { SidebarRightService } from '@xm-ngx/components/sidebar-right';
 import { Dashboard, DashboardWidget } from '@xm-ngx/core/dashboard';
 import { IId } from '@xm-ngx/interfaces';
 import { XmToasterService } from '@xm-ngx/toaster';
+import { Subject } from 'rxjs';
 
 @Injectable()
 export class DashboardEditorService {
 
+    public isEdit: Subject<boolean> = new Subject<boolean>();
     constructor(public layoutService: SidebarRightService,
                 protected router: Router,
                 protected activatedRoute: ActivatedRoute,
@@ -17,6 +19,11 @@ export class DashboardEditorService {
 
     public close(): void {
         this.layoutService.close();
+        sessionStorage.removeItem('NAVBAR_DASHBOARD_EDIT_STORAGE_KEY');
+    }
+
+    public isEditing(isEditing?: boolean): void {
+        this.isEdit.next(isEditing);
     }
 
     public editDashboard<T>(ref: Type<T>, item: Dashboard): void {

--- a/packages/administration/navbar-dashboard-edit-widget/navbar-dashboard-edit-widget.component.ts
+++ b/packages/administration/navbar-dashboard-edit-widget/navbar-dashboard-edit-widget.component.ts
@@ -70,7 +70,7 @@ export class NavbarDashboardEditWidgetComponent implements OnInit, OnDestroy, Xm
     }
 
     public ngOnInit(): void {
-        this.editorService.isEdit.pipe(takeUntilOnDestroy(this)).subscribe((isEdit) => this.isEditing = isEdit);
+        this.editorService.changeEditState().pipe(takeUntilOnDestroy(this)).subscribe((isEdit) => this.isEditing = isEdit);
 
         this.pageService.active$().pipe(takeUntilOnDestroy(this)).subscribe((i) => {
             this.page = i as Dashboard;

--- a/packages/administration/navbar-dashboard-edit-widget/navbar-dashboard-edit-widget.component.ts
+++ b/packages/administration/navbar-dashboard-edit-widget/navbar-dashboard-edit-widget.component.ts
@@ -58,7 +58,7 @@ export class NavbarDashboardEditWidgetComponent implements OnInit, OnDestroy, Xm
     public TRS: typeof DASHBOARDS_TRANSLATES = DASHBOARDS_TRANSLATES;
 
     public page: Dashboard;
-    public isEditing: boolean;
+    public isEditing: boolean = false;
 
     constructor(
         protected readonly wrapperService: DashboardStore,
@@ -70,6 +70,8 @@ export class NavbarDashboardEditWidgetComponent implements OnInit, OnDestroy, Xm
     }
 
     public ngOnInit(): void {
+        this.editorService.isEdit.pipe(takeUntilOnDestroy(this)).subscribe((isEdit) => this.isEditing = isEdit);
+
         this.pageService.active$().pipe(takeUntilOnDestroy(this)).subscribe((i) => {
             this.page = i as Dashboard;
             if (this.isEditing) {
@@ -89,15 +91,8 @@ export class NavbarDashboardEditWidgetComponent implements OnInit, OnDestroy, Xm
     }
 
     public onEdit(): void {
-        if (this.page && !this.isEditing) {
-            this.isEditing = true;
-            this.editorService.editDashboard(this.dashboardConfig.dashboardRef, this.page);
-            sessionStorage.setItem(NAVBAR_DASHBOARD_EDIT_STORAGE_KEY, NavbarDashboardEditState.Open);
-        } else {
-            this.isEditing = false;
-            sessionStorage.removeItem(NAVBAR_DASHBOARD_EDIT_STORAGE_KEY);
-            this.editorService.close();
-        }
+        this.editorService.editDashboard(this.dashboardConfig.dashboardRef, this.page);
+        sessionStorage.setItem(NAVBAR_DASHBOARD_EDIT_STORAGE_KEY, NavbarDashboardEditState.Open);
     }
 
     public ngOnDestroy(): void {

--- a/packages/administration/navbar-dashboard-edit-widget/navbar-dashboard-edit-widget.module.ts
+++ b/packages/administration/navbar-dashboard-edit-widget/navbar-dashboard-edit-widget.module.ts
@@ -2,9 +2,10 @@ import { NgModule, Type } from '@angular/core';
 import { DashboardsModule, } from '@xm-ngx/administration/dashboards-config';
 import { NavbarDashboardEditWidgetComponent, } from './navbar-dashboard-edit-widget.component';
 import { XmSharedModule } from '@xm-ngx/shared';
+import { AsyncPipe } from "@angular/common";
 
 @NgModule({
-    imports: [XmSharedModule, DashboardsModule],
+    imports: [XmSharedModule, DashboardsModule, AsyncPipe],
     exports: [NavbarDashboardEditWidgetComponent],
     declarations: [NavbarDashboardEditWidgetComponent],
 })

--- a/packages/dynamic/cell/xm-dynamic-cell.directive.ts
+++ b/packages/dynamic/cell/xm-dynamic-cell.directive.ts
@@ -14,7 +14,7 @@ import { getValue } from '@xm-ngx/operators';
 import * as _ from 'lodash';
 import { XmDynamicPresentationBase } from '../presentation';
 import { XmDynamicLayoutNode } from '../src/interfaces';
-import { XmConfig } from '@xm-ngx/interfaces';
+// import { XmConfig } from '@xm-ngx/interfaces';
 
 
 export const XM_DYNAMIC_TABLE_ROW = new InjectionToken<string>('XM_DYNAMIC_TABLE_ROW');


### PR DESCRIPTION
Fixed a defect when the modal for editing the dashboard constantly opened, as if not to click on the edit button again.
 How it works now:

 -when we press the button edit dashboard, the state of the open modal window is saved in the session store.

- when we press the button to close the modal for editing, this value is removed from the session store.