### PR TITLE
Controllers injector

### DIFF
--- a/packages/dynamic/cell/xm-dynamic-cell.directive.ts
+++ b/packages/dynamic/cell/xm-dynamic-cell.directive.ts
@@ -84,7 +84,7 @@ export class XmDynamicCellDirective<V, O extends XmDynamicCell<O>>
         if (style?.includes('${')) {
             try {
                 style = _.template(style ?? '')(this.row as object ?? {});
-            } catch(e) {
+            } catch (e) {
                 console.warn(e);
             }
         }
@@ -96,7 +96,7 @@ export class XmDynamicCellDirective<V, O extends XmDynamicCell<O>>
         if (classNames?.includes('${')) {
             try {
                 classNames = _.template(classNames ?? '')(this.row as object ?? {});
-            } catch(e) {
+            } catch (e) {
                 console.warn(e);
             }
         }
@@ -118,14 +118,14 @@ export class XmDynamicCellDirective<V, O extends XmDynamicCell<O>>
         }
     }
 
-    public createInjector(injector: Injector = this.injector): Injector {
-        return Injector.create({
+    public createInjector(injector: Injector = this.injector): Promise<Injector> {
+        return Promise.resolve(Injector.create({
             providers: [
                 {provide: XM_DYNAMIC_TABLE_ROW, useValue: this.row},
                 {provide: XM_DYNAMIC_TABLE_CELL, useValue: this._cell},
             ],
             parent: injector,
-        });
+        }));
     }
 
     public ngDoCheck(): void {

--- a/packages/dynamic/control/xm-dynamic-control.directive.ts
+++ b/packages/dynamic/control/xm-dynamic-control.directive.ts
@@ -13,15 +13,15 @@ import {
     ViewContainerRef,
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { XmDynamicServiceFactory } from '@xm-ngx/dynamic';
-import { XmDynamicInjectionTokenStoreService } from '@xm-ngx/dynamic/src/services/xm-dynamic-injection-token-store.service';
 import { from, ReplaySubject, Subject, switchMap, takeUntil, tap } from 'rxjs';
 import { setComponentInput } from '../operators/set-component-input';
 import { XmDynamicPresentation } from '../presentation/xm-dynamic-presentation-base.directive';
 import { XmDynamicPresentationDirective } from '../presentation/xm-dynamic-presentation.directive';
+import { XmDynamicServiceFactory } from '../services/xm-dynamic-service-factory.service';
 import { XmDynamicConstructor } from '../src/interfaces/xm-dynamic-constructor';
 import { XmDynamicEntryModule } from '../src/interfaces/xm-dynamic-entry-module';
 import { XmDynamicComponentRegistry } from '../src/loader/xm-dynamic-component-registry.service';
+import { XmDynamicInjectionTokenStoreService } from '../src/services/xm-dynamic-injection-token-store.service';
 
 export interface XmDynamicControl<V = unknown, C = unknown> extends XmDynamicPresentation<V, C>, ControlValueAccessor {
     valueChange: EventEmitter<V>;

--- a/packages/dynamic/control/xm-dynamic-control.directive.ts
+++ b/packages/dynamic/control/xm-dynamic-control.directive.ts
@@ -13,13 +13,15 @@ import {
     ViewContainerRef,
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { XmDynamicConstructor } from '../src/interfaces/xm-dynamic-constructor';
-import { XmDynamicEntryModule } from '../src/interfaces/xm-dynamic-entry-module';
+import { XmDynamicServiceFactory } from '@xm-ngx/dynamic';
+import { XmDynamicInjectionTokenStoreService } from '@xm-ngx/dynamic/src/services/xm-dynamic-injection-token-store.service';
+import { from, ReplaySubject, Subject, switchMap, takeUntil, tap } from 'rxjs';
+import { setComponentInput } from '../operators/set-component-input';
 import { XmDynamicPresentation } from '../presentation/xm-dynamic-presentation-base.directive';
 import { XmDynamicPresentationDirective } from '../presentation/xm-dynamic-presentation.directive';
+import { XmDynamicConstructor } from '../src/interfaces/xm-dynamic-constructor';
+import { XmDynamicEntryModule } from '../src/interfaces/xm-dynamic-entry-module';
 import { XmDynamicComponentRegistry } from '../src/loader/xm-dynamic-component-registry.service';
-import { setComponentInput } from '../operators/set-component-input';
-import { from, ReplaySubject, Subject, switchMap, takeUntil, tap } from 'rxjs';
 
 export interface XmDynamicControl<V = unknown, C = unknown> extends XmDynamicPresentation<V, C>, ControlValueAccessor {
     valueChange: EventEmitter<V>;
@@ -53,7 +55,7 @@ export interface XmDynamicControlEntryModule<V = unknown, C = unknown> extends X
  */
 @Directive({
     selector: '[xmDynamicControl]',
-    providers: [{ provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => XmDynamicControlDirective), multi: true }],
+    providers: [{provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => XmDynamicControlDirective), multi: true}],
 })
 export class XmDynamicControlDirective<V, C>
     extends XmDynamicPresentationDirective<V, C>
@@ -85,9 +87,11 @@ export class XmDynamicControlDirective<V, C>
         viewContainerRef: ViewContainerRef,
         injector: Injector,
         renderer: Renderer2,
-        dynamicComponents: XmDynamicComponentRegistry
+        dynamicComponents: XmDynamicComponentRegistry,
+        dynamicServices: XmDynamicServiceFactory,
+        dynamicInjectionTokenStore: XmDynamicInjectionTokenStoreService,
     ) {
-        super(viewContainerRef, injector, renderer, dynamicComponents);
+        super(viewContainerRef, injector, renderer, dynamicComponents, dynamicServices, dynamicInjectionTokenStore);
     }
 
 

--- a/packages/dynamic/presentation/xm-dynamic-presentation-base.directive.ts
+++ b/packages/dynamic/presentation/xm-dynamic-presentation-base.directive.ts
@@ -8,16 +8,14 @@ import {
     SimpleChanges,
     ViewContainerRef,
 } from '@angular/core';
-import { XmDynamicServiceFactory, XmDynamicWithSelector } from '@xm-ngx/dynamic';
-import {
-    XmDynamicInjectionTokenStoreService
-} from '@xm-ngx/dynamic/src/services/xm-dynamic-injection-token-store.service';
 import { XmConfig } from '@xm-ngx/interfaces';
 import { setComponentInput } from '../operators/set-component-input';
-import { XmDynamicSelector, XmDynamicWithConfig, XmLayoutNode } from '../src/interfaces';
+import { XmDynamicServiceFactory } from '../services/xm-dynamic-service-factory.service';
+import { XmDynamicSelector, XmDynamicWithConfig, XmDynamicWithSelector, XmLayoutNode } from '../src/interfaces';
 import { XmDynamicConstructor } from '../src/interfaces/xm-dynamic-constructor';
 import { XmDynamicEntryModule } from '../src/interfaces/xm-dynamic-entry-module';
 import { XmDynamicComponentRegistry } from '../src/loader/xm-dynamic-component-registry.service';
+import { XmDynamicInjectionTokenStoreService } from '../src/services/xm-dynamic-injection-token-store.service';
 
 
 /** Determines input(control) value. */

--- a/packages/dynamic/presentation/xm-dynamic-presentation.directive.ts
+++ b/packages/dynamic/presentation/xm-dynamic-presentation.directive.ts
@@ -1,6 +1,11 @@
 import { Directive, Input, OnChanges, OnInit } from '@angular/core';
-import { XmDynamicPresentationBase, XmDynamicPresentation, XmDynamicPresentationConstructor } from './xm-dynamic-presentation-base.directive';
 import { XmDynamicSelector } from '../src/interfaces';
+import {
+    XmDynamicControllerConfig,
+    XmDynamicPresentation,
+    XmDynamicPresentationBase,
+    XmDynamicPresentationConstructor
+} from './xm-dynamic-presentation-base.directive';
 
 /**
  * DynamicComponent creates a component from the DynamicLoader
@@ -14,6 +19,7 @@ import { XmDynamicSelector } from '../src/interfaces';
     selector: '[xmDynamicPresentation]',
 })
 export class XmDynamicPresentationDirective<V, O> extends XmDynamicPresentationBase<V, O> implements XmDynamicPresentation<V, O>, OnChanges, OnInit {
+    @Input() public controllers: XmDynamicControllerConfig[] = [];
     /** Component value */
     @Input() public value: V;
     /**

--- a/packages/dynamic/services/xm-dynamic-service-factory.service.ts
+++ b/packages/dynamic/services/xm-dynamic-service-factory.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Injector, Type } from '@angular/core';
 import { XmDynamicComponentRegistry } from '../src/loader/xm-dynamic-component-registry.service';
 import { XmConfig } from '@xm-ngx/interfaces';
-import { XmDynamicSelector, XmDynamicWithConfig } from '../src/interfaces';
+import { XmDynamicConstructor, XmDynamicSelector, XmDynamicWithConfig } from '../src/interfaces';
 
 export interface XmDynamicService<C = XmConfig> extends XmDynamicWithConfig<C> {
 }
@@ -22,10 +22,14 @@ export class XmDynamicServiceFactory {
         return injector.get<T>(serviceConstructor);
     }
 
-    public async findAndFactory<T>(selector: XmDynamicSelector, injector = this.injector): Promise<T> {
-        const serviceConstructor = await this.xmDynamicComponentRegistry.find<Type<T>>(selector, injector);
-        return this.factory<T>(serviceConstructor.componentType, injector);
+    public async find<T>(selector: XmDynamicSelector, injector = this.injector): Promise<XmDynamicConstructor<T>> {
+        const serviceConstructor = await this.xmDynamicComponentRegistry.find<T>(selector, injector);
+        return serviceConstructor.componentType;
     }
 
+    public async findAndFactory<T>(selector: XmDynamicSelector, injector = this.injector): Promise<T> {
+        const componentType = await this.find<T>(selector, injector);
+        return this.factory<T>(componentType, injector);
+    }
 
 }

--- a/packages/dynamic/src/module/xm-dynamic.module.ts
+++ b/packages/dynamic/src/module/xm-dynamic.module.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { ModuleWithProviders, NgModule, Provider } from '@angular/core';
-import { XmDynamicInjectionTokenStoreService } from '@xm-ngx/dynamic/src/services/xm-dynamic-injection-token-store.service';
+import { XmDynamicInjectionTokenStoreService } from '../services/xm-dynamic-injection-token-store.service';
 import { XmDynamicControlDirective } from '../../control/xm-dynamic-control.directive';
 import { XmDynamicFormControlDirective } from '../../control/xm-dynamic-form-control.directive';
 import { XM_DYNAMIC_ENTRIES } from '../dynamic.injectors';

--- a/packages/dynamic/src/module/xm-dynamic.module.ts
+++ b/packages/dynamic/src/module/xm-dynamic.module.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { ModuleWithProviders, NgModule, Provider } from '@angular/core';
+import { XmDynamicInjectionTokenStoreService } from '@xm-ngx/dynamic/src/services/xm-dynamic-injection-token-store.service';
 import { XmDynamicControlDirective } from '../../control/xm-dynamic-control.directive';
 import { XmDynamicFormControlDirective } from '../../control/xm-dynamic-form-control.directive';
 import { XM_DYNAMIC_ENTRIES } from '../dynamic.injectors';
@@ -44,6 +45,7 @@ export class XmDynamicModule {
                 XmDynamicComponentRegistry,
                 XmDynamicServiceFactory,
                 XmDynamicModuleRegistry,
+                XmDynamicInjectionTokenStoreService,
                 dynamicModuleInitializer(components)],
         };
     }

--- a/packages/dynamic/src/services/xm-dynamic-injection-token-store.service.ts
+++ b/packages/dynamic/src/services/xm-dynamic-injection-token-store.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, InjectionToken } from '@angular/core';
-import { XmDynamicService } from '@xm-ngx/dynamic';
+import { XmDynamicService } from '../../services/xm-dynamic-service-factory.service';
 
 
 @Injectable()

--- a/packages/dynamic/src/services/xm-dynamic-injection-token-store.service.ts
+++ b/packages/dynamic/src/services/xm-dynamic-injection-token-store.service.ts
@@ -1,0 +1,17 @@
+import { Injectable, InjectionToken } from '@angular/core';
+import { XmDynamicService } from '@xm-ngx/dynamic';
+
+
+@Injectable()
+export class XmDynamicInjectionTokenStoreService {
+
+    private mapper: Record<string, InjectionToken<unknown>> = {};
+
+    public resolve<T extends XmDynamicService>(key: string): InjectionToken<T> {
+        if (!this.mapper[key]) {
+            this.mapper[key] = new InjectionToken<T>(key);
+        }
+        return this.mapper[key];
+    }
+
+}


### PR DESCRIPTION
The following pull request provides an ability to dynamically inject services like it works with components.
In order to add dynamic services all we need is to pass `@Input` parameter into dynamic presentation directive with name `controllers` which will inject service instance into the Angular injector.
Controllers config has own structure:
```
{
   key: string, // required field in order to associate Class instance in the injector dependency tree
   selector: string, // uniq identification key that you defined in registry file, associated with service Class
   config: XmConfig, // literally any object
}
```

How to inject (TBD):
We could inject controller into component using `XmDynamicInjectionTokenStoreService` with following syntax
```
private dynamicInjectionTokenStore = inject(XmDynamicInjectionTokenStoreService);
public editStateService = inject(this.dynamicInjectionTokenStore.resolve('edit-state'));
```

`XmDynamicInjectionTokenStoreService` provides `InjectionToken` by `string` value. This token will be used as the key for controller instance.