### PR TITLE
MWUSSD1-277: xm-table-widget storage and pagination fix

### DIFF
--- a/packages/components/table/controllers/collections/a-xm-table-local-pageable-collection-controller.service.ts
+++ b/packages/components/table/controllers/collections/a-xm-table-local-pageable-collection-controller.service.ts
@@ -23,21 +23,22 @@ export abstract class AXmTableLocalPageableCollectionController<T>
         const { pageableAndSortable } = defaultsDeep(request, cloneDeep({ pageableAndSortable: PAGEABLE_AND_SORTABLE_DEFAULT, filterParams: {}}));
         pageableAndSortable.total = rawData.length;
 
-        const from = pageableAndSortable.pageIndex * pageableAndSortable.pageSize;
-        const maxLast = (pageableAndSortable.pageIndex + 1) * pageableAndSortable.pageSize;
-        const to = maxLast > pageableAndSortable.total ? pageableAndSortable.total : maxLast;
-        const items = _.slice(this.rawData, from, to - 1);
+        const { pageIndex, pageSize, total, sortOrder, sortBy } = pageableAndSortable;
+        const fromIndex = pageIndex * pageSize;
+        const expectedToIndex = ((pageIndex + 1) * pageSize) || total;
+        const availableToIndex = Math.min(expectedToIndex, total);
+        const items = _.slice(this.rawData, fromIndex, availableToIndex);
 
         this._state.next({
             items: cloneDeep(items),
             error: null,
             loading: false,
             pageableAndSortable: {
-                pageIndex: pageableAndSortable.pageIndex,
-                pageSize: pageableAndSortable.pageSize,
-                total: pageableAndSortable.total,
-                sortOrder: pageableAndSortable.sortOrder,
-                sortBy: pageableAndSortable.sortBy,
+                pageIndex,
+                pageSize,
+                total,
+                sortOrder,
+                sortBy,
             },
         });
     }

--- a/packages/components/table/controllers/config/xm-table-columns-setting-storage.service.ts
+++ b/packages/components/table/controllers/config/xm-table-columns-setting-storage.service.ts
@@ -60,21 +60,24 @@ export class XmTableSettingStore implements OnDestroy {
     public clearStore(key: string): void {
         const state = this.store.value;
         delete state[key];
+        this.store.next(state);
     }
 }
 
 @Injectable()
 export class XmTableColumnsSettingStorageService {
-
+    private _key: string;
 
     constructor(
         private XmTableColumnsSettingStorageService: XmTableSettingStore,
     ) {
     }
 
-    private get key(): string {
-        // TODO: improve make a unique location for each table
-        return location.pathname;
+    public set key(key: string) {
+        this._key = key;
+    }
+    public get key(): string {
+        return this._key;
     }
 
     public updateStore(columns: ColumnsSettingStorageItem[]): void {

--- a/packages/components/table/controllers/filters/xm-table-query-params-store.service.ts
+++ b/packages/components/table/controllers/filters/xm-table-query-params-store.service.ts
@@ -9,10 +9,19 @@ import { XmTableQueryParamsToFilter } from '../../table-widget/xm-table-widget.c
 @Injectable()
 export class XmTableQueryParamsStoreService {
 
+    private _key: string;
+
     constructor(
         public router: Router,
         private activatedRoute: ActivatedRoute,
     ) {
+    }
+
+    public set key(key: string) {
+        this._key = key;
+    }
+    public get key(): string {
+        return this._key;
     }
 
     public set(queryParams: QueryParamsPageable, removeFieldsFromUrl?: Record<string, string>): void {
@@ -20,9 +29,9 @@ export class XmTableQueryParamsStoreService {
             [],
             {
                 relativeTo: this.activatedRoute,
-                queryParams: { 
+                queryParams: {
                     ...(removeFieldsFromUrl ?? {}),
-                    json: JSON.stringify(queryParams) 
+                    [this.key]: JSON.stringify(queryParams)
                 },
                 queryParamsHandling: 'merge'
             },
@@ -32,13 +41,13 @@ export class XmTableQueryParamsStoreService {
 
     public get(queryParamsToFillter?: XmTableQueryParamsToFilter): QueryParamsPageable {
         const queryParams = this.activatedRoute.snapshot.queryParams;
-        const jsonString = queryParams?.json as string;
+        const jsonString = queryParams?.[this.key] as string;
 
         const jsonParams = (isString(jsonString) && !isEmpty(jsonString)
-            ? JSON.parse(jsonString) 
+            ? JSON.parse(jsonString)
             : {}
         ) as (XmFilterQueryParams | object);
-        
+
         if (!isEmpty(queryParamsToFillter)) {
             const queryParamsFilter= omitBy(format(queryParamsToFillter ?? {}, queryParams) ?? {}, isEmpty);
             const jsonFilterParams = get(jsonParams, 'filterParams', {}) as object;

--- a/packages/components/table/directives/xm-table.directive.ts
+++ b/packages/components/table/directives/xm-table.directive.ts
@@ -67,11 +67,17 @@ export class XmTableDirective implements OnInit, OnDestroy {
     @Input('xmTableConfig')
     public set config(value: XmTableConfig) {
         this._config = _.defaultsDeep({}, value, cloneDeep(XM_TABLE_CONFIG_DEFAULT));
+        this.setStorageKeys();
         this.columnsSettingStorageService.defaultStore(getDisplayedColumns(this._config));
     }
 
     public ngOnInit(): void {
         this.onControllerStateChangeUpdateContext();
+    }
+
+    private setStorageKeys(): void {
+        const storageKey: string = this.config.storageKey || location.pathname;
+        this.columnsSettingStorageService.key = this.queryParamsStoreService.key = storageKey;
     }
 
     public onControllerStateChangeUpdateContext(): void {

--- a/packages/components/table/directives/xm-table.model.ts
+++ b/packages/components/table/directives/xm-table.model.ts
@@ -14,6 +14,7 @@ export interface XmTableConfig {
     collection: XmTableCollectionControllerType,
     queryParamsToFillter?: XmTableQueryParamsToFilter;
     pageableAndSortable: XmTableWithColumnDynamicCellOptionsPagination,
+    storageKey: string;
 }
 
 export const XM_TABLE_CONFIG_DEFAULT: XmTableConfig = {
@@ -26,4 +27,5 @@ export const XM_TABLE_CONFIG_DEFAULT: XmTableConfig = {
             hidePagination: false,
         },
     },
+    storageKey: '',
 };

--- a/packages/components/table/table-widget/xm-table-widget.component.ts
+++ b/packages/components/table/table-widget/xm-table-widget.component.ts
@@ -33,6 +33,7 @@ function getConfig(value: Partial<XmTableWidgetConfig>): XmTableWidgetConfig {
     const config = defaultsDeep({}, value, XM_TABLE_WIDGET_CONFIG_DEFAULT, XM_TABLE_CONFIG_DEFAULT) as XmTableWidgetConfig;
     config.columns.forEach(c => c.name = c.name || c.field);
     config.pageableAndSortable.sortBy = config.pageableAndSortable.sortBy || config.columns[0].name;
+    config.storageKey = config.storageKey || `${location.pathname}.xm-table-widget`;
     return config;
 }
 

--- a/packages/repositories/src/i-entity-collection-pageable.ts
+++ b/packages/repositories/src/i-entity-collection-pageable.ts
@@ -25,7 +25,7 @@ export interface PageableAndSortable extends Pageable, Sortable {
 
 export const PAGEABLE_AND_SORTABLE_DEFAULT: PageableAndSortable = {
     pageIndex: 0,
-    pageSize: 0,
+    pageSize: Number.MAX_SAFE_INTEGER,
     total: 0,
     sortOrder: 'asc',
     sortBy: null,


### PR DESCRIPTION
- Add support for the several `xm-table-widgets` on the same page, dialog, etc
- Add support for the several `xm-table-widgets` filters on the same page, dialog, etc
- Fixed pagination bug when the last element in the table was sliced