### PR TITLE
fix(autocomplete-control): Fix selection for the items in autocomplete-table-control

### DIFF
--- a/packages/components/autocomplete-control/autocomple-control.interface.ts
+++ b/packages/components/autocomplete-control/autocomple-control.interface.ts
@@ -49,6 +49,7 @@ export interface XmAutocompleteControlConfig {
     startFromCharSearch?: number;
     errors?: XmControlErrorsTranslates;
     required?: boolean;
+    isSelectOnlyExistValues?: boolean;
 }
 
 export const AUTOCOMPLETE_CONTROL_DEFAULT_CONFIG: XmAutocompleteControlConfig = {

--- a/packages/components/autocomplete-control/autocomplete-table-control.component.ts
+++ b/packages/components/autocomplete-control/autocomplete-table-control.component.ts
@@ -144,8 +144,7 @@ export class XmAutocompleteTableControl extends XmAutocompleteControl {
         }
 
         this.selection.toggle(row);
-
-        this.change(this.selection.selected);
+        this.change(this.selection.selected, 'data');
     }
 
     public toggleAllRows(): void {
@@ -159,6 +158,6 @@ export class XmAutocompleteTableControl extends XmAutocompleteControl {
             this.selection.select(...this.list.value);
         }
 
-        this.change(this.selection.selected);
+        this.change(this.selection.selected, 'data');
     }
 }

--- a/packages/core/permission/src/directives/xm-permitted.directive.spec.ts
+++ b/packages/core/permission/src/directives/xm-permitted.directive.spec.ts
@@ -1,9 +1,9 @@
-import { Component, ElementRef } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
-import { of } from 'rxjs';
-import { XmPermissionService, XmPermittedDirective } from '@xm-ngx/core/permission';
-import { MockPermissionService } from '@xm-ngx/core/permission/testing';
+import {Component, ElementRef} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+import {of} from 'rxjs';
+import {XmPermissionService, XmPermittedDirective} from '@xm-ngx/core/permission';
+import {MockPermissionService} from '@xm-ngx/core/permission/testing';
 import SpyObj = jasmine.SpyObj;
 
 @Component({
@@ -79,7 +79,7 @@ describe('XmPermittedDirective', () => {
         throw new Error('Resolve false, no match');
     };
 
-    beforeEach(waitForAsync(() => {
+    beforeEach(() => {
 
         mockPrincipalService = jasmine.createSpyObj<MockPermissionService>(['hasPrivileges', 'permissions$']);
 
@@ -97,29 +97,20 @@ describe('XmPermittedDirective', () => {
         });
 
         fixture = TestBed.createComponent(TestComponent);
-    }));
-
-    it('should be visible all elements from OK_SET', waitForAsync(() => {
         fixture.detectChanges();
+    });
 
-        void fixture.whenStable().then(() => {
-            const buttonComp = fixture.debugElement.queryAll(By.css('button')) as ElementRef<HTMLElement>[];
-            for (const item of buttonComp) {
-                void expect(OK_SET.has(item.nativeElement.textContent)).toBe(true);
-            }
-        });
+    it('should be visible all elements from OK_SET', () => {
+        const buttonComp = fixture.debugElement.queryAll(By.css('button')) as ElementRef<HTMLElement>[];
+        for (const item of buttonComp) {
+            expect(OK_SET.has(item.nativeElement.textContent)).toBe(true);
+        }
+    });
 
-    }));
-
-    it('should not be visible all elements from NOK_SET', waitForAsync(() => {
-        fixture.detectChanges();
-
-        void fixture.whenStable().then(() => {
-            const buttonComp = fixture.debugElement.queryAll(By.css('button')) as ElementRef<HTMLElement>[];
-            for (const item of buttonComp) {
-                void expect(NOK_SET.has(item.nativeElement.textContent)).toBe(false);
-            }
-        });
-
-    }));
+    it('should not be visible all elements from NOK_SET', () => {
+        const buttonComp = fixture.debugElement.queryAll(By.css('button')) as ElementRef<HTMLElement>[];
+        for (const item of buttonComp) {
+            expect(NOK_SET.has(item.nativeElement.textContent)).toBe(false);
+        }
+    });
 });


### PR DESCRIPTION
- fix case when all items were selected after page initialization, but they shouldn't.
- unit-tests fix