### PR TITLE
fix(xm-ace-editor): Fix object to JSON support + formatting

### DIFF
--- a/packages/administration/dashboards-config/dashboard-edit/dashboard-edit.component.ts
+++ b/packages/administration/dashboards-config/dashboard-edit/dashboard-edit.component.ts
@@ -12,7 +12,11 @@ import {
 import {AbstractControl, FormControl, ValidationErrors, Validators} from '@angular/forms';
 import {TranslateService} from '@ngx-translate/core';
 import {XmAlertService} from '@xm-ngx/alert';
-import {XmAceEditorControlModeEnum, XmAceEditorControlOptions} from '@xm-ngx/components/ace-editor';
+import {
+    XmAceEditorControlModeEnum,
+    XmAceEditorControlOptions,
+    XmAceEditorControlTypeEnum
+} from '@xm-ngx/components/ace-editor';
 import {XM_CONTROL_ERRORS_TRANSLATES} from '@xm-ngx/components/control-error';
 import {XmTextControlOptions} from '@xm-ngx/components/text';
 import {XmEventManager} from '@xm-ngx/core';
@@ -32,7 +36,6 @@ import {
     DashboardsListExpandComponent,
 } from '../dashboards-list/dashboards-list-expand/dashboards-list-expand.component';
 import {DashboardCollection, DashboardConfig as DashboardConfigInjector} from '../injectors';
-import {XmAceEditorControlTypeEnum} from '@xm-ngx/components/ace-editor/ace-editor-control/xm-ace-editor-control.model';
 
 export enum EditType {
     Create = 1,

--- a/packages/administration/dashboards-config/dashboard-edit/dashboard-edit.component.ts
+++ b/packages/administration/dashboards-config/dashboard-edit/dashboard-edit.component.ts
@@ -9,29 +9,30 @@ import {
     Type,
     ViewChild,
 } from '@angular/core';
-import { AbstractControl, FormControl, ValidationErrors, Validators } from '@angular/forms';
-import { TranslateService } from '@ngx-translate/core';
-import { XmAlertService } from '@xm-ngx/alert';
-import { XmAceEditorControlOptions } from '@xm-ngx/components/ace-editor';
-import { XM_CONTROL_ERRORS_TRANSLATES } from '@xm-ngx/components/control-error';
-import { XmTextControlOptions } from '@xm-ngx/components/text';
-import { XmEventManager } from '@xm-ngx/core';
-import { Dashboard, DashboardConfig, DashboardLayout, DashboardStore, DashboardWidget } from '@xm-ngx/core/dashboard';
-import { Principal } from '@xm-ngx/core/user';
-import { copyToClipboard, readFromClipboard, takeUntilOnDestroy, takeUntilOnDestroyDestroy } from '@xm-ngx/operators';
-import { XmToasterService } from '@xm-ngx/toaster';
-import { XmTranslateService } from '@xm-ngx/translation';
+import {AbstractControl, FormControl, ValidationErrors, Validators} from '@angular/forms';
+import {TranslateService} from '@ngx-translate/core';
+import {XmAlertService} from '@xm-ngx/alert';
+import {XmAceEditorControlModeEnum, XmAceEditorControlOptions} from '@xm-ngx/components/ace-editor';
+import {XM_CONTROL_ERRORS_TRANSLATES} from '@xm-ngx/components/control-error';
+import {XmTextControlOptions} from '@xm-ngx/components/text';
+import {XmEventManager} from '@xm-ngx/core';
+import {Dashboard, DashboardConfig, DashboardLayout, DashboardStore, DashboardWidget} from '@xm-ngx/core/dashboard';
+import {Principal} from '@xm-ngx/core/user';
+import {copyToClipboard, readFromClipboard, takeUntilOnDestroy, takeUntilOnDestroyDestroy} from '@xm-ngx/operators';
+import {XmToasterService} from '@xm-ngx/toaster';
+import {XmTranslateService} from '@xm-ngx/translation';
 import * as _ from 'lodash';
-import { prop } from 'lodash/fp';
-import { merge, Observable } from 'rxjs';
-import { delay, distinctUntilChanged, filter, map, switchMap, take, tap } from 'rxjs/operators';
-import { DASHBOARDS_TRANSLATES } from '../const';
-import { CONFIG_TYPE, CopiedObject, DashboardEditorService, XM_WEBAPP_OPERATIONS } from '../dashboard-editor.service';
+import {cloneDeep, omit} from 'lodash';
+import {prop} from 'lodash/fp';
+import {merge, Observable} from 'rxjs';
+import {delay, distinctUntilChanged, filter, map, switchMap, take, tap} from 'rxjs/operators';
+import {DASHBOARDS_TRANSLATES} from '../const';
+import {CONFIG_TYPE, CopiedObject, DashboardEditorService, XM_WEBAPP_OPERATIONS} from '../dashboard-editor.service';
 import {
     DashboardsListExpandComponent,
 } from '../dashboards-list/dashboards-list-expand/dashboards-list-expand.component';
-import { cloneDeep, omit } from 'lodash';
-import { DashboardCollection, DashboardConfig as DashboardConfigInjector } from '../injectors';
+import {DashboardCollection, DashboardConfig as DashboardConfigInjector} from '../injectors';
+import {XmAceEditorControlTypeEnum} from '@xm-ngx/components/ace-editor/ace-editor-control/xm-ace-editor-control.model';
 
 export enum EditType {
     Create = 1,
@@ -72,7 +73,12 @@ export class DashboardEditComponent implements OnInit, OnDestroy, AfterViewInit 
     public disabled: boolean;
     public EDIT_EVENT: string = this.dashboardConfig.EDIT_DASHBOARD_EVENT;
 
-    public aceEditorOptions: XmAceEditorControlOptions = {title: '', mode: 'object-to-yaml', height: 'calc(100vh - 350px)'};
+    public aceEditorOptions: XmAceEditorControlOptions = {
+        title: '',
+        mode: XmAceEditorControlModeEnum.JSON,
+        type: XmAceEditorControlTypeEnum.OBJECT,
+        height: 'calc(100vh - 350px)',
+    };
 
     public editType: EditType;
     public widgetEditComponentType: Type<unknown> = this.dashboardConfig.widgetRef;

--- a/packages/administration/dashboards-config/widget-edit/config-editor.component.ts
+++ b/packages/administration/dashboards-config/widget-edit/config-editor.component.ts
@@ -1,7 +1,8 @@
-import { Component } from '@angular/core';
-import { XmAceEditorControl, XmAceEditorControlOptions } from '@xm-ngx/components/ace-editor';
-import { NgControlAccessor } from '@xm-ngx/components/ng-accessor';
-import { FormsModule } from '@angular/forms';
+import {Component} from '@angular/core';
+import {XmAceEditorControl, XmAceEditorControlModeEnum, XmAceEditorControlOptions} from '@xm-ngx/components/ace-editor';
+import {NgControlAccessor} from '@xm-ngx/components/ng-accessor';
+import {FormsModule} from '@angular/forms';
+import {XmAceEditorControlTypeEnum} from '@xm-ngx/components/ace-editor/ace-editor-control/xm-ace-editor-control.model';
 
 @Component({
     selector: 'xm-config-editor',
@@ -23,7 +24,8 @@ import { FormsModule } from '@angular/forms';
 })
 export class ConfigEditorComponent extends NgControlAccessor<string> {
     public aceEditorOptions: Partial<XmAceEditorControlOptions> = {
-        mode: 'object-to-yaml',
+        mode: XmAceEditorControlModeEnum.JSON,
+        type: XmAceEditorControlTypeEnum.OBJECT,
         title: '',
         options: {
             tabSize: 2,

--- a/packages/administration/dashboards-config/widget-edit/config-editor.component.ts
+++ b/packages/administration/dashboards-config/widget-edit/config-editor.component.ts
@@ -1,8 +1,12 @@
 import {Component} from '@angular/core';
-import {XmAceEditorControl, XmAceEditorControlModeEnum, XmAceEditorControlOptions} from '@xm-ngx/components/ace-editor';
+import {
+    XmAceEditorControl,
+    XmAceEditorControlModeEnum,
+    XmAceEditorControlOptions,
+    XmAceEditorControlTypeEnum
+} from '@xm-ngx/components/ace-editor';
 import {NgControlAccessor} from '@xm-ngx/components/ng-accessor';
 import {FormsModule} from '@angular/forms';
-import {XmAceEditorControlTypeEnum} from '@xm-ngx/components/ace-editor/ace-editor-control/xm-ace-editor-control.model';
 
 @Component({
     selector: 'xm-config-editor',

--- a/packages/administration/form-playground/form-playground.component.ts
+++ b/packages/administration/form-playground/form-playground.component.ts
@@ -3,7 +3,11 @@ import {HttpClient} from '@angular/common/http';
 import {Component, OnInit} from '@angular/core';
 import {UntypedFormControl} from '@angular/forms';
 import {ActivatedRoute} from '@angular/router';
-import {XmAceEditorControlModeEnum, XmAceEditorControlOptions} from '@xm-ngx/components/ace-editor';
+import {
+    XmAceEditorControlModeEnum,
+    XmAceEditorControlOptions,
+    XmAceEditorControlTypeEnum
+} from '@xm-ngx/components/ace-editor';
 import {FunctionSpec, XmEntitySpec, XmEntitySpecWrapperService} from '@xm-ngx/entity';
 import {BehaviorSubject, Observable, Subject} from 'rxjs';
 import {map, startWith, tap} from 'rxjs/operators';
@@ -16,7 +20,6 @@ import {
     processValidationMessages,
 } from '@xm-ngx/json-schema-form';
 import {EXAMPLES} from './example-schemas.model';
-import {XmAceEditorControlTypeEnum} from '@xm-ngx/components/ace-editor/ace-editor-control/xm-ace-editor-control.model';
 
 interface FormsConfig {
     key: string;
@@ -79,7 +82,7 @@ export class FormPlaygroundComponent implements OnInit {
     public submittedFormData: any = null;
     public aceEditorOptions: XmAceEditorControlOptions = {
         mode: XmAceEditorControlModeEnum.JSON,
-        type: XmAceEditorControlTypeEnum.OBJECT,
+        type: XmAceEditorControlTypeEnum.STRING,
         options: {
             highlightActiveLine: true,
             maxLines: 1000,

--- a/packages/administration/form-playground/form-playground.component.ts
+++ b/packages/administration/form-playground/form-playground.component.ts
@@ -1,12 +1,12 @@
-import { animate, state, style, transition, trigger } from '@angular/animations';
-import { HttpClient } from '@angular/common/http';
-import { Component, OnInit } from '@angular/core';
-import { UntypedFormControl } from '@angular/forms';
-import { ActivatedRoute } from '@angular/router';
-import { XmAceEditorControlOptions } from '@xm-ngx/components/ace-editor';
-import { FunctionSpec, XmEntitySpec, XmEntitySpecWrapperService } from '@xm-ngx/entity';
-import { BehaviorSubject, Observable, Subject } from 'rxjs';
-import { map, startWith, tap } from 'rxjs/operators';
+import {animate, state, style, transition, trigger} from '@angular/animations';
+import {HttpClient} from '@angular/common/http';
+import {Component, OnInit} from '@angular/core';
+import {UntypedFormControl} from '@angular/forms';
+import {ActivatedRoute} from '@angular/router';
+import {XmAceEditorControlModeEnum, XmAceEditorControlOptions} from '@xm-ngx/components/ace-editor';
+import {FunctionSpec, XmEntitySpec, XmEntitySpecWrapperService} from '@xm-ngx/entity';
+import {BehaviorSubject, Observable, Subject} from 'rxjs';
+import {map, startWith, tap} from 'rxjs/operators';
 
 import {
     addValidationComponent,
@@ -15,7 +15,8 @@ import {
     getJsfWidgets,
     processValidationMessages,
 } from '@xm-ngx/json-schema-form';
-import { EXAMPLES } from './example-schemas.model';
+import {EXAMPLES} from './example-schemas.model';
+import {XmAceEditorControlTypeEnum} from '@xm-ngx/components/ace-editor/ace-editor-control/xm-ace-editor-control.model';
 
 interface FormsConfig {
     key: string;
@@ -77,7 +78,8 @@ export class FormPlaygroundComponent implements OnInit {
     public formIsValid: boolean = null;
     public submittedFormData: any = null;
     public aceEditorOptions: XmAceEditorControlOptions = {
-        mode: 'json',
+        mode: XmAceEditorControlModeEnum.JSON,
+        type: XmAceEditorControlTypeEnum.OBJECT,
         options: {
             highlightActiveLine: true,
             maxLines: 1000,

--- a/packages/administration/specification-management/entity-spec-management/entity-spec-management.component.ts
+++ b/packages/administration/specification-management/entity-spec-management/entity-spec-management.component.ts
@@ -1,12 +1,15 @@
 import {Component, Input, OnInit} from '@angular/core';
 import {MatDialog} from '@angular/material/dialog';
-import {XmAceEditorControlModeEnum, XmAceEditorControlOptions} from '@xm-ngx/components/ace-editor';
+import {
+    XmAceEditorControlModeEnum,
+    XmAceEditorControlOptions,
+    XmAceEditorControlTypeEnum
+} from '@xm-ngx/components/ace-editor';
 import {StatesManagementDialogComponent} from '@xm-ngx/entity';
 import {XmConfigService} from '@xm-ngx/core/config';
 
 import {ConfigValidatorUtil} from '../config-validator/config-validator.util';
 import {ConfigVisualizerDialogComponent} from '../config-visualizer-dialog/config-visualizer-dialog.component';
-import {XmAceEditorControlTypeEnum} from '@xm-ngx/components/ace-editor/ace-editor-control/xm-ace-editor-control.model';
 
 @Component({
     selector: 'xm-entity-spec-mng',

--- a/packages/administration/specification-management/entity-spec-management/entity-spec-management.component.ts
+++ b/packages/administration/specification-management/entity-spec-management/entity-spec-management.component.ts
@@ -1,11 +1,12 @@
-import { Component, Input, OnInit } from '@angular/core';
-import { MatDialog } from '@angular/material/dialog';
-import { XmAceEditorControlOptions } from '@xm-ngx/components/ace-editor';
-import { StatesManagementDialogComponent } from '@xm-ngx/entity';
-import { XmConfigService } from '@xm-ngx/core/config';
+import {Component, Input, OnInit} from '@angular/core';
+import {MatDialog} from '@angular/material/dialog';
+import {XmAceEditorControlModeEnum, XmAceEditorControlOptions} from '@xm-ngx/components/ace-editor';
+import {StatesManagementDialogComponent} from '@xm-ngx/entity';
+import {XmConfigService} from '@xm-ngx/core/config';
 
-import { ConfigValidatorUtil } from '../config-validator/config-validator.util';
-import { ConfigVisualizerDialogComponent } from '../config-visualizer-dialog/config-visualizer-dialog.component';
+import {ConfigValidatorUtil} from '../config-validator/config-validator.util';
+import {ConfigVisualizerDialogComponent} from '../config-visualizer-dialog/config-visualizer-dialog.component';
+import {XmAceEditorControlTypeEnum} from '@xm-ngx/components/ace-editor/ace-editor-control/xm-ace-editor-control.model';
 
 @Component({
     selector: 'xm-entity-spec-mng',
@@ -21,7 +22,8 @@ export class EntitySpecManagementComponent implements OnInit {
     public entitySpecificationOut: string;
     public line: number;
     public aceEditorOptions: XmAceEditorControlOptions = {
-        mode: 'yaml',
+        mode: XmAceEditorControlModeEnum.YAML,
+        type: XmAceEditorControlTypeEnum.STRING,
         options: {
             highlightActiveLine: true,
             maxLines: 50,

--- a/packages/administration/specification-management/private-ui-mng/private-ui-mng.component.ts
+++ b/packages/administration/specification-management/private-ui-mng/private-ui-mng.component.ts
@@ -1,9 +1,10 @@
-import { Component, Input, OnInit } from '@angular/core';
-import { ConfigValidatorUtil } from '../config-validator/config-validator.util';
-import { XmAceEditorControlOptions } from '@xm-ngx/components/ace-editor';
-import { finalize } from 'rxjs/operators';
-import { XmConfigService } from '@xm-ngx/core/config';
-import { Principal } from '@xm-ngx/core/user';
+import {Component, Input, OnInit} from '@angular/core';
+import {ConfigValidatorUtil} from '../config-validator/config-validator.util';
+import {XmAceEditorControlModeEnum, XmAceEditorControlOptions} from '@xm-ngx/components/ace-editor';
+import {finalize} from 'rxjs/operators';
+import {XmConfigService} from '@xm-ngx/core/config';
+import {Principal} from '@xm-ngx/core/user';
+import {XmAceEditorControlTypeEnum} from '@xm-ngx/components/ace-editor/ace-editor-control/xm-ace-editor-control.model';
 
 @Component({
     selector: 'xm-private-ui-mng',
@@ -18,7 +19,8 @@ export class PrivateUiMngComponent implements OnInit {
     public isUiPrivateSpecValid: boolean;
     public uiPrivateSpecificationProgress: boolean;
     public aceEditorOptions: XmAceEditorControlOptions = {
-        mode: 'yaml',
+        mode: XmAceEditorControlModeEnum.JSON,
+        type: XmAceEditorControlTypeEnum.STRING,
         options: {
             highlightActiveLine: true,
             maxLines: 50,

--- a/packages/administration/specification-management/private-ui-mng/private-ui-mng.component.ts
+++ b/packages/administration/specification-management/private-ui-mng/private-ui-mng.component.ts
@@ -1,10 +1,13 @@
 import {Component, Input, OnInit} from '@angular/core';
 import {ConfigValidatorUtil} from '../config-validator/config-validator.util';
-import {XmAceEditorControlModeEnum, XmAceEditorControlOptions} from '@xm-ngx/components/ace-editor';
+import {
+    XmAceEditorControlModeEnum,
+    XmAceEditorControlOptions,
+    XmAceEditorControlTypeEnum
+} from '@xm-ngx/components/ace-editor';
 import {finalize} from 'rxjs/operators';
 import {XmConfigService} from '@xm-ngx/core/config';
 import {Principal} from '@xm-ngx/core/user';
-import {XmAceEditorControlTypeEnum} from '@xm-ngx/components/ace-editor/ace-editor-control/xm-ace-editor-control.model';
 
 @Component({
     selector: 'xm-private-ui-mng',
@@ -19,7 +22,7 @@ export class PrivateUiMngComponent implements OnInit {
     public isUiPrivateSpecValid: boolean;
     public uiPrivateSpecificationProgress: boolean;
     public aceEditorOptions: XmAceEditorControlOptions = {
-        mode: XmAceEditorControlModeEnum.JSON,
+        mode: XmAceEditorControlModeEnum.YAML,
         type: XmAceEditorControlTypeEnum.STRING,
         options: {
             highlightActiveLine: true,

--- a/packages/administration/specification-management/tenant-mng/tenant-mng.component.ts
+++ b/packages/administration/specification-management/tenant-mng/tenant-mng.component.ts
@@ -1,9 +1,12 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { ConfigValidatorUtil } from '../config-validator/config-validator.util';
-import {XmAceEditorControlModeEnum, XmAceEditorControlOptions} from '@xm-ngx/components/ace-editor';
+import {
+    XmAceEditorControlModeEnum,
+    XmAceEditorControlOptions,
+    XmAceEditorControlTypeEnum
+} from '@xm-ngx/components/ace-editor';
 import { finalize } from 'rxjs/operators';
 import { XmConfigService } from '@xm-ngx/core/config';
-import {XmAceEditorControlTypeEnum} from '@xm-ngx/components/ace-editor/ace-editor-control/xm-ace-editor-control.model';
 
 const TENANT_SPEC_PATH = '/tenant-config.yml';
 
@@ -21,7 +24,7 @@ export class TenantMngComponent implements OnInit {
     public isTenantSpecValid: boolean;
 
     public aceEditorOptions: XmAceEditorControlOptions = {
-        mode: XmAceEditorControlModeEnum.JSON,
+        mode: XmAceEditorControlModeEnum.YAML,
         type: XmAceEditorControlTypeEnum.STRING,
         options: {
             highlightActiveLine: true,

--- a/packages/administration/specification-management/tenant-mng/tenant-mng.component.ts
+++ b/packages/administration/specification-management/tenant-mng/tenant-mng.component.ts
@@ -1,8 +1,9 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { ConfigValidatorUtil } from '../config-validator/config-validator.util';
-import { XmAceEditorControlOptions } from '@xm-ngx/components/ace-editor';
+import {XmAceEditorControlModeEnum, XmAceEditorControlOptions} from '@xm-ngx/components/ace-editor';
 import { finalize } from 'rxjs/operators';
 import { XmConfigService } from '@xm-ngx/core/config';
+import {XmAceEditorControlTypeEnum} from '@xm-ngx/components/ace-editor/ace-editor-control/xm-ace-editor-control.model';
 
 const TENANT_SPEC_PATH = '/tenant-config.yml';
 
@@ -20,7 +21,8 @@ export class TenantMngComponent implements OnInit {
     public isTenantSpecValid: boolean;
 
     public aceEditorOptions: XmAceEditorControlOptions = {
-        mode: 'yaml',
+        mode: XmAceEditorControlModeEnum.JSON,
+        type: XmAceEditorControlTypeEnum.STRING,
         options: {
             highlightActiveLine: true,
             maxLines: 50,

--- a/packages/administration/specification-management/timeline-mng/timeline-mng.component.ts
+++ b/packages/administration/specification-management/timeline-mng/timeline-mng.component.ts
@@ -1,8 +1,11 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { SpecificationManagementComponent } from '../specification-management.component';
-import {XmAceEditorControlModeEnum, XmAceEditorControlOptions} from '@xm-ngx/components/ace-editor';
+import {
+    XmAceEditorControlModeEnum,
+    XmAceEditorControlOptions,
+    XmAceEditorControlTypeEnum
+} from '@xm-ngx/components/ace-editor';
 import { XmConfigService } from '@xm-ngx/core/config';
-import {XmAceEditorControlTypeEnum} from '@xm-ngx/components/ace-editor/ace-editor-control/xm-ace-editor-control.model';
 
 @Component({
     selector: 'xm-timeline-mng',
@@ -17,7 +20,7 @@ export class TimelineMngComponent implements OnInit {
     public isTimelineSpecValid: boolean;
 
     public aceEditorOptions: XmAceEditorControlOptions = {
-        mode: XmAceEditorControlModeEnum.JSON,
+        mode: XmAceEditorControlModeEnum.YAML,
         type: XmAceEditorControlTypeEnum.STRING,
         options: {
             highlightActiveLine: true,

--- a/packages/administration/specification-management/timeline-mng/timeline-mng.component.ts
+++ b/packages/administration/specification-management/timeline-mng/timeline-mng.component.ts
@@ -1,7 +1,8 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { SpecificationManagementComponent } from '../specification-management.component';
-import { XmAceEditorControlOptions } from '@xm-ngx/components/ace-editor';
+import {XmAceEditorControlModeEnum, XmAceEditorControlOptions} from '@xm-ngx/components/ace-editor';
 import { XmConfigService } from '@xm-ngx/core/config';
+import {XmAceEditorControlTypeEnum} from '@xm-ngx/components/ace-editor/ace-editor-control/xm-ace-editor-control.model';
 
 @Component({
     selector: 'xm-timeline-mng',
@@ -16,7 +17,8 @@ export class TimelineMngComponent implements OnInit {
     public isTimelineSpecValid: boolean;
 
     public aceEditorOptions: XmAceEditorControlOptions = {
-        mode: 'yaml',
+        mode: XmAceEditorControlModeEnum.JSON,
+        type: XmAceEditorControlTypeEnum.STRING,
         options: {
             highlightActiveLine: true,
             maxLines: 50,

--- a/packages/administration/specification-management/uaa-login-mng/uaa-login-mng.component.ts
+++ b/packages/administration/specification-management/uaa-login-mng/uaa-login-mng.component.ts
@@ -1,7 +1,8 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { SpecificationManagementComponent } from '../specification-management.component';
-import { XmAceEditorControlOptions } from '@xm-ngx/components/ace-editor';
+import {XmAceEditorControlModeEnum, XmAceEditorControlOptions} from '@xm-ngx/components/ace-editor';
 import { XmConfigService } from '@xm-ngx/core/config';
+import {XmAceEditorControlTypeEnum} from '@xm-ngx/components/ace-editor/ace-editor-control/xm-ace-editor-control.model';
 
 @Component({
     selector: 'xm-uaa-login-mng',
@@ -17,7 +18,8 @@ export class UaaLoginMngComponent implements OnInit {
     public loginsValidation: any;
 
     public aceEditorOptions: XmAceEditorControlOptions = {
-        mode: 'yaml',
+        mode: XmAceEditorControlModeEnum.JSON,
+        type: XmAceEditorControlTypeEnum.STRING,
         options: {
             highlightActiveLine: true,
             maxLines: 50,

--- a/packages/administration/specification-management/uaa-login-mng/uaa-login-mng.component.ts
+++ b/packages/administration/specification-management/uaa-login-mng/uaa-login-mng.component.ts
@@ -1,8 +1,11 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { SpecificationManagementComponent } from '../specification-management.component';
-import {XmAceEditorControlModeEnum, XmAceEditorControlOptions} from '@xm-ngx/components/ace-editor';
+import {
+    XmAceEditorControlModeEnum,
+    XmAceEditorControlOptions,
+    XmAceEditorControlTypeEnum
+} from '@xm-ngx/components/ace-editor';
 import { XmConfigService } from '@xm-ngx/core/config';
-import {XmAceEditorControlTypeEnum} from '@xm-ngx/components/ace-editor/ace-editor-control/xm-ace-editor-control.model';
 
 @Component({
     selector: 'xm-uaa-login-mng',
@@ -18,7 +21,7 @@ export class UaaLoginMngComponent implements OnInit {
     public loginsValidation: any;
 
     public aceEditorOptions: XmAceEditorControlOptions = {
-        mode: XmAceEditorControlModeEnum.JSON,
+        mode: XmAceEditorControlModeEnum.YAML,
         type: XmAceEditorControlTypeEnum.STRING,
         options: {
             highlightActiveLine: true,

--- a/packages/administration/specification-management/uaa-mng/uaa-mng.component.ts
+++ b/packages/administration/specification-management/uaa-mng/uaa-mng.component.ts
@@ -1,8 +1,11 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { SpecificationManagementComponent } from '../specification-management.component';
-import {XmAceEditorControlModeEnum, XmAceEditorControlOptions} from '@xm-ngx/components/ace-editor';
+import {
+    XmAceEditorControlModeEnum,
+    XmAceEditorControlOptions,
+    XmAceEditorControlTypeEnum
+} from '@xm-ngx/components/ace-editor';
 import { XmConfigService } from '@xm-ngx/core/config';
-import {XmAceEditorControlTypeEnum} from '@xm-ngx/components/ace-editor/ace-editor-control/xm-ace-editor-control.model';
 
 @Component({
     selector: 'xm-uaa-mng',
@@ -17,7 +20,7 @@ export class UaaMngComponent implements OnInit {
     public isUaaSpecValid: boolean;
 
     public aceEditorOptions: XmAceEditorControlOptions = {
-        mode: XmAceEditorControlModeEnum.JSON,
+        mode: XmAceEditorControlModeEnum.YAML,
         type: XmAceEditorControlTypeEnum.STRING,
         options: {
             highlightActiveLine: true,

--- a/packages/administration/specification-management/uaa-mng/uaa-mng.component.ts
+++ b/packages/administration/specification-management/uaa-mng/uaa-mng.component.ts
@@ -1,7 +1,8 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { SpecificationManagementComponent } from '../specification-management.component';
-import { XmAceEditorControlOptions } from '@xm-ngx/components/ace-editor';
+import {XmAceEditorControlModeEnum, XmAceEditorControlOptions} from '@xm-ngx/components/ace-editor';
 import { XmConfigService } from '@xm-ngx/core/config';
+import {XmAceEditorControlTypeEnum} from '@xm-ngx/components/ace-editor/ace-editor-control/xm-ace-editor-control.model';
 
 @Component({
     selector: 'xm-uaa-mng',
@@ -16,7 +17,8 @@ export class UaaMngComponent implements OnInit {
     public isUaaSpecValid: boolean;
 
     public aceEditorOptions: XmAceEditorControlOptions = {
-        mode: 'yaml',
+        mode: XmAceEditorControlModeEnum.JSON,
+        type: XmAceEditorControlTypeEnum.STRING,
         options: {
             highlightActiveLine: true,
             maxLines: 50,

--- a/packages/administration/specification-management/ui-mng/ui-mng.component.ts
+++ b/packages/administration/specification-management/ui-mng/ui-mng.component.ts
@@ -1,8 +1,9 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { ConfigValidatorUtil } from '../config-validator/config-validator.util';
-import { XmAceEditorControlOptions } from '@xm-ngx/components/ace-editor';
+import {XmAceEditorControlModeEnum, XmAceEditorControlOptions} from '@xm-ngx/components/ace-editor';
 import { finalize } from 'rxjs/operators';
 import { XmConfigService } from '@xm-ngx/core/config';
+import {XmAceEditorControlTypeEnum} from '@xm-ngx/components/ace-editor/ace-editor-control/xm-ace-editor-control.model';
 
 @Component({
     selector: 'xm-ui-mng',
@@ -19,7 +20,8 @@ export class UiMngComponent implements OnInit {
     public uiSpecificationProgress: boolean;
 
     public aceEditorOptions: XmAceEditorControlOptions = {
-        mode: 'yaml',
+        mode: XmAceEditorControlModeEnum.JSON,
+        type: XmAceEditorControlTypeEnum.STRING,
         height: '700px',
     };
 

--- a/packages/administration/specification-management/ui-mng/ui-mng.component.ts
+++ b/packages/administration/specification-management/ui-mng/ui-mng.component.ts
@@ -1,9 +1,12 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { ConfigValidatorUtil } from '../config-validator/config-validator.util';
-import {XmAceEditorControlModeEnum, XmAceEditorControlOptions} from '@xm-ngx/components/ace-editor';
+import {
+    XmAceEditorControlModeEnum,
+    XmAceEditorControlOptions,
+    XmAceEditorControlTypeEnum
+} from '@xm-ngx/components/ace-editor';
 import { finalize } from 'rxjs/operators';
 import { XmConfigService } from '@xm-ngx/core/config';
-import {XmAceEditorControlTypeEnum} from '@xm-ngx/components/ace-editor/ace-editor-control/xm-ace-editor-control.model';
 
 @Component({
     selector: 'xm-ui-mng',
@@ -20,7 +23,7 @@ export class UiMngComponent implements OnInit {
     public uiSpecificationProgress: boolean;
 
     public aceEditorOptions: XmAceEditorControlOptions = {
-        mode: XmAceEditorControlModeEnum.JSON,
+        mode: XmAceEditorControlModeEnum.YAML,
         type: XmAceEditorControlTypeEnum.STRING,
         height: '700px',
     };

--- a/packages/components/ace-editor/ace-editor-control/xm-ace-editor-control.model.ts
+++ b/packages/components/ace-editor/ace-editor-control/xm-ace-editor-control.model.ts
@@ -1,0 +1,24 @@
+export interface XmAceEditorControlOptions {
+    id?: string;
+    title?: string;
+    name?: string;
+    mode: string | XmAceEditorControlModeEnum;
+    height?: string;
+    theme?: string;
+    darkTheme?: string;
+    enableInitialFocus?: boolean;
+    options?: {
+        highlightActiveLine?: boolean;
+        maxLines?: number;
+        tabSize?: number;
+        printMargin?: boolean;
+        autoScrollEditorIntoView?: boolean;
+    },
+}
+
+export enum XmAceEditorControlModeEnum {
+    OBJECT_TO_JSON = 'object-to-json',
+    OBJECT_TO_YAML = 'object-to-yaml',
+    JSON = 'json',
+    YAML = 'yaml'
+}

--- a/packages/components/ace-editor/ace-editor-control/xm-ace-editor-control.model.ts
+++ b/packages/components/ace-editor/ace-editor-control/xm-ace-editor-control.model.ts
@@ -2,7 +2,8 @@ export interface XmAceEditorControlOptions {
     id?: string;
     title?: string;
     name?: string;
-    mode: string | XmAceEditorControlModeEnum;
+    mode: XmAceEditorControlModeEnum;
+    type: XmAceEditorControlTypeEnum;
     height?: string;
     theme?: string;
     darkTheme?: string;
@@ -17,8 +18,11 @@ export interface XmAceEditorControlOptions {
 }
 
 export enum XmAceEditorControlModeEnum {
-    OBJECT_TO_JSON = 'object-to-json',
-    OBJECT_TO_YAML = 'object-to-yaml',
     JSON = 'json',
     YAML = 'yaml'
+}
+
+export enum XmAceEditorControlTypeEnum {
+    OBJECT = 'object',
+    STRING = 'string'
 }

--- a/packages/components/ace-editor/ace-editor-control/xm-ace-editor-control.spec.ts
+++ b/packages/components/ace-editor/ace-editor-control/xm-ace-editor-control.spec.ts
@@ -2,8 +2,11 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {XmAceEditorControl} from './xm-ace-editor-control';
 import {ControlErrorModule} from '@xm-ngx/components/control-error';
 import {XmTranslationTestingModule} from '@xm-ngx/translation/testing';
-import {XmAceEditorControlModeEnum, XmAceEditorControlOptions} from '@xm-ngx/components/ace-editor';
-import {XmAceEditorControlTypeEnum} from '@xm-ngx/components/ace-editor/ace-editor-control/xm-ace-editor-control.model';
+import {
+    XmAceEditorControlModeEnum,
+    XmAceEditorControlOptions,
+    XmAceEditorControlTypeEnum
+} from '@xm-ngx/components/ace-editor';
 
 describe('XmAceEditorControl', () => {
     let fixture: ComponentFixture<XmAceEditorControl>;

--- a/packages/components/ace-editor/ace-editor-control/xm-ace-editor-control.spec.ts
+++ b/packages/components/ace-editor/ace-editor-control/xm-ace-editor-control.spec.ts
@@ -1,7 +1,9 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { XmAceEditorControl, XmAceEditorControlOptions } from './xm-ace-editor-control';
-import { ControlErrorModule } from '@xm-ngx/components/control-error';
-import { XmTranslationTestingModule } from '@xm-ngx/translation/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {XmAceEditorControl} from './xm-ace-editor-control';
+import {ControlErrorModule} from '@xm-ngx/components/control-error';
+import {XmTranslationTestingModule} from '@xm-ngx/translation/testing';
+import {XmAceEditorControlModeEnum, XmAceEditorControlOptions} from '@xm-ngx/components/ace-editor';
+import {XmAceEditorControlTypeEnum} from '@xm-ngx/components/ace-editor/ace-editor-control/xm-ace-editor-control.model';
 
 describe('XmAceEditorControl', () => {
     let fixture: ComponentFixture<XmAceEditorControl>;
@@ -31,7 +33,8 @@ describe('XmAceEditorControl', () => {
             options: {},
             title: '',
             name: 'text',
-            mode: 'json',
+            mode: XmAceEditorControlModeEnum.JSON,
+            type: XmAceEditorControlTypeEnum.OBJECT,
             height: '200px',
             theme: 'chrome',
             darkTheme: 'tomorrow_night',
@@ -51,7 +54,11 @@ describe('XmAceEditorControl', () => {
     });
 
     it('should parse JSON input value when mode is "json"', () => {
-        component.config.mode = 'json';
+        component.config = {
+            ...component.config,
+            mode: XmAceEditorControlModeEnum.JSON,
+            type: XmAceEditorControlTypeEnum.STRING,
+        };
         const jsonValue = '{"key": "value"}';
         component.value = jsonValue;
         fixture.detectChanges();
@@ -60,7 +67,11 @@ describe('XmAceEditorControl', () => {
     });
 
     it('should stringify value when mode is "object-to-json" and input value is an object', () => {
-        component.config.mode = 'object-to-json';
+        component.config = {
+            ...component.config,
+            mode: XmAceEditorControlModeEnum.JSON,
+            type: XmAceEditorControlTypeEnum.OBJECT,
+        };
         const objectValue = { key: 'value' };
         component.value = objectValue;
         fixture.detectChanges();
@@ -69,7 +80,11 @@ describe('XmAceEditorControl', () => {
     });
 
     it('should handle JSON input value when mode is "json"', () => {
-        component.config.mode = 'json';
+        component.config = {
+            ...component.config,
+            mode: XmAceEditorControlModeEnum.JSON,
+            type: XmAceEditorControlTypeEnum.STRING,
+        };
         const jsonValue = '{key: "value"}';
         component.value = jsonValue;
         fixture.detectChanges();
@@ -78,7 +93,11 @@ describe('XmAceEditorControl', () => {
     });
 
     it('should parse YAML input value when mode is "yaml"', () => {
-        component.config.mode = 'yaml';
+        component.config = {
+            ...component.config,
+            mode: XmAceEditorControlModeEnum.YAML,
+            type: XmAceEditorControlTypeEnum.STRING,
+        };
         const yamlValue = 'key: value';
         component.value = yamlValue;
         fixture.detectChanges();
@@ -87,7 +106,11 @@ describe('XmAceEditorControl', () => {
     });
 
     it('should stringify value when mode is "object-to-yaml" and input value is an object', () => {
-        component.config.mode = 'object-to-yaml';
+        component.config = {
+            ...component.config,
+            mode: XmAceEditorControlModeEnum.YAML,
+            type: XmAceEditorControlTypeEnum.OBJECT,
+        };
         const objectValue = { key: 'value' };
         component.value = objectValue;
         void expect(component.value).toEqual(objectValue);

--- a/packages/components/ace-editor/ace-editor-control/xm-ace-editor-control.stories.ts
+++ b/packages/components/ace-editor/ace-editor-control/xm-ace-editor-control.stories.ts
@@ -5,14 +5,13 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import {
-    XmAceEditorControl, XmAceEditorControlModeEnum,
+    XmAceEditorControl, XmAceEditorControlModeEnum, XmAceEditorControlTypeEnum,
     XmAceEditorDirective,
     XmAceEditorThemeSchemeAdapterDirective,
 } from '@xm-ngx/components/ace-editor';
 import { ControlErrorModule } from '@xm-ngx/components/control-error';
 import { XM_VALIDATOR_PROCESSING_CONTROL_ERRORS_TRANSLATES } from '@xm-ngx/components/validator-processing';
 import { XmTranslationTestingModule } from '@xm-ngx/translation/testing';
-import {XmAceEditorControlTypeEnum} from '@xm-ngx/components/ace-editor/ace-editor-control/xm-ace-editor-control.model';
 
 export default {
     title: 'Core/Control/Text/Ace editor',

--- a/packages/components/ace-editor/ace-editor-control/xm-ace-editor-control.stories.ts
+++ b/packages/components/ace-editor/ace-editor-control/xm-ace-editor-control.stories.ts
@@ -5,13 +5,14 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import {
-    XmAceEditorControl,
+    XmAceEditorControl, XmAceEditorControlModeEnum,
     XmAceEditorDirective,
     XmAceEditorThemeSchemeAdapterDirective,
 } from '@xm-ngx/components/ace-editor';
 import { ControlErrorModule } from '@xm-ngx/components/control-error';
 import { XM_VALIDATOR_PROCESSING_CONTROL_ERRORS_TRANSLATES } from '@xm-ngx/components/validator-processing';
 import { XmTranslationTestingModule } from '@xm-ngx/translation/testing';
+import {XmAceEditorControlTypeEnum} from '@xm-ngx/components/ace-editor/ace-editor-control/xm-ace-editor-control.model';
 
 export default {
     title: 'Core/Control/Text/Ace editor',
@@ -39,28 +40,28 @@ export default {
 
 export const ModeJson: StoryObj<XmAceEditorControl> = {
     args: {
-        config: { mode: 'json' },
+        config: { mode: XmAceEditorControlModeEnum.JSON, type: XmAceEditorControlTypeEnum.STRING },
         value: '{"prop1":"value1","prop2":true}',
     },
 };
 
 export const ModeObjectToJson: StoryObj<XmAceEditorControl> = {
     args: {
-        config: { mode: 'object-to-json' },
+        config: { mode: XmAceEditorControlModeEnum.JSON, type: XmAceEditorControlTypeEnum.OBJECT },
         value: {'prop1':'value1','prop2':true},
     },
 };
 
 export const ModeYaml: StoryObj<XmAceEditorControl> = {
     args: {
-        config: { mode: 'yaml' },
+        config: { mode: XmAceEditorControlModeEnum.YAML, type: XmAceEditorControlTypeEnum.STRING },
         value: 'prop1:value1,prop2:true',
     },
 };
 
 export const ModeObjectToYaml: StoryObj<XmAceEditorControl> = {
     args: {
-        config: { mode: 'object-to-yaml' },
+        config: { mode: XmAceEditorControlModeEnum.YAML, type: XmAceEditorControlTypeEnum.OBJECT },
         value: {'prop1':'value1','prop2':true},
     },
 };

--- a/packages/components/ace-editor/ace-editor-control/xm-ace-editor-control.ts
+++ b/packages/components/ace-editor/ace-editor-control/xm-ace-editor-control.ts
@@ -8,8 +8,11 @@ import {MatFormFieldModule} from '@angular/material/form-field';
 import {ControlErrorModule} from '@xm-ngx/components/control-error';
 import {parse, stringify} from 'yaml';
 import {Defaults} from '@xm-ngx/operators';
-import {XmAceEditorControlModeEnum, XmAceEditorControlOptions} from '@xm-ngx/components/ace-editor';
-import {XmAceEditorControlTypeEnum} from '@xm-ngx/components/ace-editor/ace-editor-control/xm-ace-editor-control.model';
+import {
+    XmAceEditorControlModeEnum,
+    XmAceEditorControlOptions,
+    XmAceEditorControlTypeEnum
+} from './xm-ace-editor-control.model';
 
 const XM_ACE_EDITOR_CONTROL_DEFAULT_OPTIONS: XmAceEditorControlOptions = {
     options: {},

--- a/packages/components/ace-editor/ace-editor-control/xm-ace-editor-control.ts
+++ b/packages/components/ace-editor/ace-editor-control/xm-ace-editor-control.ts
@@ -8,45 +8,13 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { ControlErrorModule } from '@xm-ngx/components/control-error';
 import { parse, stringify } from 'yaml';
 import { Defaults } from '@xm-ngx/operators';
-
-/**
- *
- * yaml - string
- * json - string
- * object-to-yaml - object
- * object-to-json - object
- *
- */
-export enum XmAceEditorControlOptionsModeType {
-    'yaml' = 'yaml',
-    'json' = 'json',
-    'object-to-yaml' = 'object-to-yaml',
-    'object-to-json' = 'object-to-json',
-}
-
-export interface XmAceEditorControlOptions {
-    id?: string;
-    title?: string;
-    name?: string;
-    mode: string | XmAceEditorControlOptionsModeType;
-    height?: string;
-    theme?: string;
-    darkTheme?: string;
-    enableInitialFocus?: boolean;
-    options?: {
-        highlightActiveLine?: boolean;
-        maxLines?: number;
-        tabSize?: number;
-        printMargin?: boolean;
-        autoScrollEditorIntoView?: boolean;
-    },
-}
+import {XmAceEditorControlModeEnum, XmAceEditorControlOptions} from '@xm-ngx/components/ace-editor';
 
 const XM_ACE_EDITOR_CONTROL_DEFAULT_OPTIONS: XmAceEditorControlOptions = {
     options: {},
     title: '',
     name: 'text',
-    mode: 'json',
+    mode: XmAceEditorControlModeEnum.JSON,
     height: '200px',
     theme: 'chrome',
     darkTheme: 'tomorrow_night',
@@ -104,9 +72,11 @@ export class XmAceEditorControl extends NgControlAccessor<AceEditorValue> {
     public get value(): AceEditorValue {
         try {
             switch (this.config.mode) {
-                case 'object-to-json':
+                case XmAceEditorControlModeEnum.OBJECT_TO_JSON:
+                case XmAceEditorControlModeEnum.JSON:
                     return JSON.parse(this._value);
-                case 'object-to-yaml':
+                case XmAceEditorControlModeEnum.OBJECT_TO_YAML:
+                case XmAceEditorControlModeEnum.YAML:
                     return parse(this._value);
             }
             return this._value;
@@ -122,14 +92,17 @@ export class XmAceEditorControl extends NgControlAccessor<AceEditorValue> {
     public set value(value: AceEditorValue) {
         try {
             switch (this.config.mode) {
-                case 'object-to-yaml':
+                case XmAceEditorControlModeEnum.OBJECT_TO_YAML:
+                case XmAceEditorControlModeEnum.YAML:
                     this._value = stringify(value, { blockQuote: 'literal' });
                     return;
-                case 'object-to-json':
-                    this._value = JSON.stringify(value);
+                case XmAceEditorControlModeEnum.OBJECT_TO_JSON:
+                case XmAceEditorControlModeEnum.JSON:
+                    this._value = JSON.stringify(value, null, 2);
                     return;
+                default:
+                    this._value = '';
             }
-            this._value = value as string;
         } catch (e) {
             this.error = e;
         }
@@ -137,12 +110,12 @@ export class XmAceEditorControl extends NgControlAccessor<AceEditorValue> {
 
     public getMode(): string | null {
         switch (this.config.mode) {
-            case 'object-to-yaml':
-            case 'yaml':
-                return 'yaml';
-            case 'object-to-json':
-            case 'json':
-                return 'json';
+            case XmAceEditorControlModeEnum.OBJECT_TO_YAML:
+            case XmAceEditorControlModeEnum.YAML:
+                return XmAceEditorControlModeEnum.YAML;
+            case XmAceEditorControlModeEnum.OBJECT_TO_JSON:
+            case XmAceEditorControlModeEnum.JSON:
+                return XmAceEditorControlModeEnum.JSON;
         }
         return null;
     }

--- a/packages/components/ace-editor/index.ts
+++ b/packages/components/ace-editor/index.ts
@@ -1,6 +1,7 @@
 export {
     XmAceEditorControlOptions,
     XmAceEditorControlModeEnum,
+    XmAceEditorControlTypeEnum
 } from './ace-editor-control/xm-ace-editor-control.model';
 
 export {

--- a/packages/components/ace-editor/index.ts
+++ b/packages/components/ace-editor/index.ts
@@ -1,5 +1,9 @@
 export {
     XmAceEditorControlOptions,
+    XmAceEditorControlModeEnum,
+} from './ace-editor-control/xm-ace-editor-control.model';
+
+export {
     XmAceEditorControl,
 } from './ace-editor-control/xm-ace-editor-control';
 

--- a/packages/components/ace-editor/xm-ace-editor.directive.ts
+++ b/packages/components/ace-editor/xm-ace-editor.directive.ts
@@ -132,7 +132,7 @@ export class XmAceEditorDirective<O = unknown> implements OnDestroy {
 
     private updateValue(): void {
         const newVal = this.editor.getValue();
-        
+
         if (this.oldText != null) {
             this.textChanged.emit(newVal);
         }

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -65,3 +65,8 @@ import '@angular/localize/init';
 
 // Fix charlist, Error: Global not defined
 (window as any).global = window;
+
+// Fix ace-editor, when it throws an error ReferenceError: process is not defined
+(window as any).process = {
+    env: { DEBUG: undefined },
+};


### PR DESCRIPTION
After YAML support was added, JSON support broke.
- Add fixes to support object-to-JSON conversion
- Rollback JSON formatting
- Replace strings to Enum
- Move Interface and Enum to the model file