### PR TITLE
autocomplete-control: Empty search result case

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "5.3.23",
+  "version": "5.3.24",
   "release": "5.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/packages/components/autocomplete-control/autocomplete-control.ts
+++ b/packages/components/autocomplete-control/autocomplete-control.ts
@@ -169,6 +169,9 @@ export class XmAutocompleteControl extends NgModelWrapper<object | string> imple
             debounceTime(300),
             filter(searchQuery => searchQuery?.length === 0 || (searchQuery?.length >= this.config.startFromCharSearch)),
             switchMap((searchQuery) => {
+                if (this.isEmptySearchResult(searchQuery)) {
+                    return of([]);
+                }
                 return this.searchByQuery(searchQuery).pipe(
                     catchError(() => of([])),
                 );
@@ -195,6 +198,11 @@ export class XmAutocompleteControl extends NgModelWrapper<object | string> imple
         if (this.config.startEmptySearch) {
             this.searchQueryControl.setValue('');
         }
+    }
+
+    private isEmptySearchResult(searchQuery: string): boolean {
+        const isSearchLimited: boolean = searchQuery?.length < this.config.startFromCharSearch;
+        return !this.config.startEmptySearch && (!searchQuery?.length || isSearchLimited);
     }
 
     public ngOnChanges(changes: SimpleChanges): void {


### PR DESCRIPTION
- Add logic to return empty array for the case when on empty search shouldn't be any results.