### PR TITLE
Fix empty query params error

### DIFF
--- a/packages/components/table/controllers/filters/xm-table-query-params-store.service.ts
+++ b/packages/components/table/controllers/filters/xm-table-query-params-store.service.ts
@@ -89,7 +89,7 @@ export class XmTableQueryParamsStoreService {
         const keysToCheck: string[] = ['pageIndex', 'pageSize', 'sortBy', 'sortOrder'];
         const changedValues: PageableAndSortable = {};
         keysToCheck.forEach((key: string) => {
-            if (configParams[key].toString() !== pageableAndSortable[key].toString()) {
+            if (configParams[key] && pageableAndSortable[key] && configParams[key].toString() !== pageableAndSortable[key].toString()) {
                 changedValues[key] = pageableAndSortable[key];
             }
         });


### PR DESCRIPTION
When some of `keysToCheck` has not defined we will face with the problem of `reading *** of undefined`. Looks like if we ignore them, everything will work fine.