### PR TITLE
Fix/xm multiple enum comtrol set empty value to control

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "6.0.76",
+  "version": "6.0.77",
   "release": "6.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/packages/components/enum/multiple-control/xm-multiple-enum-control.component.ts
+++ b/packages/components/enum/multiple-control/xm-multiple-enum-control.component.ts
@@ -9,7 +9,7 @@ import { XmEnumViewOptions } from '../view/xm-enum-view';
 import { HintModule, HintText } from '@xm-ngx/components/hint';
 import { XmTranslationModule } from '@xm-ngx/translation';
 import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatSelectModule } from '@angular/material/select';
+import { MatSelectChange, MatSelectModule } from '@angular/material/select';
 import { FormsModule, NgControl, ReactiveFormsModule } from '@angular/forms';
 import { MatIconModule } from '@angular/material/icon';
 import { CommonModule } from '@angular/common';
@@ -40,6 +40,7 @@ export const XM_MULTIPLE_ENUM_CONTROL_OPTIONS_DEFAULT: XmMultipleEnumControlOpti
                         [required]="config.required"
                         [id]="config.id"
                         [attr.data-qa]="config.dataQa"
+                        (selectionChange)="selectionsChange($event)"
                         multiple>
                 <mat-select-trigger>
                     <ng-container *ngIf="itemsMap && itemsMap[value[0] + '']">
@@ -115,5 +116,11 @@ export class XmMultipleEnumControl
             }
         });
         this.itemsMap = keyBy(this.itemsList, 'value');
+    }
+
+    public selectionsChange(res: MatSelectChange): void {
+        if (res.value?.length === 0) {
+            this.control.patchValue(null);
+        }
     }
 }


### PR DESCRIPTION
Fixed a case when the user chose one of the options, and then canceled his choice, then instead of null in the control, a significant empty array was defined.