### PR TITLE
Feat/xm link add static query params

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "6.0.84",
+  "version": "6.0.85",
   "release": "6.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "6.0.82",
+  "version": "6.0.83",
   "release": "6.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/packages/components/link/xm-link.ts
+++ b/packages/components/link/xm-link.ts
@@ -4,13 +4,15 @@ import { MatIconModule } from '@angular/material/icon';
 import { RouterModule } from '@angular/router';
 import { XmDynamicPresentation } from '@xm-ngx/dynamic';
 import { IId } from '@xm-ngx/interfaces';
-import { interpolate, transformByMap } from '@xm-ngx/operators';
+import { flattenObjectDeep, interpolate, transformByMap } from '@xm-ngx/operators';
 import { Translate, XmTranslationModule } from '@xm-ngx/translation';
 import { clone, get, isString } from 'lodash';
 
 export interface XmLinkOptions {
     /** list of fields which will be transformed to queryParams */
     queryParamsFromEntityFields?: { [key: string]: string };
+    /** list of fields which will fill statically queryParams */
+    staticQueryParams?: { [key: string]: string };
     /** string is field path or regular url */
     routerLink: string[] | string;
     /** Set field text from configuration */
@@ -24,7 +26,7 @@ export interface XmLinkOptions {
 }
 
 export const XM_LINK_DEFAULT_OPTIONS: XmLinkOptions = {
-    queryParamsFromEntityFields: {'id': 'id'},
+    queryParamsFromEntityFields: { 'id': 'id' },
     routerLink: [],
     valueField: 'id',
     valueTitle: null,
@@ -66,9 +68,14 @@ export class XmLink implements XmDynamicPresentation<IId, XmLinkOptions>, OnInit
             return;
         }
 
+        const queryParamsFromEntityFields = transformByMap<IId, object, object>(this.value, this.config?.queryParamsFromEntityFields || this.config?.config?.queryParamsFromEntityFields || this.defaultOptions.queryParamsFromEntityFields);
+
         this.fieldValue = get(this.value, this.config?.valueField || this.config?.config?.valueField || this.defaultOptions.valueField, null);
         this.fieldTitle = this.config?.valueTitle || this.config?.config?.valueTitle;
-        this.queryParams = transformByMap(this.value, this.config?.queryParamsFromEntityFields || this.config?.config?.queryParamsFromEntityFields || this.defaultOptions.queryParamsFromEntityFields);
+        this.queryParams = {
+            ...this.config?.staticQueryParams,
+            ...flattenObjectDeep(queryParamsFromEntityFields, ''),
+        };
 
         const routerLink = this.config?.routerLink || this.config?.config?.routerLink;
 


### PR DESCRIPTION
1) Added the ability to define static queried parameters that are not related to the entity
![Знімок екрана 2024-04-02 о 11 47 45](https://github.com/xm-online/xm-webapp/assets/53058777/19cfa8f0-8cdd-4783-9dec-756b9c786282)

![Знімок екрана 2024-04-02 о 11 48 18](https://github.com/xm-online/xm-webapp/assets/53058777/28816aa0-c64f-409b-a3e9-15959891d662)

2) Fixed definition of query parameters with complex path
    Example: entity.property.id