### PR TITLE
fix: Menu parent node as a link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "6.0.111",
+  "version": "6.0.112",
   "release": "6.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/packages/components/menu/menu.component.html
+++ b/packages/components/menu/menu.component.html
@@ -36,6 +36,7 @@
             'active-with-stretch': isMaterial3Menu && !node.children?.length && node?.category === selectedCategory,
             'rounded-menu-link': isMaterial3Menu,
          }"
+         [href]="node.slug"
          [attr.data-qa]="node.dataQa || 'default-menu-parent-key'"
       >
         <mat-icon class="menu-icon" *ngIf="!isMaterial3Menu">{{node.icon}}</mat-icon>

--- a/packages/components/menu/menu.interface.ts
+++ b/packages/components/menu/menu.interface.ts
@@ -36,6 +36,10 @@ export interface MenuItem extends DataQa {
     position: number;
     permission?: string | string[];
     url: string[];
+    /**
+     * Slug added automatically by JS mapping. Look in nested-menu.ts.
+     */
+    slug?: string;
     icon: string;
     title: Translate;
     parent: MenuItem,

--- a/packages/components/menu/nested-menu.ts
+++ b/packages/components/menu/nested-menu.ts
@@ -114,6 +114,7 @@ export function buildMenuTree(dashboards: Dashboard[], checkCondition?: typeof C
                         title: menuName || configName || dashboardName,
                         permission: permission || 'DASHBOARD.GET_LIST',
                         url: [ 'dashboard', ...slug.split('/') ],
+                        slug: `dashboard/${slug}`,
                         parent: tree,
                         children: [],
                         activeItemPathPatterns,


### PR DESCRIPTION
Now all elements in menu behaves as a link, not only nested elements in accordions.