### PR TITLE
Fix/trigger table after init

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "6.0.112",
+  "version": "6.0.113",
   "release": "6.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/packages/components/table/collections/xm-table-array-collection-controller.ts
+++ b/packages/components/table/collections/xm-table-array-collection-controller.ts
@@ -1,17 +1,15 @@
-import { inject, Injectable, Injector, OnDestroy } from '@angular/core';
-import {
-    XmDynamicInstanceService,
-} from '@xm-ngx/dynamic';
-import { XmConfig } from '@xm-ngx/interfaces';
-import { UUID } from 'angular2-uuid';
-import { cloneDeep, get, isFunction, set } from 'lodash';
-import { Subject, isObservable, of, filter, switchMap, take, tap, Observable } from 'rxjs';
-import { XmTableEntityController } from '../controllers/entity/xm-table-entity-controller.service';
-import { AXmTableLocalPageableCollectionController } from './a-xm-table-local-pageable-collection-controller.service';
-import { IXmTableCollectionController, XmFilterQueryParams } from './i-xm-table-collection-controller';
-import { XmToasterService } from '@xm-ngx/toaster';
-import { XmAlertService } from '@xm-ngx/alert';
-import { takeUntilOnDestroy, takeUntilOnDestroyDestroy } from '@xm-ngx/operators';
+import {inject, Injectable, Injector, OnDestroy} from '@angular/core';
+import {XmDynamicInstanceService,} from '@xm-ngx/dynamic';
+import {XmConfig} from '@xm-ngx/interfaces';
+import {UUID} from 'angular2-uuid';
+import {cloneDeep, get, isFunction, set} from 'lodash';
+import {filter, isObservable, Observable, of, Subject, switchMap, take, tap} from 'rxjs';
+import {XmTableEntityController} from '../controllers/entity/xm-table-entity-controller.service';
+import {AXmTableLocalPageableCollectionController} from './a-xm-table-local-pageable-collection-controller.service';
+import {IXmTableCollectionController, XmFilterQueryParams} from './i-xm-table-collection-controller';
+import {XmToasterService} from '@xm-ngx/toaster';
+import {XmAlertService} from '@xm-ngx/alert';
+import {takeUntilOnDestroy, takeUntilOnDestroyDestroy} from '@xm-ngx/operators';
 
 export interface XmTableEntity extends XmConfig {
     path: string;
@@ -53,7 +51,7 @@ export class XmTableArrayCollectionController<T = unknown>
         super();
 
         this.syncRequest.asObservable().pipe(
-            switchMap(() => {
+            switchMap((requestData: XmFilterQueryParams) => {
                 const controller = this.getEntityController() as Record<string, () => Observable<unknown[]>>;
                 const controllerMethod = this.config?.entityController?.method || 'entity$';
 
@@ -79,13 +77,14 @@ export class XmTableArrayCollectionController<T = unknown>
 
                         const items = get(value, this.config.path, []) as T[];
 
-                        this.items = this.config?.buildItemAsNestedKey?.length > 0
+                        const rawItems = this.config?.buildItemAsNestedKey?.length > 0
                             ? [
                                 {
                                     [this.config?.buildItemAsNestedKey]: items,
                                 } as T,
                             ]
                             : items;
+                        this.changeByItems(rawItems, requestData);
                     }),
                 );
             }),

--- a/packages/components/table/collections/xm-table-array-collection-controller.ts
+++ b/packages/components/table/collections/xm-table-array-collection-controller.ts
@@ -1,15 +1,15 @@
-import {inject, Injectable, Injector, OnDestroy} from '@angular/core';
-import {XmDynamicInstanceService,} from '@xm-ngx/dynamic';
-import {XmConfig} from '@xm-ngx/interfaces';
-import {UUID} from 'angular2-uuid';
-import {cloneDeep, get, isFunction, set} from 'lodash';
-import {filter, isObservable, Observable, of, Subject, switchMap, take, tap} from 'rxjs';
-import {XmTableEntityController} from '../controllers/entity/xm-table-entity-controller.service';
-import {AXmTableLocalPageableCollectionController} from './a-xm-table-local-pageable-collection-controller.service';
-import {IXmTableCollectionController, XmFilterQueryParams} from './i-xm-table-collection-controller';
-import {XmToasterService} from '@xm-ngx/toaster';
-import {XmAlertService} from '@xm-ngx/alert';
-import {takeUntilOnDestroy, takeUntilOnDestroyDestroy} from '@xm-ngx/operators';
+import { inject, Injectable, Injector, OnDestroy } from '@angular/core';
+import { XmDynamicInstanceService, } from '@xm-ngx/dynamic';
+import { XmConfig } from '@xm-ngx/interfaces';
+import { UUID } from 'angular2-uuid';
+import { cloneDeep, get, isFunction, set } from 'lodash';
+import { filter, isObservable, Observable, of, Subject, switchMap, take, tap } from 'rxjs';
+import { XmTableEntityController } from '../controllers/entity/xm-table-entity-controller.service';
+import { AXmTableLocalPageableCollectionController } from './a-xm-table-local-pageable-collection-controller.service';
+import { IXmTableCollectionController, XmFilterQueryParams } from './i-xm-table-collection-controller';
+import { XmToasterService } from '@xm-ngx/toaster';
+import { XmAlertService } from '@xm-ngx/alert';
+import { takeUntilOnDestroy, takeUntilOnDestroyDestroy } from '@xm-ngx/operators';
 
 export interface XmTableEntity extends XmConfig {
     path: string;

--- a/packages/components/table/directives/xm-table.directive.ts
+++ b/packages/components/table/directives/xm-table.directive.ts
@@ -107,6 +107,7 @@ export class XmTableDirective implements OnInit, OnDestroy {
                     settings: {displayedColumns},
                 });
             }),
+            shareReplay(1),
         );
 
         this.eventManagerService.listenTo<{ queryParams: Params }>(

--- a/packages/components/text/text-join/xm-text-join.component.ts
+++ b/packages/components/text/text-join/xm-text-join.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Inject, Input, OnInit, Optional } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Inject, Input, OnChanges, Optional } from '@angular/core';
 import { ConditionDirective } from '@xm-ngx/components/condition';
 import { XmTextTitleOptions } from '../text-title';
 import {
@@ -31,7 +31,7 @@ export interface XmTextJoinValueOptions {
     standalone: true,
     changeDetection: ChangeDetectionStrategy.Default,
 })
-export class XmTextJoinComponent implements OnInit, XmDynamicPresentation<unknown, XmTextJoinValueOptions> {
+export class XmTextJoinComponent implements OnChanges, XmDynamicPresentation<unknown, XmTextJoinValueOptions> {
     @Input() public value: unknown;
     @Input() public config: XmTextJoinValueOptions;
     public joinValue: string;
@@ -42,7 +42,7 @@ export class XmTextJoinComponent implements OnInit, XmDynamicPresentation<unknow
     ) {
     }
 
-    public ngOnInit(): void {
+    public ngOnChanges(): void {
         this.joinValue = this.joinTemplates(this.config.templates || []);
     }
 

--- a/packages/components/text/text-view/xm-text-view.component.ts
+++ b/packages/components/text/text-view/xm-text-view.component.ts
@@ -39,7 +39,7 @@ export type PrimitiveOrTranslate = Primitive & Translate;
                 } @else if (value !== undefined) {
                     <span>{{ value | translate }}</span>
                 } @else {
-                    <ng-template>{{ config.emptyValue | translate }}</ng-template>
+                    {{config.emptyValue | translate}}
                 }
             </span>
         </xm-text-view-container>


### PR DESCRIPTION
In case when table data has been retrieved before pagination render we could face with incorrect behavior such as empty page index and disabled page navigation buttons