### PR TITLE
feat: xm-breadcrumbs – keep query params

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "6.0.133",
+  "version": "6.0.134",
   "release": "6.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/packages/components/breadcrumb/breadcrumb/xm-breadcrumb.component.html
+++ b/packages/components/breadcrumb/breadcrumb/xm-breadcrumb.component.html
@@ -6,6 +6,7 @@
 
     <a *ngIf="!last; else pageTitle"
        [routerLink]="breadcrumb.url"
+       [queryParams]="breadcrumb.queryParams"
        class="xm-breadcrumb-item-link"
        mat-button>{{ breadcrumb.label | translate }}
     </a>

--- a/packages/components/breadcrumb/interfaces/xm-breadcrumb.interface.ts
+++ b/packages/components/breadcrumb/interfaces/xm-breadcrumb.interface.ts
@@ -1,8 +1,10 @@
 import { XmDynamicPresentationLayout } from '@xm-ngx/dynamic';
+import { Params } from '@angular/router';
 
 export interface XmBreadcrumb {
     url: string;
     label: string;
+    queryParams: Params;
 }
 
 export interface XmBreadcrumbOptions {

--- a/packages/components/breadcrumb/reolvers/xm-breadcrumb-default.resolver.ts
+++ b/packages/components/breadcrumb/reolvers/xm-breadcrumb-default.resolver.ts
@@ -1,5 +1,5 @@
 import { XmBreadcrumbResolver } from './xm-breadcrumb.resolver';
-import { ActivatedRouteSnapshot } from '@angular/router';
+import { ActivatedRouteSnapshot, Params } from '@angular/router';
 import { XmBreadcrumbRouteData } from '../interfaces/xm-breadcrumb-route-data.interface';
 import { XmBreadcrumb } from '../interfaces/xm-breadcrumb.interface';
 
@@ -43,6 +43,21 @@ export class XmBreadcrumbDefaultResolver extends XmBreadcrumbResolver {
         return {
             label: title,
             url: getResolvedUrl(route),
+            queryParams: this.keepQueryParams(route.queryParams, data),
         };
+    }
+
+    private static keepQueryParams(queryParams: Params, data: any): Params | null {
+        const { keepQueryParams } = data.dashboard.config || {};
+        if (Array.isArray(keepQueryParams)) {
+            return keepQueryParams.reduce((accumulator: Params, key: string) => {
+                return {
+                    ...accumulator,
+                    [key]: queryParams[key],
+                };
+            }, {});
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
If during navigation your url has queryParams and when you click on previous crumb (to navigate on previous page) you want to keep some of existing queryParams just specify them in dashboard config as array of strings.

For ex:
url: 
https://domain.com/dashboard/parent/child1/child2??callId=123&userId=123-123

breadcrumbs:
`Parent` > `Child1` > `Child2`

So, now you on `Child2` page,  if you want to go back to `Child1` page and keep `userId` param in url, then add to the `Child1` dashboard config:
```json
{
  "keepQueryParams": [
      "userId"
    ]
}
```