### PR TITLE
feat: Add navigation config property and fix bug in xm-table-widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "6.0.177",
+  "version": "6.0.178",
   "release": "6.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/packages/components/table/controllers/filters/xm-table-query-params-store.service.ts
+++ b/packages/components/table/controllers/filters/xm-table-query-params-store.service.ts
@@ -49,6 +49,7 @@ export class XmTableQueryParamsStoreService {
                 relativeTo: this.route,
                 queryParams: finalQuery,
                 queryParamsHandling: 'merge',
+                replaceUrl: config?.navigation?.replaceUrl,
             },
         );
     }

--- a/packages/components/table/directives/xm-table.directive.ts
+++ b/packages/components/table/directives/xm-table.directive.ts
@@ -138,8 +138,8 @@ export class XmTableDirective implements OnInit, OnDestroy {
             )
             .subscribe((obsObj) => {
                 const filterParams = obsObj.tableFilter;
-                const pageableAndSortable = this.mapPageableAndSortable(filterParams, obsObj.pageableAndSortable);
                 this.filters = cloneDeep(filterParams);
+                const pageableAndSortable = this.mapPageableAndSortable(filterParams, obsObj.pageableAndSortable);
                 const queryParams = _.merge({}, {pageableAndSortable}, {filterParams});
 
                 this.queryParamsStoreService.set(queryParams, this.config);

--- a/packages/components/table/directives/xm-table.directive.ts
+++ b/packages/components/table/directives/xm-table.directive.ts
@@ -138,8 +138,8 @@ export class XmTableDirective implements OnInit, OnDestroy {
             )
             .subscribe((obsObj) => {
                 const filterParams = obsObj.tableFilter;
-                this.filters = cloneDeep(filterParams);
                 const pageableAndSortable = this.mapPageableAndSortable(filterParams, obsObj.pageableAndSortable);
+                this.filters = cloneDeep(filterParams);
                 const queryParams = _.merge({}, {pageableAndSortable}, {filterParams});
 
                 this.queryParamsStoreService.set(queryParams, this.config);
@@ -152,7 +152,7 @@ export class XmTableDirective implements OnInit, OnDestroy {
     }
 
     private mapPageableAndSortable(filterParams: FiltersControlValue, pageableAndSortable: PageableAndSortable): PageableAndSortable {
-        if (!isEqual(filterParams, this.filters)){
+        if (this.filters && !isEqual(filterParams, this.filters)){
             set(pageableAndSortable, 'pageIndex', 0);
         }
         return pageableAndSortable;

--- a/packages/components/table/directives/xm-table.model.ts
+++ b/packages/components/table/directives/xm-table.model.ts
@@ -22,6 +22,12 @@ export interface XmTableConfig {
     isExpandable: boolean;
     showFilterChips?: boolean;
     popUpFilter?: boolean;
+    navigation?: XmTableNavigation;
+}
+
+export interface XmTableNavigation {
+    /** See Angular replaceUrl routerLink parameter for more details https://angular.dev/api/router/NavigationExtras#replaceUrl */
+    replaceUrl: boolean;
 }
 
 export const XM_TABLE_CONFIG_DEFAULT: XmTableConfig = {
@@ -41,6 +47,9 @@ export const XM_TABLE_CONFIG_DEFAULT: XmTableConfig = {
     popUpFilter: false,
     showFilterChips: true,
     queryPrefixKey: '',
+    navigation: {
+        replaceUrl: false,
+    },
 };
 
 export enum XmTableEventType {


### PR DESCRIPTION
- add navigation.replaceUrl property to do no push new route to the browser history
- fix bug when pageIndex resets to 0 on every table initialization