### PR TITLE
fix: Menu collapse/expand behaviour, navigation, login/logout categories issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "6.0.179",
+  "version": "6.0.180",
   "release": "6.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/packages/components/menu/menu.component.ts
+++ b/packages/components/menu/menu.component.ts
@@ -125,7 +125,6 @@ export class MenuComponent implements OnInit, AfterViewInit, OnDestroy {
         this.observeSectionsFiltering();
         this.assignSubCategories();
         this.observeNavigationAndSubCategories();
-        this.observeLogoutEvent();
     }
 
     public ngAfterViewInit(): void {
@@ -248,16 +247,6 @@ export class MenuComponent implements OnInit, AfterViewInit, OnDestroy {
             activeNode.isActiveRoute = true;
             this.previousActiveNode = activeNode;
         }
-    }
-
-    private observeLogoutEvent(): void {
-        this.eventManager.listenTo('USER-LOGOUT')
-            .pipe(takeUntilOnDestroy(this))
-            .subscribe(() => {
-                this.categories = [];
-                this.menuByCategories = {};
-                this.menuService.setMenuCategories([]);
-            });
     }
 
     public observeSectionsFiltering(): void {

--- a/packages/components/menu/menu.component.ts
+++ b/packages/components/menu/menu.component.ts
@@ -125,6 +125,7 @@ export class MenuComponent implements OnInit, AfterViewInit, OnDestroy {
         this.observeSectionsFiltering();
         this.assignSubCategories();
         this.observeNavigationAndSubCategories();
+        this.observeLogoutEvent();
     }
 
     public ngAfterViewInit(): void {
@@ -145,11 +146,18 @@ export class MenuComponent implements OnInit, AfterViewInit, OnDestroy {
                     return menu;
                 }
                 this.menuService.setMenuCategories(this.categories);
+                this.navigateInCaseOfEmptyPath();
                 return menu;
             }),
             takeUntilOnDestroy(this),
             shareReplay(1),
         );
+    }
+
+    private navigateInCaseOfEmptyPath(): void {
+        if (this.router.url === '/') {
+            this.router.navigate(['dashboard']);
+        }
     }
 
     private get activeDashboards$(): Observable<MenuItem[]> {
@@ -240,6 +248,16 @@ export class MenuComponent implements OnInit, AfterViewInit, OnDestroy {
             activeNode.isActiveRoute = true;
             this.previousActiveNode = activeNode;
         }
+    }
+
+    private observeLogoutEvent(): void {
+        this.eventManager.listenTo('USER-LOGOUT')
+            .pipe(takeUntilOnDestroy(this))
+            .subscribe(() => {
+                this.categories = [];
+                this.menuByCategories = {};
+                this.menuService.setMenuCategories([]);
+            });
     }
 
     public observeSectionsFiltering(): void {

--- a/src/app/layouts/components/layout-wrapper/layout-wrapper.component.ts
+++ b/src/app/layouts/components/layout-wrapper/layout-wrapper.component.ts
@@ -51,7 +51,10 @@ export class LayoutWrapperComponent implements OnInit, AfterViewInit, OnDestroy 
     private observeLogoutEvent(): void {
         this.eventManager.listenTo('USER-LOGOUT')
             .pipe(takeUntilOnDestroy(this))
-            .subscribe(() => this.menuService.sidenav.close());
+            .subscribe(() => {
+                this.menuService.sidenav.close();
+                this.menuService.setMenuCategories([]);
+            });
     }
 
     private observeIsMobileScreen(): void {


### PR DESCRIPTION
- after receiving dashboards check if url path is empty, do navigation to dashboards
- change menu collapse/expand behaviour, now it's hiding immediately when user clicks on Collapse button
- fix issue when user logged out and then login again there was a tiny second when categories were shown from the previous user