### PR TITLE
fix(xm-quick-filters-control.component): reset quick-filters-control …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "7.0.35",
+  "version": "7.0.36",
   "release": "6.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/packages/components/table/components/xm-quick-filters-control.component.ts
+++ b/packages/components/table/components/xm-quick-filters-control.component.ts
@@ -95,6 +95,10 @@ export class XmTableQuickFilterControl<T = FiltersControlValue> extends NgContro
             this.disabled ? this.formGroup.disable() : this.formGroup.enable();
         }
 
+        if (this.formGroup && changes.value) {
+            this.formGroup.setValue(this.value);
+        }
+
         if (changes.options && !changes.options.isFirstChange()) {
             this.destroyForm();
             this.initForm();

--- a/packages/components/table/components/xm-table-filter-button-dialog-controls.component.ts
+++ b/packages/components/table/components/xm-table-filter-button-dialog-controls.component.ts
@@ -14,6 +14,8 @@ export interface XmTableFiltersControlRequestConfig {
     filterStoreKey?: string;
     quickFilters?: FormLayoutItem[];
     hideDefaultFilters?: boolean;
+    hideResetButton?: boolean;
+    quickFilterInlineContainerStyle?: string;
 }
 
 @Component({

--- a/packages/components/table/components/xm-table-quick-filter-inline.component.ts
+++ b/packages/components/table/components/xm-table-quick-filter-inline.component.ts
@@ -20,16 +20,17 @@ import { XmTableQuickFilterControlsComponent } from '../components/xm-table-quic
     selector: 'xm-table-quick-filter-inline',
     standalone: true,
     template: `
-        <div class="d-flex quick-filter-block">
-        <span *ngIf="!config?.isOnlyExpand" class="xm-filters-btn">
-            <button (click)="toggleFilters()"
-                    class="ms-2 mb-2 filter-btn"
-                    color="accent"
-                    mat-icon-button
-                    type="button">
-                <mat-icon>filter_list</mat-icon>
-            </button>
-        </span>
+        <div class="d-flex quick-filter-block" [style]="config?.quickFilterInlineContainerStyle">
+            <span *ngIf="!config?.isOnlyExpand" class="xm-filters-btn">
+                <button (click)="toggleFilters()"
+                        class="ms-2 mb-2 filter-btn"
+                        color="accent"
+                        mat-icon-button
+                        type="button">
+                    <mat-icon>filter_list</mat-icon>
+                </button>
+            </span>
+
             <ng-container *ngIf="!(config?.quickFilters | xmEmpty)">
                 <div class="quick-filter-holder">
                     <xm-quick-filters-control-request
@@ -40,7 +41,7 @@ import { XmTableQuickFilterControlsComponent } from '../components/xm-table-quic
                         [ngClass]="{'xm-filters-control-hidden': filterExpand}">
                     </xm-quick-filters-control-request>
 
-                    <button mat-button *ngIf="hasActiveFilters"
+                    <button mat-button *ngIf="!config?.hideResetButton && hasActiveFilters"
                             class="me-3"
                             (click)="reset()">
                         {{ 'table.filter.button.reset' | xmTranslate }}


### PR DESCRIPTION
- fix reset quick-filters-control value when user pushed reset button
- added an additional property "hideResetButton" on the configuration for xm-table-quick-filter-inline. This property makes the reset button hidden
- added an additional property on the configuration for xm-table-quick-filter-inline. This property allows you to define styles for a component container from a widget configuration