### PR TITLE
Feat: Add extra error cases to the *xmControlErrors directive

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "7.0.54",
+  "version": "7.0.55",
   "release": "6.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/packages/components/control-error/control-errors.directive.ts
+++ b/packages/components/control-error/control-errors.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Inject, Input, OnChanges, TemplateRef, ViewContainerRef } from '@angular/core';
+import { Directive, Inject, Input, OnChanges, OnInit, TemplateRef, ViewContainerRef } from '@angular/core';
 import { ValidationErrors } from '@angular/forms';
 import { XM_CONTROL_ERRORS_TRANSLATES, XmControlErrorsTranslates } from './xm-control-errors-translates';
 import { Translate, TranslatePipe } from '@xm-ngx/translation';
@@ -17,12 +17,28 @@ interface ControlErrorsContext<T = unknown> {
  * myControl = new FormControl(null, Validators.required);
  * <mat-error *xmControlErrors="myControl.errors; message as message">{{message}}</mat-error>
  * ```
+ *
+ * @example
+ * In case you need to pass you custom error message translation, you can use the `xmControlErrorsExtraErrorTranslations` input
+ * ```html
+ * <mat-error *xmControlErrors="inputControl.errors; extraErrorTranslations: extraErrorTranslations; message as message;">
+ *     {{ message }}
+ * </mat-error>
+ * ```
+ * where extraErrorTranslations:
+ * ```ts
+ * public extraErrorTranslations: XmControlErrorsTranslates = {
+ *     unique: marker('ext.translation.key.to.the.unique.error.message'),
+ * };
+ * ```
+ *
  */
 @Directive({
     selector: '[xmControlErrors]',
 })
-export class ControlErrorsDirective implements OnChanges {
+export class ControlErrorsDirective implements OnInit, OnChanges {
     @Input() public xmControlErrors: ValidationErrors | null;
+    @Input() public xmControlErrorsExtraErrorTranslations: XmControlErrorsTranslates = {};
     private thenTemplateRef: TemplateRef<ControlErrorsContext>;
 
     constructor(
@@ -49,8 +65,16 @@ export class ControlErrorsDirective implements OnChanges {
         };
     }
 
+    public ngOnInit(): void {
+        this.setExtraErrors();
+    }
+
     public ngOnChanges(): void {
         this.updateView();
+    }
+
+    private setExtraErrors(): void {
+        this._xmControlErrorsTranslates = {...this._xmControlErrorsTranslates, ...this.xmControlErrorsExtraErrorTranslations};
     }
 
     private getErrorMessage<T>(error: T, errorKey: string): string {

--- a/packages/components/control-error/control-errors.directive.ts
+++ b/packages/components/control-error/control-errors.directive.ts
@@ -66,14 +66,14 @@ export class ControlErrorsDirective implements OnInit, OnChanges {
     }
 
     public ngOnInit(): void {
-        this.setExtraErrors();
+        this.setExtraErrorTranslations();
     }
 
     public ngOnChanges(): void {
         this.updateView();
     }
 
-    private setExtraErrors(): void {
+    private setExtraErrorTranslations(): void {
         this._xmControlErrorsTranslates = {...this._xmControlErrorsTranslates, ...this.xmControlErrorsExtraErrorTranslations};
     }
 


### PR DESCRIPTION
In case you need to pass you custom error message translation, you can use the `xmControlErrorsExtraErrorTranslations` input:
```html
<mat-error *xmControlErrors="inputControl.errors; extraErrorTranslations: extraErrorTranslations; message as message;">
    {{ message }}
</mat-error>
```
where extraErrorTranslations:
```ts
public extraErrorTranslations: XmControlErrorsTranslates = {
    unique: marker('ext.translation.key.to.the.unique.error.message'),
};
```