### PR TITLE
feat: dashboard transfer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "7.0.82",
+  "version": "7.0.83",
   "release": "6.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/packages/administration/dashboards-config/components/dashboards-transfer/components/action-type-step/action-type-step.component.html
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/components/action-type-step/action-type-step.component.html
@@ -1,0 +1,10 @@
+<ng-container [formGroup]="formGroup">
+  <mat-radio-group [color]="'primary'" [formControlName]="'selectedAction'" class="action-group">
+    @for (action of actions; track action.translateKey) {
+      <mat-radio-button
+        [value]="action.value">
+        {{ action.translateKey | xmTranslate }}
+      </mat-radio-button>
+    }
+  </mat-radio-group>
+</ng-container>

--- a/packages/administration/dashboards-config/components/dashboards-transfer/components/action-type-step/action-type-step.component.scss
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/components/action-type-step/action-type-step.component.scss
@@ -1,0 +1,4 @@
+.action-group {
+  display: flex;
+  flex-direction: column;
+}

--- a/packages/administration/dashboards-config/components/dashboards-transfer/components/action-type-step/action-type-step.component.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/components/action-type-step/action-type-step.component.ts
@@ -1,0 +1,26 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { MatRadioButton, MatRadioGroup } from '@angular/material/radio';
+import { XmTranslatePipe } from '@xm-ngx/translation';
+
+import { Action } from '../../types';
+import { actions, translates } from '../../constants';
+
+@Component({
+    selector: 'xm-action-type-step',
+    standalone: true,
+    imports: [
+        MatRadioGroup,
+        MatRadioButton,
+        XmTranslatePipe,
+        ReactiveFormsModule,
+    ],
+    templateUrl: './action-type-step.component.html',
+    styleUrl: './action-type-step.component.scss',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ActionTypeStepComponent {
+    @Input() public formGroup: FormGroup;
+    public readonly translates = translates;
+    public readonly actions: Action[] = actions;
+}

--- a/packages/administration/dashboards-config/components/dashboards-transfer/components/congratulations-step/congratulations-step.component.html
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/components/congratulations-step/congratulations-step.component.html
@@ -1,0 +1,60 @@
+<div class="mb-4">
+  <h4 class="d-flex justify-content-center align-items-center gap-2 mb-4 text-primary">
+    <div class="circle text-primary">
+      <mat-icon>check</mat-icon>
+    </div>
+
+    {{ translates.doneStep.title | xmTranslate }}
+  </h4>
+
+  <div class="content text-center">
+    @if (actionType === 'transfer-dashboards') {
+      {{ translates.doneStep.successTransferredDashboards | xmTranslate }}: <span
+        class="text-primary">{{ amountOfTransferredDashboards }}</span>
+    }
+
+    @if (actionType === 'update-roles') {
+      {{ translates.doneStep.successUpdatedRoles | xmTranslate }}: <span
+        class="text-primary">{{ amountOfTransferredRoles }}</span>
+    }
+  </div>
+
+  <div class="content text-center">
+    {{ translates.doneStep.inEnvironment | xmTranslate }}: <span class="text-primary">{{ transferUrlTo }}</span>
+  </div>
+</div>
+
+@if (rolesErrors.length) {
+  <div class="content errors-wrapper">
+    <mat-divider></mat-divider>
+
+    <div class="text-center mt-4 mb-2">
+      <span
+        class="text-primary text-uppercase">{{ translates.doneStep.pleaseNote | xmTranslate }}</span> {{ translates.doneStep.errorsOccurredWhileUpdating | xmTranslate }} {{ rolesErrors.length }} {{ translates.doneStep.roles | xmTranslate }}
+    </div>
+
+    <div class="errors-block">
+      <div>roleKey</div>
+      <div>{{ translates.doneStep.statusCode | xmTranslate }}</div>
+      <div>{{ translates.doneStep.errorDescription | xmTranslate }}</div>
+
+      @for (error of rolesErrors; track error.roleKey) {
+        <div class="role-key" [matTooltip]="error.roleKey" [matTooltipPosition]="'above'">
+          {{ error.roleKey }}
+        </div>
+        <div class="status-code">{{ error.errorCode }}</div>
+        <div class="description" [matTooltip]="error.errorDescription" [matTooltipPosition]="'above'">
+          {{ error.errorDescription }}
+        </div>
+      }
+    </div>
+  </div>
+
+}
+
+
+
+
+
+
+

--- a/packages/administration/dashboards-config/components/dashboards-transfer/components/congratulations-step/congratulations-step.component.scss
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/components/congratulations-step/congratulations-step.component.scss
@@ -1,0 +1,79 @@
+:host {
+  display: block;
+  padding-top: 40px;
+  padding-bottom: 40px;
+}
+
+.circle {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border: 2px solid red;
+  color: red;
+}
+
+.content {
+  max-width: 500px;
+  margin: 0 auto;
+}
+
+.errors-wrapper {
+  max-width: 800px;
+}
+
+.errors-block {
+  display: grid;
+  grid-template-columns: 1fr 120px 1fr;
+  border: 1px solid #ccc;
+  max-height: 286px;
+  overflow-y: auto;
+
+  div {
+    padding: 18px 8px;
+    border-bottom: 1px solid #ccc;
+    border-right: 1px solid #ccc;
+  }
+
+  div:nth-child(3n+1), div:nth-child(3n) {
+    padding: 18px 16px;
+  }
+
+  div:nth-child(3n) {
+    border-right: none;
+  }
+
+  div:nth-last-child(-n+3) {
+    border-bottom: none;
+  }
+
+  div:nth-child(-n+3) {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-weight: 500;
+  }
+
+  .role-key {
+    display: block;
+    width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .status-code {
+    text-align: center;
+  }
+
+  .description {
+    display: block;
+    width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 50ch;
+  }
+}

--- a/packages/administration/dashboards-config/components/dashboards-transfer/components/congratulations-step/congratulations-step.component.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/components/congratulations-step/congratulations-step.component.ts
@@ -1,0 +1,83 @@
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, Input, OnDestroy, OnInit } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { MatIcon } from '@angular/material/icon';
+import { XmTranslatePipe } from '@xm-ngx/translation';
+import { takeUntilOnDestroy, takeUntilOnDestroyDestroy } from '@xm-ngx/operators';
+import { tap } from 'rxjs';
+import { MatDivider } from '@angular/material/divider';
+import { MatTooltip } from '@angular/material/tooltip';
+
+import { translates } from '../../constants';
+import { RolesStateService } from '../../services/roles-state.service';
+import { RoleError } from '../../types';
+
+@Component({
+    selector: 'xm-congratulations-step',
+    standalone: true,
+    imports: [
+        MatIcon,
+        XmTranslatePipe,
+        MatDivider,
+        MatTooltip,
+
+    ],
+    templateUrl: './congratulations-step.component.html',
+    styleUrl: './congratulations-step.component.scss',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CongratulationsStepComponent implements OnInit, OnDestroy {
+    public transferUrlTo: string;
+    public amountOfTransferredDashboards: number;
+    public amountOfTransferredRoles: number;
+    public actionType: string;
+    public rolesErrors: RoleError[] = [];
+
+    public readonly translates = translates;
+    @Input() public formGroup: FormGroup;
+
+    private readonly rolesService = inject(RolesStateService);
+    private readonly cdr = inject(ChangeDetectorRef);
+
+    public get selectedRolesLength(): number {
+        return this.formGroup.value.rolesGroup.selected.length as number;
+    }
+
+    public ngOnInit(): void {
+        const { actionTypeGroup, envGroup } = this.formGroup.value;
+
+        this.actionType = actionTypeGroup.selectedAction;
+        this.transferUrlTo = envGroup.envUrl;
+
+        switch (this.actionType) {
+            case 'transfer-dashboards': {
+                this.processDashboardsSummary();
+                break;
+            }
+            case 'update-roles': {
+                this.processRolesSummary();
+                break;
+            }
+        }
+    }
+
+    public ngOnDestroy(): void {
+        takeUntilOnDestroyDestroy(this);
+    }
+
+    private processDashboardsSummary(): void {
+        this.amountOfTransferredDashboards = this.formGroup.value.dashboardsGroup.selected.length;
+    }
+
+    private processRolesSummary(): void {
+        this.amountOfTransferredRoles = this.selectedRolesLength;
+
+        this.rolesService.errors$.pipe(
+            tap((errors: RoleError[]) => {
+                this.amountOfTransferredRoles = this.selectedRolesLength - errors.length;
+                this.rolesErrors = errors;
+                this.cdr.markForCheck();
+            }),
+            takeUntilOnDestroy(this),
+        ).subscribe();
+    }
+}

--- a/packages/administration/dashboards-config/components/dashboards-transfer/components/dashboard-confirmation-step/dashboard-confirmation-step.component.html
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/components/dashboard-confirmation-step/dashboard-confirmation-step.component.html
@@ -1,0 +1,16 @@
+<mat-list>
+  <cdk-virtual-scroll-viewport
+    #viewport
+    [itemSize]="viewportItemHeight"
+    [style.height.px]="viewportHeight"
+    class="viewport">
+    <mat-list-item *cdkVirtualFor="let dashboard of dashboards$ | async; index as i; trackBy: trackByFn">
+      <div class="d-flex gap-2 align-items-center">
+        <div class="position grey-color">
+          {{ i + 1 }}.
+        </div>
+        <xm-dashboard-option [dashboard]="dashboard"></xm-dashboard-option>
+      </div>
+    </mat-list-item>
+  </cdk-virtual-scroll-viewport>
+</mat-list>

--- a/packages/administration/dashboards-config/components/dashboards-transfer/components/dashboard-confirmation-step/dashboard-confirmation-step.component.scss
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/components/dashboard-confirmation-step/dashboard-confirmation-step.component.scss
@@ -1,0 +1,30 @@
+.viewport {
+  width: 100%;
+}
+
+.position {
+  padding: 0 5px;
+  width: 30px;
+}
+
+.grey-color {
+  color: #666666;
+}
+
+xm-dashboard-option {
+  flex-grow: 1;
+}
+
+mat-list {
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 0;
+  
+  mat-list-item {
+    height: 56px;
+
+    &:not(:last-of-type) {
+      border-bottom: 1px solid #ccc;
+    }
+  }
+}

--- a/packages/administration/dashboards-config/components/dashboards-transfer/components/dashboard-confirmation-step/dashboard-confirmation-step.component.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/components/dashboard-confirmation-step/dashboard-confirmation-step.component.ts
@@ -1,0 +1,75 @@
+import {
+    ChangeDetectionStrategy,
+    ChangeDetectorRef,
+    Component,
+    inject,
+    Input,
+    OnDestroy,
+    OnInit,
+    ViewChild,
+} from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { MatList, MatListItem } from '@angular/material/list';
+import { filter, map, Observable, tap } from 'rxjs';
+import { DashboardWithWidgets } from '@xm-ngx/core/dashboard';
+import { startWith } from 'rxjs/operators';
+import { AsyncPipe } from '@angular/common';
+import { CdkFixedSizeVirtualScroll, CdkVirtualForOf, CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
+import { takeUntilOnDestroy, takeUntilOnDestroyDestroy } from '@xm-ngx/operators';
+
+import { DashboardOptionComponent } from '../dashboard-option/dashboard-option.component';
+import { DynamicScrollViewportHeight } from '../dynamic-scroll-viewport-height/dynamic-scroll-viewport-height';
+
+
+@Component({
+    selector: 'xm-dashboard-confirmation-step',
+    standalone: true,
+    imports: [
+        AsyncPipe,
+        CdkFixedSizeVirtualScroll,
+        CdkVirtualForOf,
+        CdkVirtualScrollViewport,
+        DashboardOptionComponent,
+        MatList,
+        MatListItem,
+
+    ],
+    templateUrl: './dashboard-confirmation-step.component.html',
+    styleUrl: './dashboard-confirmation-step.component.scss',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DashboardConfirmationStepComponent extends DynamicScrollViewportHeight implements OnInit, OnDestroy {
+    @Input() public formGroup: FormGroup;
+
+    @ViewChild('viewport') public cdkVirtualScrollViewport: CdkVirtualScrollViewport;
+
+    public dashboards$: Observable<DashboardWithWidgets[]>;
+
+    public cdr: ChangeDetectorRef = inject(ChangeDetectorRef);
+
+    public get selectedControl(): FormControl<DashboardWithWidgets[]> {
+        return this.formGroup.get('selected') as FormControl<DashboardWithWidgets[]>;
+    }
+
+    public ngOnInit(): void {
+        this.dashboards$ = this.selectedControl.valueChanges.pipe(
+            startWith(this.selectedControl.value),
+            filter(Boolean),
+            map((dashboards: DashboardWithWidgets[]) => {
+                return dashboards.filter(dashboard => dashboard?.id);
+            }),
+            tap((dashboards: DashboardWithWidgets[]) => {
+                this.changeViewportHeight(dashboards);
+            }),
+            takeUntilOnDestroy(this),
+        );
+    }
+
+    public ngOnDestroy(): void {
+        takeUntilOnDestroyDestroy(this);
+    }
+
+    public trackByFn(_: number, dashboard: DashboardWithWidgets): number {
+        return dashboard.id;
+    }
+}

--- a/packages/administration/dashboards-config/components/dashboards-transfer/components/dashboard-option/dashboard-option.component.html
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/components/dashboard-option/dashboard-option.component.html
@@ -1,0 +1,16 @@
+<div class="d-flex gap-3">
+  <div class="column">
+    <span class="label">ID</span>
+    <span class="text-primary value">{{ dashboard.id }}</span>
+  </div>
+
+  <div class="column">
+    <span class="label">name</span>
+    <span class="text-primary value">{{ dashboard.name }}</span>
+  </div>
+
+  <div class="column">
+    <span class="label">typeKey</span>
+    <span class="text-primary value">{{ dashboard.typeKey }}</span>
+  </div>
+</div>

--- a/packages/administration/dashboards-config/components/dashboards-transfer/components/dashboard-option/dashboard-option.component.scss
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/components/dashboard-option/dashboard-option.component.scss
@@ -1,0 +1,12 @@
+.column {
+  width: 33%;
+  display: flex;
+  flex-direction: column;
+
+  .value {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 40ch;
+  }
+}

--- a/packages/administration/dashboards-config/components/dashboards-transfer/components/dashboard-option/dashboard-option.component.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/components/dashboard-option/dashboard-option.component.ts
@@ -1,0 +1,14 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { Dashboard } from '@xm-ngx/core/dashboard';
+
+@Component({
+    selector: 'xm-dashboard-option',
+    standalone: true,
+    imports: [],
+    templateUrl: './dashboard-option.component.html',
+    styleUrl: './dashboard-option.component.scss',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DashboardOptionComponent {
+    @Input() public dashboard!: Dashboard;
+}

--- a/packages/administration/dashboards-config/components/dashboards-transfer/components/dashboards-step/dashboards-step.component.html
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/components/dashboards-step/dashboards-step.component.html
@@ -1,0 +1,33 @@
+<mat-form-field>
+  <mat-label>{{ translates.dashboardsStep.searchLabel | xmTranslate }}</mat-label>
+
+  <input
+    [formControl]="searchTermControl"
+    [placeholder]="translates.dashboardsStep.searchPlaceholder | xmTranslate"
+    [type]="'text'"
+    matInput>
+</mat-form-field>
+
+<cdk-virtual-scroll-viewport class="viewport" itemSize="56">
+  <mat-selection-list
+    (selectionChange)="onSelectionChange($event)"
+    [color]="'primary'"
+    [multiple]="true"
+    class="selection-list">
+
+    <mat-list-option
+      (selectedChange)="onSelectAll($event)"
+      [togglePosition]="'before'"
+      class="select-all-option">
+      {{ translates.dashboardsStep.selectAllDashboards | xmTranslate }}
+    </mat-list-option>
+
+    <mat-list-option
+      *cdkVirtualFor="let dashboard of items$ | async; templateCacheSize: 0; index as i; trackBy: trackByFn"
+      [selected]="selectionModel.isSelected(dashboard)"
+      [togglePosition]="'before'"
+      [value]="dashboard">
+      <xm-dashboard-option [dashboard]="dashboard"></xm-dashboard-option>
+    </mat-list-option>
+  </mat-selection-list>
+</cdk-virtual-scroll-viewport>

--- a/packages/administration/dashboards-config/components/dashboards-transfer/components/dashboards-step/dashboards-step.component.scss
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/components/dashboards-step/dashboards-step.component.scss
@@ -1,0 +1,14 @@
+.viewport {
+  height: 560px;
+  width: 100%;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.selection-list {
+  padding: 0;
+}
+
+.select-all-option, mat-list-option {
+  border-bottom: 1px solid #ccc;
+}

--- a/packages/administration/dashboards-config/components/dashboards-transfer/components/dashboards-step/dashboards-step.component.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/components/dashboards-step/dashboards-step.component.ts
@@ -1,0 +1,64 @@
+import { ChangeDetectionStrategy, Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { DashboardWithWidgets } from '@xm-ngx/core/dashboard';
+import { MatListOption, MatSelectionList } from '@angular/material/list';
+import { CdkFixedSizeVirtualScroll, CdkVirtualForOf, CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatFormField, MatLabel } from '@angular/material/form-field';
+import { MatInput } from '@angular/material/input';
+import { takeUntilOnDestroy, takeUntilOnDestroyDestroy } from '@xm-ngx/operators';
+import { Observable } from 'rxjs';
+import { XmTranslatePipe } from '@xm-ngx/translation';
+import { AsyncPipe } from '@angular/common';
+
+import { translates } from '../../constants';
+import { AbstractSelectionList, SelectionFormGroup } from '../selection-list/abstract-selection-list';
+import { DashboardOptionComponent } from '../dashboard-option/dashboard-option.component';
+
+
+@Component({
+    selector: 'xm-dashboards-step',
+    standalone: true,
+    imports: [
+        MatSelectionList,
+        MatListOption,
+        DashboardOptionComponent,
+        CdkVirtualScrollViewport,
+        CdkFixedSizeVirtualScroll,
+        CdkVirtualForOf,
+        MatFormField,
+        MatLabel,
+        MatInput,
+        ReactiveFormsModule,
+        AsyncPipe,
+        XmTranslatePipe,
+
+    ],
+    templateUrl: './dashboards-step.component.html',
+    styleUrl: './dashboards-step.component.scss',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DashboardsStepComponent extends AbstractSelectionList<DashboardWithWidgets> implements OnInit, OnDestroy {
+    @Input() public formGroup: SelectionFormGroup<DashboardWithWidgets>;
+    @Input() public entities$: Observable<DashboardWithWidgets[]>;
+    public readonly translates = translates;
+
+    public filterFn = (searchTerm: string, dashboards: DashboardWithWidgets[]): DashboardWithWidgets[] => {
+        return dashboards.filter(dashboard => {
+            return dashboard.name.toLowerCase().includes(searchTerm.trim().toLowerCase());
+        });
+    };
+
+    public ngOnInit(): void {
+        this.items$ = this.getEntities().pipe(
+            takeUntilOnDestroy(this),
+        );
+    }
+
+    public ngOnDestroy(): void {
+        takeUntilOnDestroyDestroy(this);
+    }
+
+    public trackByFn = (_: number, dashboard: DashboardWithWidgets): number => {
+        return dashboard.id;
+    };
+}

--- a/packages/administration/dashboards-config/components/dashboards-transfer/components/dynamic-scroll-viewport-height/dynamic-scroll-viewport-height.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/components/dynamic-scroll-viewport-height/dynamic-scroll-viewport-height.ts
@@ -1,0 +1,20 @@
+import { CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
+import { ChangeDetectorRef } from '@angular/core';
+
+export abstract class DynamicScrollViewportHeight {
+    public abstract cdkVirtualScrollViewport: CdkVirtualScrollViewport;
+    public abstract cdr: ChangeDetectorRef;
+
+    public viewportItemHeight: number = 56;
+    public viewportHeight: number = this.viewportItemHeight;
+    public MAX_VIEWPORT_HEIGHT: number = 560;
+
+    public changeViewportHeight(items: unknown[]): void {
+        this.viewportHeight = items.length >= 10 ? this.MAX_VIEWPORT_HEIGHT : items.length * this.viewportItemHeight;
+        this.cdr.detectChanges();
+
+        if (this.cdkVirtualScrollViewport) {
+            this.cdkVirtualScrollViewport.checkViewportSize();
+        }
+    }
+}

--- a/packages/administration/dashboards-config/components/dashboards-transfer/components/environment-step/environment-step.component.html
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/components/environment-step/environment-step.component.html
@@ -1,0 +1,38 @@
+<form [formGroup]="formGroup" class="d-flex gap-4">
+  <mat-form-field class="example-full-width">
+    <mat-label>{{ translates.envStep.urlLabel | xmTranslate }}</mat-label>
+
+    <input
+      [formControlName]="'envUrl'"
+      [matAutocomplete]="auto"
+      [placeholder]="translates.envStep.urlPlaceholder | xmTranslate"
+      [type]="'text'"
+      matInput>
+
+    <mat-autocomplete #auto="matAutocomplete">
+      @for (environment of environments; track environment) {
+        <mat-option [value]="environment">{{ environment }}</mat-option>
+      }
+    </mat-autocomplete>
+
+    <mat-error
+      *xmControlErrors="formGroup.get('envUrl')?.errors; extraErrorTranslations: extraErrorTranslations; message as message">
+      {{ message }}
+    </mat-error>
+  </mat-form-field>
+
+  <mat-form-field>
+    <mat-label>{{ translates.envStep.tokenLabel | xmTranslate }}</mat-label>
+
+    <input
+      [formControlName]="'token'"
+      [placeholder]="translates.envStep.tokenPlaceholder | xmTranslate"
+      [type]="'text'"
+      matInput>
+
+    <mat-error
+      *xmControlErrors="formGroup.get('token')?.errors; message as message">
+      {{ message }}
+    </mat-error>
+  </mat-form-field>
+</form>

--- a/packages/administration/dashboards-config/components/dashboards-transfer/components/environment-step/environment-step.component.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/components/environment-step/environment-step.component.ts
@@ -1,0 +1,37 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { MatError, MatFormField } from '@angular/material/form-field';
+import { MatInput, MatLabel } from '@angular/material/input';
+import { ControlErrorModule, XmControlErrorsTranslates } from '@xm-ngx/components/control-error';
+import { MatAutocomplete, MatAutocompleteTrigger, MatOption } from '@angular/material/autocomplete';
+import { XmTranslatePipe } from '@xm-ngx/translation';
+
+import { EnvironmentUrl } from '../../types';
+import { errorTranslations, translates } from '../../constants';
+
+@Component({
+    selector: 'xm-environment-step',
+    standalone: true,
+    imports: [
+        MatFormField,
+        MatLabel,
+        MatInput,
+        MatError,
+        ControlErrorModule,
+        ReactiveFormsModule,
+        XmTranslatePipe,
+        MatAutocomplete,
+        MatOption,
+        MatAutocompleteTrigger,
+    ],
+    templateUrl: './environment-step.component.html',
+    styleUrl: './environment-step.component.scss',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class EnvironmentStepComponent {
+    @Input() public formGroup: FormGroup;
+    @Input() public environments: EnvironmentUrl[];
+
+    public readonly translates = translates;
+    public readonly extraErrorTranslations: XmControlErrorsTranslates = errorTranslations;
+}

--- a/packages/administration/dashboards-config/components/dashboards-transfer/components/roles-confirmation-step/roles-confirmation-step.component.html
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/components/roles-confirmation-step/roles-confirmation-step.component.html
@@ -1,0 +1,16 @@
+<mat-list>
+  <cdk-virtual-scroll-viewport
+    #viewport
+    [itemSize]="viewportItemHeight"
+    [style.height.px]="viewportHeight"
+    class="viewport">
+    <mat-list-item *cdkVirtualFor="let role of roles$ | async; index as i; trackBy: trackByFn">
+      <div class="d-flex gap-2">
+        <div class="grey-color">
+          {{ i + 1 }}.
+        </div>
+        {{ role.roleKey }}
+      </div>
+    </mat-list-item>
+  </cdk-virtual-scroll-viewport>
+</mat-list>

--- a/packages/administration/dashboards-config/components/dashboards-transfer/components/roles-confirmation-step/roles-confirmation-step.component.scss
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/components/roles-confirmation-step/roles-confirmation-step.component.scss
@@ -1,0 +1,26 @@
+.viewport {
+  width: 100%;
+}
+
+.position {
+  padding: 0 5px;
+  width: 30px;
+}
+
+.grey-color {
+  color: #666666;
+}
+
+mat-list {
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 0;
+
+  mat-list-item {
+    height: 56px;
+
+    &:not(:last-of-type) {
+      border-bottom: 1px solid #ccc;
+    }
+  }
+}

--- a/packages/administration/dashboards-config/components/dashboards-transfer/components/roles-confirmation-step/roles-confirmation-step.component.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/components/roles-confirmation-step/roles-confirmation-step.component.ts
@@ -1,0 +1,72 @@
+import {
+    ChangeDetectionStrategy,
+    ChangeDetectorRef,
+    Component,
+    inject,
+    Input,
+    OnDestroy,
+    OnInit,
+    ViewChild,
+} from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { filter, map, Observable, tap } from 'rxjs';
+import { startWith } from 'rxjs/operators';
+import { Role } from '@xm-ngx/core/role';
+import { AsyncPipe } from '@angular/common';
+import { CdkFixedSizeVirtualScroll, CdkVirtualForOf, CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
+import { MatList, MatListItem } from '@angular/material/list';
+import { takeUntilOnDestroy, takeUntilOnDestroyDestroy } from '@xm-ngx/operators';
+
+import { DynamicScrollViewportHeight } from '../dynamic-scroll-viewport-height/dynamic-scroll-viewport-height';
+
+@Component({
+    selector: 'xm-roles-confirmation-step',
+    standalone: true,
+    imports: [
+        AsyncPipe,
+        CdkVirtualForOf,
+        CdkVirtualScrollViewport,
+        MatList,
+        MatListItem,
+        CdkFixedSizeVirtualScroll,
+    ],
+    templateUrl: './roles-confirmation-step.component.html',
+    styleUrl: './roles-confirmation-step.component.scss',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RolesConfirmationStepComponent extends DynamicScrollViewportHeight implements OnInit, OnDestroy {
+    @Input() public formGroup: FormGroup;
+
+    @ViewChild('viewport') public cdkVirtualScrollViewport: CdkVirtualScrollViewport;
+
+    public roles$: Observable<Role[]>;
+
+    public cdr: ChangeDetectorRef = inject(ChangeDetectorRef);
+
+    public get selectedControl(): FormControl<Role[]> {
+        return this.formGroup.get('selected') as FormControl<Role[]>;
+    }
+
+    public ngOnInit(): void {
+        this.roles$ = this.selectedControl.valueChanges.pipe(
+            startWith(this.selectedControl.value),
+            filter(Boolean),
+            map((roles: Role[]) => {
+                return roles.filter(role => role?.roleKey);
+            }),
+            tap((roles: Role[]) => {
+                this.changeViewportHeight(roles);
+                this.cdr.detectChanges();
+            }),
+            takeUntilOnDestroy(this),
+        );
+    }
+
+    public ngOnDestroy(): void {
+        takeUntilOnDestroyDestroy(this);
+    }
+
+    public trackByFn(_: number, role: Role): string {
+        return role.roleKey;
+    }
+}

--- a/packages/administration/dashboards-config/components/dashboards-transfer/components/roles-step/roles-step.component.html
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/components/roles-step/roles-step.component.html
@@ -1,0 +1,33 @@
+<mat-form-field>
+  <mat-label>{{ translates.rolesStep.searchLabel | xmTranslate }}</mat-label>
+
+  <input
+    [formControl]="searchTermControl"
+    [placeholder]="translates.rolesStep.searchPlaceholder | xmTranslate"
+    [type]="'text'"
+    matInput>
+</mat-form-field>
+
+<cdk-virtual-scroll-viewport class="viewport" itemSize="56">
+  <mat-selection-list
+    (selectionChange)="onSelectionChange($event)"
+    [color]="'primary'"
+    [multiple]="true"
+    class="selection-list">
+
+    <mat-list-option
+      (selectedChange)="onSelectAll($event)"
+      [togglePosition]="'before'"
+      class="select-all-option">
+      {{ translates.rolesStep.selectAllRoles | xmTranslate }}
+    </mat-list-option>
+
+    <mat-list-option
+      *cdkVirtualFor="let role of items$ | async; templateCacheSize: 0; index as i; trackBy: trackByFn"
+      [selected]="selectionModel.isSelected(role)"
+      [togglePosition]="'before'"
+      [value]="role">
+      {{ role.roleKey }}
+    </mat-list-option>
+  </mat-selection-list>
+</cdk-virtual-scroll-viewport>

--- a/packages/administration/dashboards-config/components/dashboards-transfer/components/roles-step/roles-step.component.scss
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/components/roles-step/roles-step.component.scss
@@ -1,0 +1,14 @@
+.viewport {
+  height: 560px;
+  width: 100%;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.selection-list {
+  padding: 0;
+}
+
+.select-all-option {
+  border-bottom: 1px solid #ccc;
+}

--- a/packages/administration/dashboards-config/components/dashboards-transfer/components/roles-step/roles-step.component.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/components/roles-step/roles-step.component.ts
@@ -1,0 +1,61 @@
+import { ChangeDetectionStrategy, Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { AsyncPipe } from '@angular/common';
+import { CdkFixedSizeVirtualScroll, CdkVirtualForOf, CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
+import { MatFormField, MatLabel } from '@angular/material/form-field';
+import { MatInput } from '@angular/material/input';
+import { MatListOption, MatSelectionList } from '@angular/material/list';
+import { Observable } from 'rxjs';
+import { Role } from '@xm-ngx/core/role';
+import { XmTranslatePipe } from '@xm-ngx/translation';
+import { takeUntilOnDestroy, takeUntilOnDestroyDestroy } from '@xm-ngx/operators';
+
+import { translates } from '../../constants';
+import { AbstractSelectionList, SelectionFormGroup } from '../selection-list/abstract-selection-list';
+
+@Component({
+    selector: 'xm-roles-step',
+    standalone: true,
+    imports: [
+        AsyncPipe,
+        CdkFixedSizeVirtualScroll,
+        CdkVirtualForOf,
+        CdkVirtualScrollViewport,
+        MatFormField,
+        MatInput,
+        MatLabel,
+        MatListOption,
+        MatSelectionList,
+        ReactiveFormsModule,
+        XmTranslatePipe,
+    ],
+    templateUrl: './roles-step.component.html',
+    styleUrl: './roles-step.component.scss',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RolesStepComponent extends AbstractSelectionList<Role> implements OnInit, OnDestroy {
+    @Input() public formGroup: SelectionFormGroup<Role>;
+    @Input() public entities$: Observable<Role[]>;
+
+    public readonly translates = translates;
+
+    public filterFn = (searchTerm: string, roles: Role[]): Role[] => {
+        return roles.filter(role => {
+            return role.roleKey.toLowerCase().includes(searchTerm.trim().toLowerCase());
+        });
+    };
+
+    public ngOnInit(): void {
+        this.items$ = this.getEntities().pipe(
+            takeUntilOnDestroy(this),
+        );
+    }
+
+    public ngOnDestroy(): void {
+        takeUntilOnDestroyDestroy(this);
+    }
+
+    public trackByFn = (_: number, role: Role): string => {
+        return role.roleKey;
+    };
+}

--- a/packages/administration/dashboards-config/components/dashboards-transfer/components/selection-list/abstract-selection-list.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/components/selection-list/abstract-selection-list.ts
@@ -1,0 +1,48 @@
+import { SelectionModel } from '@angular/cdk/collections';
+import { map, Observable, switchMap, tap } from 'rxjs';
+import { FormControl, FormGroup } from '@angular/forms';
+import { MatListOption, MatSelectionListChange } from '@angular/material/list';
+import { debounceTime, startWith } from 'rxjs/operators';
+
+export type SelectionFormGroup<T> = FormGroup<{ selected: FormControl<T[]> }>;
+
+export abstract class AbstractSelectionList<T> {
+    public abstract formGroup: SelectionFormGroup<T>;
+    public abstract entities$: Observable<T[]>;
+    public abstract filterFn: (searchTerm: string, entities: T[]) => T[];
+
+    public selectionModel: SelectionModel<T> = new SelectionModel<T>(true);
+    public items: T[] = [];
+    public searchTermControl: FormControl = new FormControl('');
+
+    public items$: Observable<T[]>;
+    public abstract trackByFn: (_: number, role: T) => unknown;
+
+    public onSelectAll(selected: boolean): void {
+        selected ? this.selectionModel.select(...this.items) : this.selectionModel.clear();
+        this.formGroup.get('selected').patchValue([...this.items], { emitEvent: false });
+    }
+
+    public onSelectionChange(selection: MatSelectionListChange): void {
+        const targetOption: MatListOption = selection.options[0];
+        const targetValues: T[] = [targetOption.value] as T[];
+
+        targetOption.selected ? this.selectionModel.select(...targetValues) : this.selectionModel.deselect(...targetValues);
+        this.formGroup.get('selected').patchValue([...this.selectionModel.selected]);
+    }
+
+    public getEntities(): Observable<T[]> {
+        return this.entities$.pipe(
+            switchMap((entities: T[]) => {
+                return this.searchTermControl.valueChanges.pipe(
+                    startWith(this.searchTermControl.value),
+                    debounceTime(500),
+                    map((searchTerm: string) => this.filterFn(searchTerm, entities)),
+                    tap((entities: T[]) => {
+                        this.items = entities;
+                    }),
+                );
+            }),
+        );
+    }
+}

--- a/packages/administration/dashboards-config/components/dashboards-transfer/constants/actions.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/constants/actions.ts
@@ -1,0 +1,13 @@
+import { Action } from '../types';
+import { marker } from '@biesbjerg/ngx-translate-extract-marker';
+
+export const actions: Action[] = [
+    {
+        translateKey: marker('transfer-dashboards.actionTypeStep.transferDashboards'),
+        value: 'transfer-dashboards',
+    },
+    {
+        translateKey: marker('transfer-dashboards.actionTypeStep.updateRoles'),
+        value: 'update-roles',
+    },
+];

--- a/packages/administration/dashboards-config/components/dashboards-transfer/constants/error-translations.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/constants/error-translations.ts
@@ -1,0 +1,6 @@
+import { XmControlErrorsTranslates } from '@xm-ngx/components/control-error';
+import { marker } from '@biesbjerg/ngx-translate-extract-marker';
+
+export const errorTranslations: XmControlErrorsTranslates = {
+    invalidUrl: marker('xm-control-errors.validators.invalidUrl'),
+};

--- a/packages/administration/dashboards-config/components/dashboards-transfer/constants/index.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/constants/index.ts
@@ -1,0 +1,4 @@
+export * from './error-translations';
+export * from './actions';
+export * from './initial-dashboard-transfer-config';
+export * from './translates';

--- a/packages/administration/dashboards-config/components/dashboards-transfer/constants/initial-dashboard-transfer-config.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/constants/initial-dashboard-transfer-config.ts
@@ -1,0 +1,5 @@
+import { DashboardsTransferConfig } from '../types';
+
+export const initialDashboardTransferConfig: DashboardsTransferConfig = {
+    environments: [],
+};

--- a/packages/administration/dashboards-config/components/dashboards-transfer/constants/translates.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/constants/translates.ts
@@ -1,0 +1,66 @@
+import { marker } from '@biesbjerg/ngx-translate-extract-marker';
+
+export const translates = {
+    actionTypeStepLabel: marker('transfer-dashboards.steps.actionTypeStepLabel'),
+    actionTypeStepTitle: marker('transfer-dashboards.steps.actionTypeStepTitle'),
+
+    environmentStepLabel: marker('transfer-dashboards.steps.environmentStepLabel'),
+    environmentTitle: marker('transfer-dashboards.steps.environmentStepTitle'),
+
+    dashboardsStepLabel: marker('transfer-dashboards.steps.dashboardsStepLabel'),
+    dashboardsTitle: marker('transfer-dashboards.steps.dashboardsStepTitle'),
+
+    dashboardsConfirmStepLabel: marker('transfer-dashboards.steps.dashboardsConfirmationStepLabel'),
+    dashboardsConfirmTitle: marker('transfer-dashboards.steps.dashboardsConfirmationStepTitle'),
+
+    rolesStepLabel: marker('transfer-dashboards.steps.rolesStepLabel'),
+    rolesTitle: marker('transfer-dashboards.steps.rolesStepTitle'),
+
+    rolesConfirmationStepLabel: marker('transfer-dashboards.steps.rolesConfirmationStepLabel'),
+    rolesConfirmationStepTitle: marker('transfer-dashboards.steps.rolesConfirmationStepTitle'),
+
+    doneStepLabel: marker('transfer-dashboards.steps.doneStepLabel'),
+
+    actionNext: marker('transfer-dashboards.actions.next'),
+    actionBack: marker('transfer-dashboards.actions.back'),
+    actionTransfer: marker('transfer-dashboards.actions.transfer'),
+    actionNextWithoutUpdatingRoles: marker('transfer-dashboards.actions.nextWithoutUpdatingRoles'),
+    actionUpdateRoles: marker('transfer-dashboards.actions.updateRoles'),
+    actionDoItAgain: marker('transfer-dashboards.actions.doItAgain'),
+
+    envStep: {
+        urlLabel: marker('transfer-dashboards.envStep.urlLabel'),
+        urlPlaceholder: marker('transfer-dashboards.envStep.urlPlaceholder'),
+        tokenLabel: marker('transfer-dashboards.envStep.tokenLabel'),
+        tokenPlaceholder: marker('transfer-dashboards.envStep.tokenPlaceholder'),
+    },
+    dashboardsStep: {
+        searchLabel: marker('transfer-dashboards.dashboardsStep.searchLabel'),
+        searchPlaceholder: marker('transfer-dashboards.dashboardsStep.searchPlaceholder'),
+        selectAllDashboards: marker('transfer-dashboards.dashboardsStep.selectAllDashboards'),
+    },
+    rolesStep: {
+        searchLabel: marker('transfer-dashboards.rolesStep.searchLabel'),
+        searchPlaceholder: marker('transfer-dashboards.rolesStep.searchPlaceholder'),
+        selectAllRoles: marker('transfer-dashboards.rolesStep.selectAllRoles'),
+    },
+    doneStep: {
+        title: marker('transfer-dashboards.doneStep.title'),
+        successTransferredDashboards: marker('transfer-dashboards.doneStep.successTransferredDashboards'),
+        successUpdatedRoles: marker('transfer-dashboards.doneStep.successUpdatedRoles'),
+        inEnvironment: marker('transfer-dashboards.doneStep.inEnvironment'),
+        pleaseNote: marker('transfer-dashboards.doneStep.pleaseNote'),
+        errorsOccurredWhileUpdating: marker('transfer-dashboards.doneStep.errorsOccurredWhileUpdating'),
+        roles: marker('transfer-dashboards.doneStep.roles'),
+        statusCode: marker('transfer-dashboards.doneStep.statusCode'),
+        errorDescription: marker('transfer-dashboards.doneStep.errorDescription'),
+    },
+    errors: {
+        atLeastOneDashboardRequired: marker('transfer-dashboards.errors.atLeastOneDashboardRequired'),
+        atLeastOneRoleRequired: marker('transfer-dashboards.errors.atLeastOneRoleRequired'),
+    },
+    successMessages: {
+        dashboardSuccessfullyCreated: marker('transfer-dashboards.successMessages.dashboardSuccessfullyCreated'),
+        rolesSuccessfullyUpdated: marker('transfer-dashboards.successMessages.rolesSuccessfullyUpdated'),
+    },
+};

--- a/packages/administration/dashboards-config/components/dashboards-transfer/dashboards-transfer.component.html
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/dashboards-transfer.component.html
@@ -1,0 +1,211 @@
+<mat-horizontal-stepper #stepperRef [linear]="true">
+  <mat-step
+    [editable]="!actionDone"
+    [label]="translates.actionTypeStepLabel | xmTranslate"
+    [stepControl]="actionTypeGroup">
+
+    <h4>{{ translates.actionTypeStepTitle | xmTranslate }}</h4>
+
+    <xm-action-type-step
+      [formGroup]="actionTypeGroup">
+    </xm-action-type-step>
+
+    <div class="actions-wrapper">
+      <button
+        [color]="'primary'"
+        [disabled]="actionTypeGroup.invalid"
+        mat-stroked-button
+        matStepperNext>
+        {{ translates.actionNext | xmTranslate }}
+      </button>
+    </div>
+  </mat-step>
+
+  <mat-step
+    [editable]="!actionDone"
+    [label]="translates.environmentStepLabel | xmTranslate"
+    [stepControl]="envGroup">
+
+    <h4>{{ translates.environmentTitle | xmTranslate }}</h4>
+
+    <xm-environment-step
+      [environments]="config.environments"
+      [formGroup]="envGroup">
+    </xm-environment-step>
+
+    <div class="actions-wrapper">
+      <button
+        [disabled]="loading"
+        mat-button
+        matStepperPrevious>
+        {{ translates.actionBack | xmTranslate }}
+      </button>
+
+      <button
+        (click)="processEnvStep()"
+        [color]="'primary'"
+        [disabled]="loading"
+        mat-stroked-button>
+        {{ translates.actionNext | xmTranslate }}
+      </button>
+    </div>
+  </mat-step>
+
+  @if (action === 'transfer-dashboards') {
+    <mat-step
+      [editable]="envGroup.valid && !actionDone"
+      [label]="translates.dashboardsStepLabel | xmTranslate"
+      [stepControl]="dashboardsGroup">
+
+      <h4>{{ translates.dashboardsTitle | xmTranslate }}</h4>
+
+      <xm-dashboards-step
+        [formGroup]="dashboardsGroup"
+        [entities$]="dashboards$"
+      ></xm-dashboards-step>
+
+      <div class="actions-wrapper">
+        <button
+          [color]="'primary'"
+          [disabled]="loading"
+          mat-button
+          matStepperPrevious>
+          {{ translates.actionBack | xmTranslate }}
+        </button>
+
+        <button
+          (click)="processDashboardsStep()"
+          [color]="'primary'"
+          [disabled]="loading"
+          mat-button>
+          {{ translates.actionNext | xmTranslate }}
+        </button>
+      </div>
+    </mat-step>
+
+    <mat-step
+      [editable]="envGroup.valid && dashboardsGroup.valid && !actionDone"
+      [label]="translates.dashboardsConfirmStepLabel | xmTranslate">
+
+      <h4>{{ translates.dashboardsConfirmTitle | xmTranslate }}</h4>
+
+      @if (loading) {
+        <ng-container [ngTemplateOutlet]="loader"></ng-container>
+      } @else {
+        <xm-dashboard-confirmation-step
+          [formGroup]="dashboardsGroup">
+        </xm-dashboard-confirmation-step>
+      }
+
+      <div class="actions-wrapper">
+        <button
+          [color]="'primary'"
+          [disabled]="loading"
+          mat-button
+          matStepperPrevious>
+          {{ translates.actionBack | xmTranslate }}
+        </button>
+
+        <button
+          (click)="processDashboardsConfirmationStep()"
+          [color]="'primary'"
+          [disabled]="loading || envGroup.invalid || dashboardsGroup.invalid"
+          mat-button>
+          {{ translates.actionTransfer | xmTranslate }}
+        </button>
+      </div>
+    </mat-step>
+  }
+
+  @if (action === 'update-roles') {
+    <mat-step
+      [editable]="!actionDone"
+      [label]="translates.rolesStepLabel | xmTranslate"
+      [stepControl]="rolesGroup">
+
+      <h4>{{ translates.rolesTitle | xmTranslate }}</h4>
+
+      <xm-roles-step
+        [formGroup]="rolesGroup"
+        [entities$]="roles$">
+      </xm-roles-step>
+
+      <div class="actions-wrapper">
+        <button
+          [color]="'primary'"
+          [disabled]="loading"
+          mat-button
+          matStepperPrevious>
+          {{ translates.actionBack | xmTranslate }}
+        </button>
+
+        <button
+          [color]="'primary'"
+          [disabled]="loading"
+          mat-button
+          (click)="processRolesStep()">
+          {{ translates.actionNext | xmTranslate }}
+        </button>
+      </div>
+    </mat-step>
+
+    <mat-step
+      [editable]="envGroup.valid && rolesGroup.valid && !actionDone"
+      [label]="translates.rolesConfirmationStepLabel | xmTranslate">
+
+      <h4>{{ translates.rolesConfirmationStepTitle | xmTranslate }}</h4>
+
+      @if (loading) {
+        <ng-container [ngTemplateOutlet]="loader"></ng-container>
+      } @else {
+        <xm-roles-confirmation-step
+          [formGroup]="rolesGroup">
+        </xm-roles-confirmation-step>
+      }
+
+      <div class="actions-wrapper">
+        <button
+          [color]="'primary'"
+          [disabled]="loading"
+          mat-button
+          matStepperPrevious>
+          {{ translates.actionBack | xmTranslate }}
+        </button>
+
+        <button
+          (click)="processRolesConfirmationStep()"
+          [color]="'primary'"
+          [disabled]="loading || envGroup.invalid || rolesGroup.invalid"
+          mat-button>
+          {{ translates.actionUpdateRoles | xmTranslate }}
+        </button>
+      </div>
+    </mat-step>
+  }
+
+  @if (actionDone) {
+    <mat-step
+      [label]="translates.doneStepLabel | xmTranslate">
+
+      <xm-congratulations-step
+        [formGroup]="rootGroup">
+      </xm-congratulations-step>
+
+      <div class="actions-wrapper">
+        <button
+          (click)="window.location.reload()"
+          [color]="'primary'"
+          mat-button>
+          {{ translates.actionDoItAgain | xmTranslate }}
+        </button>
+      </div>
+    </mat-step>
+  }
+
+</mat-horizontal-stepper>
+
+<ng-template #loader>
+  <div class="loader">
+    <mat-progress-spinner diameter="72" mode="indeterminate"></mat-progress-spinner>
+  </div>
+</ng-template>

--- a/packages/administration/dashboards-config/components/dashboards-transfer/dashboards-transfer.component.scss
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/dashboards-transfer.component.scss
@@ -1,0 +1,20 @@
+.actions-wrapper {
+  padding-top: 1rem;
+}
+
+xm-environment-group {
+  width: 100%;
+  max-width: 1200px;
+  display: block;
+}
+
+//.mat-horizontal-content-container {
+//  padding: 24px;
+//}
+
+.loader {
+  height: 560px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/packages/administration/dashboards-config/components/dashboards-transfer/dashboards-transfer.component.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/dashboards-transfer.component.ts
@@ -1,0 +1,263 @@
+import {
+    AfterViewInit,
+    ChangeDetectionStrategy,
+    Component,
+    inject,
+    Input,
+    OnDestroy,
+    OnInit,
+    ViewChild,
+} from '@angular/core';
+import { MatStep, MatStepper, MatStepperNext, MatStepperPrevious } from '@angular/material/stepper';
+import { MatButton } from '@angular/material/button';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { Defaults, takeUntilOnDestroy, takeUntilOnDestroyDestroy } from '@xm-ngx/operators';
+import { filter, Observable, tap } from 'rxjs';
+import { XmToasterService } from '@xm-ngx/toaster';
+import { DashboardWithWidgets } from '@xm-ngx/core/dashboard';
+import { StepperSelectionEvent } from '@angular/cdk/stepper';
+import { LoaderModule } from '@xm-ngx/components/loader';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
+import { NgTemplateOutlet } from '@angular/common';
+import { XmTranslatePipe } from '@xm-ngx/translation';
+
+import { delay } from 'rxjs/operators';
+import { Role } from '@xm-ngx/core/role';
+
+import { DashboardsTransferDataService } from './services/dashboards-transfer-data.service';
+import { DashboardsTransferApiService } from './services/dashboards-transfer-api.service';
+import { oneItemInArrayRequired, urlValidator } from './validators/';
+import { translates } from './constants/translates';
+import { DashboardsTransferConfig } from './types';
+import { initialDashboardTransferConfig } from './constants';
+import { EnvironmentStepComponent } from './components/environment-step/environment-step.component';
+import { DashboardsStepComponent } from './components/dashboards-step/dashboards-step.component';
+import {
+    DashboardConfirmationStepComponent,
+} from './components/dashboard-confirmation-step/dashboard-confirmation-step.component';
+import { RolesStepComponent } from './components/roles-step/roles-step.component';
+import { CongratulationsStepComponent } from './components/congratulations-step/congratulations-step.component';
+import { ActionTypeStepComponent } from './components/action-type-step/action-type-step.component';
+import {
+    RolesConfirmationStepComponent,
+} from './components/roles-confirmation-step/roles-confirmation-step.component';
+import { DashboardsStateService } from './services/dashboards-state.service';
+import { RolesStateService } from './services/roles-state.service';
+
+@Component({
+    selector: 'xm-dashboards-transfer',
+    standalone: true,
+    imports: [
+        MatStepper,
+        MatStep,
+        MatButton,
+        MatStepperPrevious,
+        EnvironmentStepComponent,
+        DashboardsStepComponent,
+        MatStepperNext,
+        DashboardConfirmationStepComponent,
+        LoaderModule,
+        MatProgressSpinner,
+        NgTemplateOutlet,
+        RolesStepComponent,
+        CongratulationsStepComponent,
+        XmTranslatePipe,
+        ActionTypeStepComponent,
+        RolesConfirmationStepComponent,
+
+    ],
+    templateUrl: './dashboards-transfer.component.html',
+    styleUrl: './dashboards-transfer.component.scss',
+    providers: [DashboardsTransferApiService, DashboardsTransferDataService, RolesStateService, DashboardsStateService],
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DashboardsTransferComponent implements OnInit, AfterViewInit, OnDestroy {
+    @Input() @Defaults(initialDashboardTransferConfig) public config: DashboardsTransferConfig;
+
+    @ViewChild('stepperRef') public stepperRef: MatStepper;
+
+    public rootGroup: FormGroup;
+    public loading: boolean = false;
+    public actionDone: boolean = false;
+
+    public readonly translates = translates;
+
+    protected readonly window = window;
+
+    private readonly fb: FormBuilder = inject(FormBuilder);
+    private readonly notify: XmToasterService = inject(XmToasterService);
+    private readonly transferDataService = inject(DashboardsTransferDataService);
+    private readonly dashboardsStateService = inject(DashboardsStateService);
+    private readonly rolesStateService = inject(RolesStateService);
+
+    public roles$: Observable<Role[]> = this.rolesStateService.getRoles();
+    public dashboards$: Observable<DashboardWithWidgets[]> = this.dashboardsStateService.getDashboards();
+
+    public get actionTypeGroup(): FormGroup {
+        return this.rootGroup.get('actionTypeGroup') as FormGroup;
+    }
+
+    public get action(): string {
+        return this.actionTypeGroup.get('selectedAction').value as string;
+    }
+
+    public get envGroup(): FormGroup {
+        return this.rootGroup.get('envGroup') as FormGroup;
+    }
+
+    public get dashboardsGroup(): FormGroup {
+        return this.rootGroup.get('dashboardsGroup') as FormGroup;
+    }
+
+    public get rolesGroup(): FormGroup {
+        return this.rootGroup.get('rolesGroup') as FormGroup;
+    }
+
+    public ngOnInit(): void {
+        this.buildFormGroups();
+        this.listenLoadingChange();
+        this.listenResetStepperChange();
+    }
+
+    public ngOnDestroy(): void {
+        takeUntilOnDestroyDestroy(this);
+    }
+
+    public ngAfterViewInit(): void {
+        this.listenStepperChange();
+    }
+
+    public processEnvStep(): void {
+        if (this.envGroup.invalid) {
+            this.envGroup.markAllAsTouched();
+            return;
+        }
+
+        this.stepperRef.next();
+    }
+
+    public processDashboardsStep(): void {
+        if (this.dashboardsGroup.invalid) {
+            this.dashboardsGroup.markAllAsTouched();
+            this.notify.create({ type: 'danger', msg: this.translates.errors.atLeastOneDashboardRequired }).subscribe();
+            return;
+        }
+
+        this.stepperRef.next();
+    }
+
+    public processDashboardsConfirmationStep(): void {
+        const { envUrl: url, token } = this.envGroup.value as { envUrl: string; token: string };
+        const { selected } = this.dashboardsGroup.value as { selected: DashboardWithWidgets[] };
+        const selectedDashboards = selected.filter((d: DashboardWithWidgets) => d?.id);
+
+        this.dashboardsStateService.transferDashboards(url, token, selectedDashboards).pipe(
+            filter(Boolean),
+            tap(() => {
+                this.notify.create({
+                    type: 'success',
+                    msg: this.translates.successMessages.dashboardSuccessfullyCreated,
+                    timeout: 5000,
+                });
+                this.actionDone = true;
+            }),
+            delay(500),
+            tap(() => {
+                this.stepperRef.next();
+            }),
+        ).subscribe();
+    }
+
+    public processRolesStep(): void {
+        if (this.rolesGroup.invalid) {
+            this.rolesGroup.markAllAsTouched();
+            this.notify.create({ type: 'danger', msg: this.translates.errors.atLeastOneRoleRequired }).subscribe();
+            return;
+        }
+
+        this.stepperRef.next();
+    }
+
+    public processRolesConfirmationStep(): void {
+        const { envUrl: url, token } = this.envGroup.value as { envUrl: string; token: string };
+        const { selected } = this.rolesGroup.value as { selected: Role[] };
+        const selectedRoles: Role[] = selected.filter((role: Role) => role?.roleKey);
+
+        this.rolesStateService.updateRoles(selectedRoles, { url, token }).pipe(
+            filter(Boolean),
+            tap(() => {
+                this.notify.create({
+                    type: 'success',
+                    msg: this.translates.successMessages.rolesSuccessfullyUpdated,
+                    timeout: 5000,
+                });
+                this.actionDone = true;
+            }),
+            delay(500),
+            tap(() => {
+                this.stepperRef.next();
+            }),
+        ).subscribe();
+    }
+
+    public buildFormGroups(): void {
+        this.rootGroup = this.fb.group({
+            actionTypeGroup: this.fb.group({
+                selectedAction: [null, [Validators.required]],
+            }),
+            envGroup: this.fb.group({
+                envUrl: ['', [Validators.required, urlValidator()]],
+                token: ['', Validators.required],
+            }),
+            dashboardsGroup: this.fb.group({
+                selected: [[], oneItemInArrayRequired()],
+            }),
+            rolesGroup: this.fb.group({
+                selected: [[], oneItemInArrayRequired()],
+            }),
+        });
+    }
+
+    private resetStepInteraction(event: StepperSelectionEvent): void {
+        const { selectedIndex, previouslySelectedIndex } = event || {};
+        if (selectedIndex < previouslySelectedIndex) {
+            this.stepperRef.steps.forEach((step: MatStep, index: number) => index > selectedIndex && (step.interacted = false));
+        }
+    }
+
+    private listenStepperChange(): void {
+        this.stepperRef.selectionChange.pipe(
+            tap((event: StepperSelectionEvent) => {
+                this.resetStepInteraction(event);
+            }),
+            takeUntilOnDestroy(this),
+        ).subscribe();
+    }
+
+    private listenLoadingChange(): void {
+        this.transferDataService.loading$.pipe(
+            tap(loading => this.loading = loading),
+            tap(loading => {
+                const formGroups = Object.values(this.rootGroup.controls) as FormGroup[];
+
+                if (loading) {
+                    formGroups.forEach((group: FormGroup) => group.disable({ emitEvent: false }));
+                } else {
+                    formGroups.forEach((group: FormGroup) => group.enable({ emitEvent: false }));
+                }
+            }),
+            takeUntilOnDestroy(this),
+        ).subscribe();
+    }
+
+    private listenResetStepperChange(): void {
+        this.transferDataService.resetStepper$.pipe(
+            tap(() => {
+                this.rolesStateService.resetErrors();
+                this.stepperRef.reset();
+
+            }),
+            takeUntilOnDestroy(this),
+        ).subscribe();
+    }
+}

--- a/packages/administration/dashboards-config/components/dashboards-transfer/services/dashboards-state.service.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/services/dashboards-state.service.ts
@@ -1,0 +1,63 @@
+import { inject, Injectable } from '@angular/core';
+import { XmToasterService } from '@xm-ngx/toaster';
+import { filter, map, Observable, of, switchMap } from 'rxjs';
+import { DashboardWithWidgets } from '@xm-ngx/core/dashboard';
+import { catchError } from 'rxjs/operators';
+import { HttpErrorResponse } from '@angular/common/http';
+
+import { clearDashboardIds, createWidgetDictionary, mapDashboardWidgets } from '../utils';
+import { DashboardsTransferApiService } from './dashboards-transfer-api.service';
+import { DashboardsTransferDataService } from './dashboards-transfer-data.service';
+import { DashboardWithWidgetsPayloadType, QueryParams, TransferEnv } from '../types';
+
+@Injectable()
+export class DashboardsStateService {
+    private readonly api = inject(DashboardsTransferApiService);
+    private readonly notify = inject(XmToasterService);
+    private readonly dashboardTransferDataService = inject(DashboardsTransferDataService);
+
+    public getDashboards(queryParams: QueryParams = {}, env?: TransferEnv): Observable<DashboardWithWidgets[]> {
+        return this.api.getDashboards(queryParams, env);
+    }
+
+    public transferDashboards(url: string, token: string, dashboards: DashboardWithWidgets[]): Observable<boolean> {
+        this.dashboardTransferDataService.loading = true;
+
+        return this.getFullDashboards(dashboards).pipe(
+            filter(Boolean),
+            map(clearDashboardIds),
+            switchMap((dashboards: DashboardWithWidgetsPayloadType[]) => {
+                return this.api.createDashboards(dashboards, { url, token }).pipe(
+                    catchError((err: HttpErrorResponse) => {
+                        this.handleError(err);
+
+                        return of(false);
+                    }),
+                );
+            }),
+            filter((response => typeof response !== 'boolean')),
+            map(() => {
+                this.dashboardTransferDataService.loading = false;
+                return true;
+            }),
+        );
+    }
+
+    public getFullDashboards(dashboards: DashboardWithWidgets[]): Observable<DashboardWithWidgets[]> {
+        return this.api.getWidgets().pipe(
+            map(createWidgetDictionary),
+            map(mapDashboardWidgets(dashboards)),
+            catchError((err: HttpErrorResponse) => {
+                this.handleError(err);
+
+                return of(null);
+            }),
+        );
+    }
+
+    private handleError(err: HttpErrorResponse): void {
+        this.notify.create({ type: 'danger', msg: err.error.error, timeout: 10000 }).subscribe();
+        this.dashboardTransferDataService.resetStepper();
+        this.dashboardTransferDataService.loading = false;
+    }
+}

--- a/packages/administration/dashboards-config/components/dashboards-transfer/services/dashboards-transfer-api.service.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/services/dashboards-transfer-api.service.ts
@@ -1,0 +1,97 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { DashboardWidget, DashboardWithWidgets } from '@xm-ngx/core/dashboard';
+import { Role } from '@xm-ngx/core/role';
+
+import { DashboardWithWidgetsPayloadType, QueryParams, RequestData, TransferEnv } from '../types';
+
+@Injectable()
+export class DashboardsTransferApiService {
+    private readonly http: HttpClient = inject(HttpClient);
+
+    private readonly DASHBOARD_URL: string = 'dashboard/api/dashboards';
+    private readonly DASHBOARD_BULK_URL: string = 'dashboard/api/dashboards/bulk';
+    private readonly WIDGET_URL: string = 'dashboard/api/widgets';
+    private readonly ROLES_URL: string = 'uaa/api/roles';
+
+    public getDashboards(queryParams: QueryParams = {}, env?: TransferEnv): Observable<DashboardWithWidgets[]> {
+        const { host, headers } = this.getRequestData(env);
+
+        return this.http.get<DashboardWithWidgets[]>(
+            `${host}/${this.DASHBOARD_URL}`,
+            {
+                headers,
+                params: this.generateHttpParams(queryParams),
+            },
+        );
+    }
+
+    public createDashboards(dashboards: DashboardWithWidgetsPayloadType[], env?: TransferEnv): Observable<any> {
+        const { host, headers } = this.getRequestData(env);
+
+        return this.http.post(`${host}/${this.DASHBOARD_BULK_URL}`, dashboards, { headers });
+    }
+
+    public getRoles(queryParams: QueryParams = {}, env?: TransferEnv): Observable<Role[]> {
+        const { host, headers } = this.getRequestData(env);
+
+        return this.http.get<Role[]>(
+            `${host}/${this.ROLES_URL}`,
+            {
+                headers,
+                params: this.generateHttpParams(queryParams),
+            },
+        );
+    }
+
+    public getRole(roleKey: string, env?: TransferEnv): Observable<Role> {
+        const { host, headers } = this.getRequestData(env);
+
+        return this.http.get<Role>(`${host}/${this.ROLES_URL}/${roleKey}`, { headers });
+    }
+
+    public updateRole(role: Role, env?: TransferEnv): Observable<any> {
+        const { host, headers } = this.getRequestData(env);
+
+        return this.http.put(
+            `${host}/${this.ROLES_URL}`,
+            role,
+            { headers },
+        );
+    }
+
+    public getWidgets(queryParams: QueryParams = {}, env?: TransferEnv): Observable<DashboardWidget[]> {
+        const { host, headers } = this.getRequestData(env);
+
+        return this.http.get<DashboardWidget[]>(`${host}/${this.WIDGET_URL}`,
+            {
+                headers,
+                params: this.generateHttpParams(queryParams),
+            });
+    }
+
+    private generateHttpParams(queryParams: QueryParams): HttpParams {
+        const httpParams = new HttpParams();
+        Object.entries(queryParams).forEach(([key, value]) => httpParams.set(key, value));
+
+        return httpParams;
+    }
+
+    private getRequestData(env?: TransferEnv): RequestData {
+        const data: RequestData = {
+            host: '',
+            headers: {},
+        };
+
+        if (env) {
+            data.host = env.url;
+            data.headers = {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${env.token}`,
+            };
+        }
+
+        return data;
+    }
+}

--- a/packages/administration/dashboards-config/components/dashboards-transfer/services/dashboards-transfer-data.service.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/services/dashboards-transfer-data.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Subject } from 'rxjs';
+
+
+@Injectable()
+export class DashboardsTransferDataService {
+    private resetStepper$$ = new Subject<void>();
+    public resetStepper$ = this.resetStepper$$.asObservable();
+
+    private readonly loading$$ = new BehaviorSubject<boolean>(false);
+    public readonly loading$ = this.loading$$.asObservable();
+
+    public set loading(value: boolean) {
+        this.loading$$.next(value);
+    }
+
+    public resetStepper(): void {
+        this.resetStepper$$.next();
+    }
+}

--- a/packages/administration/dashboards-config/components/dashboards-transfer/services/roles-state.service.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/services/roles-state.service.ts
@@ -1,0 +1,73 @@
+import { inject, Injectable } from '@angular/core';
+import { BehaviorSubject, from, map, mergeMap, Observable, of, shareReplay, switchMap } from 'rxjs';
+import { Role } from '@xm-ngx/core/role';
+import { catchError, toArray } from 'rxjs/operators';
+import { HttpErrorResponse } from '@angular/common/http';
+
+import { DashboardsTransferApiService } from './dashboards-transfer-api.service';
+import { DashboardsTransferDataService } from './dashboards-transfer-data.service';
+import { QueryParams, RoleError, TransferEnv } from '../types';
+
+@Injectable()
+export class RolesStateService {
+    private readonly api = inject(DashboardsTransferApiService);
+    private readonly dashboardTransferDataService = inject(DashboardsTransferDataService);
+
+    private errors$$: BehaviorSubject<RoleError[]> = new BehaviorSubject<RoleError[]>([]);
+    public errors$: Observable<RoleError[]> = this.errors$$.asObservable().pipe(
+        shareReplay(1),
+    );
+
+    public set errors(newErrors: RoleError[]) {
+        const oldErrors: RoleError[] = this.errors$$.value;
+        this.errors$$.next([...oldErrors, ...newErrors]);
+    }
+
+    public getRoles(queryParams: QueryParams = {}, env?: TransferEnv): Observable<Role[]> {
+        return this.api.getRoles(queryParams, env);
+    }
+
+    public updateRoles(roles: Role[], env?: TransferEnv): Observable<any> {
+        this.errors = [];
+        this.dashboardTransferDataService.loading = true;
+
+        return from(roles).pipe(
+            mergeMap((role: Role) => {
+                return this.api.getRole(role.roleKey).pipe(
+                    switchMap((role: Role) => {
+                        return this.api.updateRole(role, env).pipe(
+                            catchError((err: HttpErrorResponse) => {
+                                this.addError(err, role);
+
+                                return of(null);
+                            }),
+                        );
+                    }),
+                    catchError((err: HttpErrorResponse) => {
+                        this.addError(err, role);
+
+                        return of(null);
+                    }),
+                );
+            }, 10),
+            toArray(),
+            map(() => {
+                this.dashboardTransferDataService.loading = false;
+                return true;
+            }),
+        );
+    }
+
+    private addError(err: HttpErrorResponse, role: Role): void {
+        const error: RoleError = {
+            roleKey: role.roleKey,
+            errorCode: err.status,
+            errorDescription: err.error.error_description as string,
+        };
+        this.errors = [error];
+    }
+
+    public resetErrors(): void {
+        this.errors$$.next([]);
+    }
+}

--- a/packages/administration/dashboards-config/components/dashboards-transfer/types/actions.interface.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/types/actions.interface.ts
@@ -1,0 +1,4 @@
+export interface Action {
+    translateKey: string;
+    value: string;
+}

--- a/packages/administration/dashboards-config/components/dashboards-transfer/types/dashboard-with-widgets-payload.type.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/types/dashboard-with-widgets-payload.type.ts
@@ -1,0 +1,3 @@
+import { DashboardWithWidgets } from '@xm-ngx/core/dashboard';
+
+export type DashboardWithWidgetsPayloadType = Partial<DashboardWithWidgets>;

--- a/packages/administration/dashboards-config/components/dashboards-transfer/types/dashboards-transfer-config.interface.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/types/dashboards-transfer-config.interface.ts
@@ -1,0 +1,5 @@
+export type EnvironmentUrl = string;
+
+export interface DashboardsTransferConfig {
+    environments: EnvironmentUrl[];
+}

--- a/packages/administration/dashboards-config/components/dashboards-transfer/types/index.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/types/index.ts
@@ -1,0 +1,6 @@
+export * from './transfer-env.interface';
+export * from './dashboard-with-widgets-payload.type';
+export * from './requests-data-types';
+export * from './dashboards-transfer-config.interface';
+export * from './actions.interface';
+export * from './role-error.interface';

--- a/packages/administration/dashboards-config/components/dashboards-transfer/types/requests-data-types.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/types/requests-data-types.ts
@@ -1,0 +1,4 @@
+export type QueryParamValue = string | number | boolean;
+export type QueryParams = { [key: string]: QueryParamValue };
+export type Headers = { [key: string]: string };
+export type RequestData = { host: string; headers: Headers };

--- a/packages/administration/dashboards-config/components/dashboards-transfer/types/role-error.interface.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/types/role-error.interface.ts
@@ -1,0 +1,5 @@
+export interface RoleError {
+    roleKey: string;
+    errorCode: number;
+    errorDescription: string;
+}

--- a/packages/administration/dashboards-config/components/dashboards-transfer/types/transfer-env.interface.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/types/transfer-env.interface.ts
@@ -1,0 +1,4 @@
+export interface TransferEnv {
+    url: string;
+    token: string;
+}

--- a/packages/administration/dashboards-config/components/dashboards-transfer/utils/clear-dashboard-ids.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/utils/clear-dashboard-ids.ts
@@ -1,0 +1,20 @@
+import { DashboardWidget, DashboardWithWidgets } from '@xm-ngx/core/dashboard';
+import {
+    DashboardWithWidgetsPayloadType,
+} from '@xm-ngx/administration/dashboards-config/components/dashboards-transfer/types';
+import { cloneDeep } from 'lodash';
+
+export const clearDashboardIds = (dashboards: DashboardWithWidgets[]): DashboardWithWidgetsPayloadType[] => {
+    return dashboards.map((dashboard: DashboardWithWidgets) => {
+        const dashboardCopy = cloneDeep(dashboard);
+
+        delete dashboardCopy.id;
+
+        (dashboardCopy?.widgets || []).forEach((widget: DashboardWidget) => {
+            delete widget.id;
+            delete widget.dashboard;
+        });
+
+        return dashboardCopy;
+    });
+};

--- a/packages/administration/dashboards-config/components/dashboards-transfer/utils/clear-dashboard-ids.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/utils/clear-dashboard-ids.ts
@@ -1,7 +1,5 @@
 import { DashboardWidget, DashboardWithWidgets } from '@xm-ngx/core/dashboard';
-import {
-    DashboardWithWidgetsPayloadType,
-} from '@xm-ngx/administration/dashboards-config/components/dashboards-transfer/types';
+import { DashboardWithWidgetsPayloadType } from '../types';
 import { cloneDeep } from 'lodash';
 
 export const clearDashboardIds = (dashboards: DashboardWithWidgets[]): DashboardWithWidgetsPayloadType[] => {

--- a/packages/administration/dashboards-config/components/dashboards-transfer/utils/create-widget-dictionary.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/utils/create-widget-dictionary.ts
@@ -1,0 +1,20 @@
+import { DashboardWidget } from '@xm-ngx/core/dashboard';
+
+export const createWidgetDictionary = (widgets: DashboardWidget[]): Map<number, DashboardWidget[]> => {
+    const map = new Map<number, DashboardWidget[]>();
+
+    widgets.forEach((widget: DashboardWidget) => {
+        const id = widget.dashboard as number;
+
+        if (!map.has(id)) {
+            map.set(id, []);
+        }
+
+        const values: DashboardWidget[] = map.get(id);
+        values.push(widget);
+
+        map.set(id, values);
+    });
+
+    return map;
+};

--- a/packages/administration/dashboards-config/components/dashboards-transfer/utils/index.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/utils/index.ts
@@ -1,0 +1,3 @@
+export * from './clear-dashboard-ids';
+export * from './create-widget-dictionary';
+export * from './map-dashboard-widgets';

--- a/packages/administration/dashboards-config/components/dashboards-transfer/utils/map-dashboard-widgets.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/utils/map-dashboard-widgets.ts
@@ -1,0 +1,11 @@
+import { DashboardWidget, DashboardWithWidgets } from '@xm-ngx/core/dashboard';
+
+export const mapDashboardWidgets = (dashboards: DashboardWithWidgets[]) => {
+    return (widgetDictionary: Map<number, DashboardWidget[]>): DashboardWithWidgets[] => {
+        return dashboards.map((dashboard: DashboardWithWidgets) => ({
+            ...dashboard,
+            widgets: widgetDictionary.get(dashboard.id) || [],
+        }));
+    };
+};
+

--- a/packages/administration/dashboards-config/components/dashboards-transfer/validators/index.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/validators/index.ts
@@ -1,0 +1,2 @@
+export * from './url-validator';
+export * from './one-item-in-array-required';

--- a/packages/administration/dashboards-config/components/dashboards-transfer/validators/one-item-in-array-required.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/validators/one-item-in-array-required.ts
@@ -1,0 +1,13 @@
+import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+
+export const oneItemInArrayRequired = (): ValidatorFn => {
+    return (control: AbstractControl): ValidationErrors | null => {
+        const value: unknown = control.value;
+
+        if (!value || !Array.isArray(value) || !value.length) {
+            return { oneItemInArrayRequired: true };
+        }
+
+        return null;
+    };
+};

--- a/packages/administration/dashboards-config/components/dashboards-transfer/validators/url-validator.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/validators/url-validator.ts
@@ -1,0 +1,18 @@
+import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+
+export function urlValidator(): ValidatorFn {
+    return (control: AbstractControl): ValidationErrors | null => {
+        const value: unknown = control.value;
+
+        if (!value || typeof value !== 'string') {
+            return null;
+        }
+
+        try {
+            new URL(value);
+            return null;
+        } catch (error) {
+            return { invalidUrl: true };
+        }
+    };
+}

--- a/packages/administration/dashboards-config/index.ts
+++ b/packages/administration/dashboards-config/index.ts
@@ -15,3 +15,4 @@ export * from './components/dashboards-list/dashboards-import.service';
 export * from './components/dashboards-list/dashboards-list.component';
 export * from './services/dashboards-manager.service';
 export * from './components/xm-dynamic-list.module';
+export * from './components/dashboards-transfer/dashboards-transfer.component';

--- a/packages/administration/module/xm-ngx-administration.module.ts
+++ b/packages/administration/module/xm-ngx-administration.module.ts
@@ -85,6 +85,10 @@ import { XmDynamicModule } from '@xm-ngx/dynamic';
                 loadChildren: () => import('@xm-ngx/administration/dashboards-config').then(m => m.DashboardsConfigComponent),
             },
             {
+                selector: 'dashboards-transfer',
+                loadChildren: () => import('@xm-ngx/administration/dashboards-config').then(m => m.DashboardsTransferComponent),
+            },
+            {
                 selector: 'navbar-dashboard-edit-widget',
                 loadChildren: () => import('@xm-ngx/administration/navbar-dashboard-edit-widget').then(m => m.NavbarDashboardEditWidgetComponent),
             },

--- a/src/i18n/en/core.json
+++ b/src/i18n/en/core.json
@@ -212,7 +212,7 @@
     "id": "Id",
     "info": "Info",
     "editor": "Editor",
-    "samples":  "Samples",
+    "samples": "Samples",
     "import": "Import",
     "delete-existing-dashboards": "Delete existing dashboards?",
     "layout": "Layout",
@@ -1038,7 +1038,8 @@
       "min": "The minimum value is {{min}}.",
       "minlength": "Must be at least {{requiredLength}} characters.",
       "pattern": "Field filled incorrectly.",
-      "required": "The field is required."
+      "required": "The field is required.",
+      "invalidUrl": "Invalid URL format"
     }
   },
   "xm-entity": {
@@ -1686,8 +1687,72 @@
       "code-valid": "The code is valid for 2 minutes. Do not share this code with anyone.",
       "no-sms": "Didn't receive an SMS?",
       "more-sms": "Send again",
-      "signUp":"Registration",
+      "signUp": "Registration",
       "signUp-no-account": "No account?"
+    }
+  },
+  "transfer-dashboards": {
+    "actions": {
+      "next": "Next",
+      "back": "Back",
+      "transfer": "Transfer",
+      "nextWithoutUpdatingRoles": "Next (without update roles)",
+      "updateRoles": "Update roles",
+      "doItAgain": "Do it again"
+    },
+    "steps": {
+      "actionTypeStepLabel": "What do you want to do?",
+      "actionTypeStepTitle": "Select action",
+      "environmentStepLabel": "Enter environment data",
+      "environmentStepTitle": "Environment data",
+      "dashboardsStepLabel": "What dashboards you want to transfer?",
+      "dashboardsStepTitle": "Dashboards",
+      "dashboardsConfirmationStepLabel": "Confirm your dashboards selection",
+      "dashboardsConfirmationStepTitle": "Confirm your dashboards selection",
+      "rolesStepLabel": "What roles you want to update?",
+      "rolesStepTitle": "Roles",
+      "rolesConfirmationStepLabel": "Confirm your roles selection",
+      "rolesConfirmationStepTitle": "Confirm your roles selection",
+      "doneStepLabel": "Done"
+    },
+    "actionTypeStep": {
+      "transferDashboards": "Transfer dashboards",
+      "updateRoles": "Update roles"
+    },
+    "envStep": {
+      "urlLabel": "Environment url",
+      "urlPlaceholder": "Enter environment url",
+      "tokenLabel": "Token",
+      "tokenPlaceholder": "Enter token"
+    },
+    "dashboardsStep": {
+      "searchLabel": "Search dashboards by name",
+      "searchPlaceholder": "Enter dashboard name",
+      "selectAllDashboards": "Select all dashboards"
+    },
+    "rolesStep": {
+      "searchLabel": "Search roles by roleKey",
+      "searchPlaceholder": "Enter role roleKey",
+      "selectAllRoles": "Select all roles"
+    },
+    "doneStep": {
+      "title": "Congratulations!",
+      "successTransferredDashboards": "You have successfully transferred dashboards",
+      "successUpdatedRoles": "You have successfully updated roles",
+      "inEnvironment": "in the environment",
+      "pleaseNote": "please note!",
+      "errorsOccurredWhileUpdating": "Errors occurred while updating",
+      "roles": "roles",
+      "statusCode": "Status code",
+      "errorDescription": "Error description"
+    },
+    "errors": {
+      "atLeastOneDashboardRequired": "At least one dashboard required",
+      "atLeastOneRoleRequired": "At least one role required"
+    },
+    "successMessages": {
+      "dashboardSuccessfullyCreated": "Dashboards successfully created",
+      "rolesSuccessfullyUpdated": "Roles successfully updated"
     }
   }
 }

--- a/src/i18n/uk/core.json
+++ b/src/i18n/uk/core.json
@@ -1,1716 +1,1781 @@
 {
-    "Status:": "",
-    "Unauthorized": "Потрібна авторизація!",
-    "activate": {
-        "messages": {
-            "error": "<strong>Ваш користувач не може бути активований.</strong> Для реєстрації використовуйте реєстраційну форму.",
-            "link": "увійдіть",
-            "register": "Реєстрація",
-            "success": "<strong>Ваш обліковий запис користувача активовано.</strong> Будь ласка,&nbsp;"
-        },
-        "title": "Активація"
+  "Status:": "",
+  "Unauthorized": "Потрібна авторизація!",
+  "activate": {
+    "messages": {
+      "error": "<strong>Ваш користувач не може бути активований.</strong> Для реєстрації використовуйте реєстраційну форму.",
+      "link": "увійдіть",
+      "register": "Реєстрація",
+      "success": "<strong>Ваш обліковий запис користувача активовано.</strong> Будь ласка,&nbsp;"
     },
-    "admin-config": {
-        "common": {
-            "cancel": "Скасувати",
-            "confirm": "Ви впевненi?",
-            "fields": {
-                "config": "Конфігурація",
-                "id": "ID",
-                "layout": "Розмітка",
-                "name": "Назва",
-                "owner": "Власник",
-                "selector": "Селектор",
-                "typeKey": "Код Типу"
-            },
-            "menu": {
-                "dashboard-mng": "Конфігурація Панелі",
-                "mini": {
-                    "dashboard-mng": "КП",
-                    "specification-mng": "С"
-                },
-                "specification-mng": "Специфікації",
-                "title": "Конфігурація"
-            },
-            "save": "Зберегти"
-        },
-        "dashboard-detail-dialog": {
-            "add": {
-                "success": "Успішно",
-                "title": "Додати нову панель"
-            },
-            "edit": {
-                "success": "Успішно",
-                "title": "Редагувати панель"
-            }
-        },
-        "dashboard-list-card": {
-            "export-action": "експорт в JSON",
-            "import-action": "імпорт з JSON",
-            "title": "Панелі"
-        },
-        "specification-mng": {
-            "editor": {
-                "add-entity-spec": "Додайте специфікацію об'єкта",
-                "add-state-spec": "Додайте специфікацію стану",
-                "apply-changes": "Застосувати зміни",
-                "attachments": "Вкладення",
-                "color": "Колір",
-                "coming-soon": "Незабаром...",
-                "comments": "Коментарі",
-                "data-spec": "Специфікація даних",
-                "delete": "Видалити",
-                "form-spec": "Специфікація форми",
-                "functions": "Функції",
-                "icon": "Іконка",
-                "is-abstract": "Абстрактний?",
-                "is-application": "Додаток?",
-                "key": "Ключ",
-                "links": "Зв'язки",
-                "locations": "Місцеположення",
-                "name": "Назва",
-                "next": "Наступні",
-                "plural-name": "Множинна назва",
-                "states": "Стани"
-            },
-            "entity": {
-                "save": "Оновити специфікацію Моделі",
-                "title": "Модель"
-            },
-            "loading": "завантаження специфікації...",
-            "privateui": {
-                "save": "Оновити приватну специфікацію Інтерфейсу",
-                "title": "Приватна специфікація Інтерфейсу"
-            },
-            "tenant": {
-                "save": "Оновити специфікацію Тенанта",
-                "title": "Тенант"
-            },
-            "timeline": {
-                "save": "Оновити специфікацію Історії",
-                "title": "Історія"
-            },
-            "uaa-login": {
-                "save": "Оновити специфікацію Логіна",
-                "title": "Логін"
-            },
-            "uaa": {
-                "save": "Оновити специфікацію UAA",
-                "title": "UAA"
-            },
-            "ui": {
-                "save": "Оновити специфікацію Інтерфейсу",
-                "title": "Інтерфейс"
-            },
-            "validate": "Перевірка"
-        },
-        "widget-detail-dialog": {
-            "add": {
-                "success": "Успішно",
-                "title": "Додати новий віджет"
-            },
-            "edit": {
-                "success": "Успішно",
-                "title": "Редагувати віджет"
-            }
-        },
-        "widget-list-card": {
-            "title": "Віджети"
-        }
-    },
-    "admin-webapp-ext": {
-        "common": {
-            "project": "",
-            "save": ""
-        }
-    },
-    "audits": {
-        "filter": {
-            "from": "від",
-            "title": "Фільтр за датою",
-            "to": "до"
-        },
-        "table": {
-            "data": {
-                "remoteAddress": "Дистанційна адреса:"
-            },
-            "header": {
-                "data": "Додаткові дані",
-                "date": "Дата",
-                "principal": "Користувач",
-                "status": "Стан"
-            }
-        },
-        "title": "Аудит"
-    },
-    "cancel": "",
-    "clientManagement": {
-        "client": {
-            "already": {
-                "exists": "Клієнт з цим ID вже існує!"
-            }
-        },
-        "id": "ID",
-        "clientId": "ID клієнта",
-        "clientSecret": "Пароль клієнта",
-        "createdBy": "Створено",
-        "createdDate": "Дата створення",
-        "delete": {
-            "question": "Ви впевнені, що хочете видалити додаток/клієнт з ідентифікатором {{id}}?"
-        },
-        "description": "Опис",
-        "detail": {
-            "title": "Додаток/Клієнт"
-        },
-        "actions": {
-          "block": "Ви впевнені, що бажаєте заблокувати додаток/клієнта?",
-          "unblock": "Ви впевнені, що бажаєте активувати додаток/клієнта?",
-          "confirm": "Так, підтвердити"
-        },
-        "home": {
-            "createOrEditLabel": "Створіть або відредагуйте дані автентифікації додатку/клієнта",
-            "title": "Додатки/Клієнти"
-        },
-        "lastModifiedBy": "Змінено",
-        "lastModifiedDate": "Дата зміни",
-        "role": "Роль",
-        "roleKey": "Роль",
-        "roles": "Ролі",
-        "scopes-add": "Дозволи(scopes)",
-        "search-by-client-id": "Пошук за ID додатку/клієнта",
-        "validityPeriod": "Термін дії"
-    },
-    "commons": {
-        "required-field": ""
-    },
-    "dashboard-config-widget": {
-        "add-widget": "Додати віджет",
-        "cancel": "Скасувати",
-        "close": "Закрити",
+    "title": "Активація"
+  },
+  "admin-config": {
+    "common": {
+      "cancel": "Скасувати",
+      "confirm": "Ви впевненi?",
+      "fields": {
         "config": "Конфігурація",
-        "copy": "Копія",
-        "copy-clipboard": "Копіювати в буфер обміну",
-        "create": "Створити",
-        "create-dashboard": "Створити панель",
-        "created": "Створено {{value}}",
-        "dashboard": "Інформаційна панель",
-        "dashboards": "Інформаційні панелі",
-        "delete": "Видалити {{value}}",
-        "deleted": "Видалено {{value}}",
-        "duplicate": "Дублювати",
-        "paste": "Вставити з буферу обміну",
-        "back": "Повернутися",
-        "edit-dashboard": "Редагувати панель",
-        "edit-widget": "Редагувати віджет",
-        "empty": "Порожньо",
-        "export": "Експорт",
-        "feedback": {
-            "error": "Помилки при надсиланні відгуку. Спробуйте пізніше",
-            "success": "Відгук надіслано",
-            "tooltip": "Надіслати відгук"
-        },
-        "filter": "Фільтр",
         "id": "ID",
-        "info": "Відомості",
-        "editor": "Редактор",
-        "samples":  "Зразки",
-        "import": "Імпорт",
-        "delete-existing-dashboards": "Видалити існуючі панелі?",
         "layout": "Розмітка",
-        "hidden": "Прихований",
         "name": "Назва",
-        "owner": "Автор",
-        "project": "Проект",
-        "save": "Зберегти",
-        "saved": "Збережено {{value}}",
+        "owner": "Власник",
         "selector": "Селектор",
-        "typeKey": "TypeKey",
-        "updated": "Оновлено {{value}}",
-        "widgets": "Віджети",
-        "historyChangesBtnTitle": "Історія змін",
-        "change-history": "Історія змін",
-        "type": "Тип",
-        "changed-type": "Зміни в",
-        "no-active": "Відстуня активна подія історії",
-        "change-lists": "Перелік змін",
-        "empty-history": "Відстуні записи в історії",
-        "show-more": "Показати більше"
+        "typeKey": "Код Типу"
+      },
+      "menu": {
+        "dashboard-mng": "Конфігурація Панелі",
+        "mini": {
+          "dashboard-mng": "КП",
+          "specification-mng": "С"
+        },
+        "specification-mng": "Специфікації",
+        "title": "Конфігурація"
+      },
+      "save": "Зберегти"
     },
-    "date-time-picker": {
-        "labels": {
-            "from": "Від",
-            "to": "До"
-        }
-    },
-    "entity": {
-        "action": {
-            "back": "Назад",
-            "cancel": "Скасувати",
-            "delete": "Видалити",
-            "save": "Зберегти"
-        },
-        "add": "Додати",
-        "delete": {
-            "title": "Підтвердьте операцію видалення"
-        },
-        "detail": {
-            "square": "Площа: {{квадратний}} м"
-        },
-        "search": "Пошук",
-        "validation": {
-            "maxlength": "Це поле не може перевищувати {{max}} символів.",
-            "required": "Це поле є обов'язковим!"
-        }
-    },
-    "error": {
-        "403": "Ви не маєте дозволу на доступ до цієї сторінки.",
-        "500": "Внутрішня помилка сервера.",
-        "413": "Перевищено ліміт розміру файлу сервера",
-        "NotNull": "Поле {{fieldName}} не може бути порожнім!",
-        "Size": "Поле {{fieldName}} не відповідає мінімальному / максовому розміру!",
-        "accessDenied": "Доступ заборонено",
-        "access_denied": "Доступ заборонено",
-        "business": "Помилка переадресації",
-        "concurrencyFailure": "Помилка паралельного запиту.",
-        "emailexists": "Електронна пошта вже використовується!",
-        "idexists": "Новий {{entityName}} не може вже мати ідентифікатор",
-        "insufficient_scope": "Недостатній обсяг",
-        "internalServerError": "Внутрішня помилка сервера",
-        "invalid_credentials": "Недійсні облікові дані",
-        "invalid_client": "Недійсний клієнт",
-        "invalid_grant": "Недійсний грант",
-        "invalid_request": "Невірний запит",
-        "invalid_scope": "Невірний дозвіл",
-        "invalid_token": "Неприпустимий маркер",
-        "notfound": "Ресурс не знайдено",
-        "privilegeInsufficient": "Недостатньо привилеїв '{{ name }}'!",
-        "privilegeOperationWrong": "Операція не підтримується '{{ name }}'!",
-        "redirect_uri_mismatch": "Невідповідність uri",
-        "server": {
-            "not": {
-                "reachable": "Сервер недоступний"
-            }
-        },
-        "session_expired": "Сесія закінчилася. Будь ласка, авторизуйтесь!",
-        "title": "Сторінка помилки!",
-        "unauthorized": "Необхідна авторизація",
-        "unauthorized_client": "Неавторизований клієнт",
-        "unsupported_grant_type": "Тип гранту не підтримується",
-        "unsupported_response_type": "Тип відповіді не підтримується",
-        "url": {
-            "not": {
-                "found": "Не знайдено"
-            }
-        },
-        "userexists": "Ім'я входу вже використовується!",
-        "validation": "Помилка вхідних параметрів",
-        "NotBlank": "Не пустий",
-        "Unauthorized": "Потрібна авторизація!",
-        "error": {
-            "accessDenied": "Доступ заборонено",
-            "business": "Помилка переадресації",
-            "internalServerError": "Внутрішня помилка сервера"
-        },
-        "not": {
-            "enough": {
-                "credits": "Не достатньо кредитів!"
-            }
-        },
-        "wallet": {
-            "not": {
-                "active": "Гаманець неактивний!"
-            }
-        }
-    },
-    "ext-common-entity": {
-        "available-offerings-widget": {
-            "action-dialog": {
-                "question": "Ви впевнені, що хочете <b>{{action}}</b> для <b>{{name}}</b>?"
-            }
-        },
-        "entity-fab-actions": {
-            "operation-error": "Операція не успішна!",
-            "operation-success": "Операція успішна!"
-        }
-    },
-    "ext-common": {
-        "clock-widget": {
-            "title": "Годинник"
-        },
-        "exchange-widget": {
-            "code": "Код",
-            "course": "Офіційний курс",
-            "currency": "Валюта",
-            "from": "Від",
-            "number-units": "Кількість одиниць",
-            "select-from": "Виберіть валюту з",
-            "select-to": "Виберіть валюту в",
-            "title": "Обмінний калькулятор"
-        },
-        "sign-in-up-widget": {
-            "sign-in": "Вхід",
-            "sign-up": "Зареєструватися"
-        },
-        "weather-widget": {
-            "humidity": "Вологість",
-            "ms": "м/с",
-            "wind-speed": "Швидкість вітру"
-        }
-    },
-    "formPlayground": {
-        "definition": "Визначення",
-        "errors": "- помилки з валідації помилок ():",
-        "liveData": "Живі дані - з onChanges ():",
-        "loading": "(специфікація форми завантаження ...)",
-        "na": "н.д.",
-        "output": "Вихідні дані",
-        "result": "Результат",
-        "selectSchema": "ВИБЕРІТЬ СХЕМУ",
-        "valid": "Коректно?:"
-    },
-    "gateway": {
-        "routes": {
-            "error": "Увага! Сервер не доступний!",
-            "servers": "Доступні сервери",
-            "service": "сервіс",
-            "url": "URL-адреса"
-        },
-        "title": "Шлюз"
-    },
-    "global": {
-        "policies": {
-            "count-passed": "{{count}} з {{required}} умов виконано"
-        },
-        "actionPerformed": "Дія виконана",
-        "all": "Все",
-        "common": {
-            "accept": "Прийняти",
-            "are-you-sure": "Ви впевнені?",
-            "cancel": "Скасувати",
-            "delete": "Видалити",
-            "add-to": "Додати до",
-            "delete-message": "Видалити {{value}}?",
-            "maintenance-description": "Зазвичай це займає кілька хвилин, в іншому випадку зверніться до системного адміністратром.",
-            "maintenance-export-entities": "Експорт сутності",
-            "maintenance-import-entities": "Імпорт сутності",
-            "maintenance-message": "Технічні роботи... <br> Будь ласка, спробуйте пізніше.",
-            "maintenance-reindex-elastic": "Reindex elastic",
-            "maintenance-update-tenant-configuration": "Оновити конфігурацію тенанту",
-            "maintenance-update-tenants-configuration": "Оновити конфігурацію тенантів",
-            "no": "Ні",
-            "set": "Задати",
-            "yes": "Так",
-            "yes-exit": "Так, вийти!",
-            "dbclick-to-edit": "Двічі клацніть, щоб редагувати"
-        },
-        "field": {
-            "id": "Ідентифікатор"
-        },
-        "form": {
-            "confirmpassword": "Нове підтвердження пароля",
-            "email": "Електронна пошта",
-            "firstname": "Ім'я",
-            "language": "Мова",
-            "lastname": "Прізвище",
-            "login": "Логін",
-            "newpassword": "Новий пароль",
-            "oldpassword": "Старий пароль",
-            "otp": "Одноразовий пароль",
-            "show-password": "Показати пароль",
-            "signin": "увійти"
-        },
-        "item-count": "Показано {{first}} - {{second}} із {{total}} елементів.",
-        "menu": {
-            "account": {
-                "help": "Допомога",
-                "help-not-provided": "Контент для сторінки допомоги не задано!",
-                "logout": "Вийти",
-                "mini": {
-                    "password": "П",
-                    "profile": "В",
-                    "settings": "Н"
-                },
-                "password": "Пароль",
-                "passwordSetup": "Запрошення до системи",
-                "profile": "Профіль",
-                "settings": "Налаштування"
-            },
-            "admin": {
-                "apidocs": "API",
-                "audits": "Аудит",
-                "clientManagement": "Керування клієнтами",
-                "dashboard": "Панель управління",
-                "formPlayground": "Тестовый майданчик форми",
-                "gateway": "Шлюз",
-                "health": "Здоров'я",
-                "logs": "Журнали",
-                "main": "Адміністрування",
-                "maintenance": "Обслуговування",
-                "metrics": "Показники",
-                "mini": {
-                    "apidocs": "А.",
-                    "audits": "А.",
-                    "clientManagement": "К",
-                    "formPlayground": "Г",
-                    "gateway": "Ш",
-                    "health": "С",
-                    "logs": "Л",
-                    "maintenance": "О",
-                    "metrics": "М",
-                    "rolesManagement": "Р",
-                    "rolesMatrix": "Р",
-                    "translation": "П",
-                    "userManagement": "К",
-                    "dashboard": "D"
-                },
-                "rolesManagement": "Управління ролями",
-                "rolesMatrix": "Матриця ролей",
-                "translation": "Переклади",
-                "userManagement": "Керування користувачами"
-            },
-            "applications": {
-                "application": "Програма",
-                "main": "Програми"
-            },
-            "dashboards": {
-                "main": "Інформаційні панелі"
-            },
-            "entities": {
-                "attachment": "Вкладення",
-                "calendar": "Календар",
-                "comment": "Коментар",
-                "content": "Вміст",
-                "country": "Країна",
-                "event": "Подія",
-                "jhipster-needle-menu-add-entry": "JHipster will add additional entities here (do not translate!)",
-                "link": "Посилання",
-                "location": "Місцезнаходження",
-                "main": "Об'єкти",
-                "rating": "Рейтинг",
-                "tag": "Тег",
-                "vote": "Голосувати",
-                "xmEntity": "Xm Entity"
-            }
-        },
-        "messages": {
-            "error": {
-                "captchaempty": "Будь ласка, перевірте captcha.",
-                "dontmatch": "Пароль та його підтвердження не збігаються!",
-                "upload-fail": "Сервіс завантаження недосяжний!"
-            },
-            "info": {
-                "authenticated": {
-                    "link": "увійти",
-                    "prefix": "Якщо ти хочеш ",
-                    "suffix": ", ви можете спробувати облікові записи за умовчанням:"
-                }
-            },
-            "validate": {
-                "captcha": {
-                    "required": "Потрібна сaptcha."
-                },
-                "confirmpassword": {
-                    "maxlength": "Ваш пароль підтвердження не може перевищувати 50 символів.",
-                    "minlength": "Ваш пароль підтвердження повинен складатися не менше 4 символів.",
-                    "password-max-length": "Ваш пароль підтвердження не може перевищувати {{maxLength}} символів.",
-                    "password-min-length": "Ваш пароль підтвердження повинен складатися не менше {{minLength}} символів.",
-                    "password-pattern": "Ваш пароль не відповідає шаблону {{pattern}}",
-                    "space": "Ваш пароль підтвердження не може містити пробілів.",
-                    "required": "Ваш пароль для підтвердження необхідний.",
-                    "not-match": "Ваш пароль і пароль підтвердження не збігаються."
-                },
-                "email": {
-                    "invalid": "Ваша електронна адреса недійсна.",
-                    "maxlength": "Ваш електронний лист не може перевищувати 50 символів.",
-                    "minlength": "Ваша електронна адреса повинна містити принаймні 5 символів.",
-                    "required": "Ваша електронна адреса обов'язкова."
-                },
-                "firstname": {
-                    "maxlength": "Ваше ім'я не може перевищувати 50 символів",
-                    "minlength": "Ваше ім'я має містити принаймні 1 символ",
-                    "required": "Ваше ім'я обов'язкове."
-                },
-                "lastname": {
-                    "maxlength": "Ваше прізвище не може перевищувати 50 символів",
-                    "minlength": "Ваше прізвище має містити принаймні 1 символ",
-                    "required": "Ваше прізвище потрібно."
-                },
-                "newpassword": {
-                    "maxlength": "Ваш пароль не може перевищувати 50 символів.",
-                    "minlength": "Ваш пароль повинен складатися не менше 4 символів.",
-                    "password-max-length": "Ваш пароль не може перевищувати {{maxLength}} символів.",
-                    "password-min-length": "Ваш пароль повинен складатися не менше {{minLength}} символів.",
-                    "password-pattern": "Ваш пароль не відповідає шаблону {{pattern}}",
-                    "space": "Ваш пароль не може містити пробілів.",
-                    "required": "Ваш пароль потрібен.",
-                    "strength": "Надійність паролю:"
-                },
-                "oldpassword": {
-                    "maxlength": "Старий пароль не може перевищувати 50 символів.",
-                    "minlength": "Старий пароль повинен складатися не менше 4 символів.",
-                    "password-max-length": "Старий пароль не може перевищувати {{maxLength}} символів.",
-                    "password-min-length": "Старий пароль повинен складатися не менше {{minLength}} символів.",
-                    "password-pattern": "Ваш пароль не відповідає шаблону {{pattern}}",
-                    "required": "Потрібний старий пароль."
-                }
-            }
-        },
-        "new": "Новий",
-        "noData": "Немає даних!",
-        "perPage": "елементів на сторінці",
-        "rest-select-none-option": "Нічого",
-        "rest-select-placeholder-noresults": "Нічого не знайдено",
-        "rest-select-placeholder-search": {
-            "prefix": "",
-            "simple": "Пошук",
-            "suffix": ""
-        },
-        "rest-select-search-more": "Доступні ще результати. Уточніть пошуковий запит!",
-        "ribbon": {
-            "dev": "Розвиток"
-        },
-        "shared": {
-            "ext-md-editor": {
-                "placeholder": "Натисніть кнопку редагувати щоб змінити опис в полі",
-                "placeholder-empty": "Поле пусте! Натисніть кнопку редагувати щоб додати опис в полі",
-                "save-button": "Зберегти зміни"
-            },
-            "privacy-and-terms-dialog": {
-                "i-agree": "Я згоден з Умовами Обслуговування і обробкою своєї інформації, як описано в Політиці Конфіденційності",
-                "title": "Конфіденційність і Умови"
-            }
-        }
-    },
-    "health": {
-        "details": {
-            "details": "Подробиці",
-            "error": "Помилка",
-            "name": "Ім'я",
-            "properties": "Властивості",
-            "value": "Значення"
-        },
-        "indicator": {
-            "binders": "Біндери",
-            "cassandra": "Cassandra",
-            "cdb": "CDB",
-            "configServer": "Сервер конфігурації Microservice",
-            "consul": "Консул",
-            "db": "База даних",
-            "discoveryComposite": "Discovery Composite",
-            "diskSpace": "Дисковий простір",
-            "elasticsearch": "Elastic Search",
-            "healthIndicator": "Health Indicator",
-            "hlr": "HLR",
-            "hystrix": "Hystrix",
-            "mail": "Електронна пошта",
-            "refreshScope": "Обновити обсяги Microservice"
-        },
-        "options": {
-            "done": "Закрити",
-            "instance-name": "Інстанс",
-            "service-name": "Назва сервісу"
-        },
-        "refresh": {
-            "button": "Оновити"
-        },
-        "stacktrace": "Stack trace",
-        "status": {
-            "DOWN": "DOWN",
-            "OUT_OF_SERVICE": "OUT_OF_SERVICE",
-            "UNKNOWN": "UNKNOWN",
-            "UP": "UP"
-        },
-        "table": {
-            "service": "Назва служби",
-            "status": "Статус"
-        },
-        "title": "Перевірки здоров'я"
-    },
-    "home": {
-        "subtitle": "Це ваша домашня сторінка",
-        "title": "Ласкаво просимо!"
-    },
-    "login": {
-        "separator": "Або",
-        "form": {
-            "button": "Увійти",
-            "hide-password": "Приховати пароль",
-            "otpValidateButton": "Вхід",
-            "otpValidateCancel": "Назад",
-            "password": "Пароль",
-            "rememberMe": "Запам'ятати мене",
-            "show-password": "Показати пароль"
-        },
-        "messages": {
-            "error": {
-                "authentication": "<strong>Не вдалося ввійти!</strong> Будь ласка, перевірте свої облікові дані та повторіть спробу."
-            },
-            "otp": {
-                "notification": "Будьласка введіть одноразовий пароль з листа на email"
-            },
-            "idp": {
-                "login-title": "Вхід з OAuth 2.0",
-                "wrong-key": "Неправильний ключ IDP або конфігурація клієнта"
-            }
-        },
-        "password": {
-            "forgot": "Ви забули свій пароль?"
-        },
-        "signin": "Увійти",
-        "signup": "Зареєструватися",
-        "title": "Увійти"
-    },
-    "logs": {
-        "filter": "Фільтрувати",
-        "nbloggers": "Є лічильники {{total}}.",
-        "table": {
-            "level": "Рівень",
-            "name": "Ім'я"
-        },
-        "title": "Журнали"
-    },
-    "mat": {
-        "paginator": {
-            "firstPageLabel": "Перша сторінка",
-            "itemsPerPageLabel": "Показувати по:",
-            "lastPageLabel": "Остання сторінка",
-            "nextPageLabel": "Наступна сторінка",
-            "of": "з",
-            "previousPageLabel": "Попередня сторінка"
-        }
-    },
-    "metrics": {
-        "datasource": {
-            "count": "Рахувати",
-            "max": "Макс",
-            "mean": "Середня",
-            "min": "Хв",
-            "p50": "p50",
-            "p75": "p75",
-            "p95": "p95",
-            "p99": "p99",
-            "title": "Статистика даних (час у мілісекунди)",
-            "usage": "Використання"
-        },
-        "jvm": {
-            "gc": {
-                "marksweepcount": "Відмітити знак &quot;Розминути&quot;",
-                "marksweeptime": "Позначити Sweep час",
-                "scavengecount": "Підраховувати втрати",
-                "scavengetime": "Вичерпати час",
-                "title": "Сміттєві колекції"
-            },
-            "http": {
-                "active": "Активні запити:",
-                "code": {
-                    "notfound": "Не знайдено",
-                    "ok": "Добре",
-                    "servererror": "помилка серверу"
-                },
-                "table": {
-                    "average": "Середній",
-                    "code": "Код",
-                    "count": "Рахувати",
-                    "mean": "Середня"
-                },
-                "title": "HTTP-запити (події в секунду)",
-                "total": "Загальна кількість запитів:"
-            },
-            "memory": {
-                "heap": "Купа пам'яті",
-                "nonheap": "Без пам'яті",
-                "title": "Пам'ять",
-                "total": "Загальна пам'ять"
-            },
-            "threads": {
-                "blocked": "Заблоковано",
-                "dump": {
-                    "blockedcount": "Заблокований граф",
-                    "blockedtime": "Заблокований час",
-                    "hide": "Приховати Stcktrace",
-                    "lockname": "Закріпити ім'я",
-                    "show": "Показати Стаккрайс",
-                    "title": "Нитки скидання",
-                    "waitedcount": "Чекав графа",
-                    "waitedtime": "Очікуване час"
-                },
-                "runnable": "Runnable",
-                "timedwaiting": "Час очікування",
-                "title": "Нитки",
-                "waiting": "Очікування"
-            },
-            "title": "JVM Metrics"
-        },
-        "options": {
-            "done": "Закрити",
-            "f-all": "Всі",
-            "f-blocked": "Заблоковані",
-            "f-runnable": "Runnable",
-            "f-timed-waiting": "Час очікування",
-            "f-waiting": "Очікування",
-            "instance-name": "Інстанс",
-            "service-name": "Назва сервісу"
-        },
-        "servicesstats": {
-            "table": {
-                "count": "Рахувати",
-                "max": "Макс",
-                "mean": "Середня",
-                "min": "Хв",
-                "name": "Назва служби",
-                "p50": "p50",
-                "p75": "p75",
-                "p95": "p95",
-                "p99": "p99"
-            },
-            "title": "Статистика послуг (час у мілісекунди)"
-        },
-        "title": "Метрики додатків",
-        "updating": "Оновлення ..."
-    },
-    "navbar": {
-        "notification": "Сповіщення",
-        "search": "Пошук",
-        "toggleNotification": "Переключити навігацію"
-    },
-    "time": {
-        "now": "Щойно",
-        "minAgo": "1 хвилину тому",
-        "minsAgo": " хвилин(-и) тому",
-        "hourAgo": "1 годину тому",
-        "hoursAgo": " годин(-и) тому",
-        "yesterday": "Вчора",
-        "daysAgo": " дні(-в) тому",
-        "weeksAgo": " тиж. тому"
-    },
-    "password": {
-        "form": {
-            "button": "Зберегти"
-        },
-        "messages": {
-            "error": "<strong>Сталася помилка!</strong> Пароль не може бути змінений.",
-            "success": "<strong>Пароль змінено!</strong>"
-        },
-        "title": "Пароль для [ <b>{{username}}</b> ]"
-    },
-    "register": {
-        "form": {
-            "button": "Зареєструватися"
-        },
-        "messages": {
-            "error": {
-                "emailempty": "<strong>Email не може бути порожнім!</strong> Будь ласка, виберіть один.",
-                "fail": "<strong>Реєстрація не вдалося!</strong> Будь-ласка спробуйте пізніше.",
-                "userexists": "<strong>Логін вже зареєстрований!</strong> Будь ласка, виберіть інший."
-            },
-            "success": "<strong>Реєстрація збережена!</strong> Будь ласка, перевірте свою електронну пошту для підтвердження."
-        },
-        "title": "Реєстрація"
-    },
-    "reset": {
-        "finish": {
-            "form": {
-                "button": "Перевірити новий пароль"
-            },
-            "messages": {
-                "error": "Ваш пароль неможливо скинути. Пам'ятайте, що запит на введення пароля дійсний лише 24 години.",
-                "info": "Виберіть новий пароль",
-                "keyexpired": "Ключ запиту вже не дійсний.",
-                "keymissing": "Ключ скидання відсутній.",
-                "keyused": "Ключ запиту вже використовувався.",
-                "success": "<strong>Ваш пароль був скинутий.</strong> Будь ласка&nbsp;"
-            },
-            "title": "Скинути пароль"
-        },
-        "request": {
-            "form": {
-                "button": "Скинути пароль"
-            },
-            "messages": {
-                "info": "Введіть електронну адресу, яку ви використовували для реєстрації",
-                "notfound": "<strong>Електронна адреса не зареєстрована!</strong> Будь ласка, перевірте та повторіть спробу",
-                "success": "Перегляньте свої електронні листи, щоб дізнатись, як змінити пароль."
-            },
-            "title": "Скинути пароль"
-        },
-        "setup": {
-            "form": {
-                "button": "Встановити пароль"
-            },
-            "messages": {
-                "error": "Ваш пароль неможливо створити. Пам'ятайте, що запит на введення пароля дійсний лише 24 години.",
-                "info": "Вигадайте новий пароль",
-                "success": "<strong>Ваш пароль було створено.</strong> Будь ласка,&nbsp;"
-            },
-            "title": "Налаштуйте свій пароль"
-        }
-    },
-    "rolesManagement": {
-        "basedOn": "На основі",
-        "chooseRole": "Виберіть роль",
-        "createdBy": "Створено",
-        "createdDate": "Дата створення",
-        "delete": {
-            "question": "Ви впевнені, що хочете видалити роль '{{ roleKey }}'?"
-        },
-        "description": "Опис",
-        "detail": {
-            "permissions": "права доступу",
-            "title": "Роль"
-        },
-        "home": {
-            "labelCreate": "Створити нову роль",
-            "labelEdit": "Редагувати роль",
-            "title": "Ролі"
-        },
-        "key": "Ім'я",
-        "lastModifiedBy": "Змінено",
-        "lastModifiedDate": "Дата зміни",
-        "matrix": {
-            "title": "Матриця ролей"
-        },
-        "ok": "Ok",
-        "permission": {
-            "checkAll": "Відзначити всі",
-            "condition": "Умова",
-            "conditionEnvInfo": "1. використовуйте SpEL функцiональнiсть<br>2. використовуйте # перед змiнною<br>3. #subject.role, #subject.userKey, #subject.login змiннi доступнi<br>4. #env['ipAddress'] змiнна доступна",
-            "conditionResourceInfo": "1. використовуйте SpEL функцiональнiсть<br>2. використовуйте # перед змiнною<br>3. #subject.role, #subject.userKey, #subject.login змiннi доступнi",
-            "createCondition": "Створення умови",
-            "desc": "Опис",
-            "editCondition": "Редагування умови",
-            "envCondition": "Умови середовища",
-            "msName": "Назва МС",
-            "notPermitted": "недозволенi",
-            "onForbid": "При забороні",
-            "permit": "Дозвіл",
-            "permitted": "дозволенi",
-            "permittedAny": "принаймні один",
-            "privilegeKey": "Ключ привілею",
-            "resourceCondition": "Умови ресурсу"
-        },
-        "selected": "Тільки обрані",
-        "variables": "Доступні змінні"
-    },
-    "settings": {
-        "form": {
-            "button": "Зберегти",
-            "general": "Загальна інформація",
-            "local-time": "Місцевий час: ",
-            "logins": "Логіни",
-            "offset-time": "Зміщення часового поясу: ",
-            "utc-time": "UTC-час: "
-        },
-        "messages": {
-            "logins": {
-                "success": "<strong>Логін збережений!</strong>"
-            },
-            "success": "<strong>Налаштування збережено!</strong>"
-        },
-        "security": {
-            "autoLogout": "Авто вихід",
-            "name": "Параметри безпеки",
-            "seconds": "секунди",
-            "twoFAStatus": "Двофакторна аутентифікація"
-        }
-    },
-    "social": {
-        "register": {
-            "errorTitle": "Зареєструйтеся за допомогою зовнішнього облікового запису",
-            "messages": {
-                "error": {
-                    "fail": "<strong>Реєстрація не вдалося!</strong> Під час валідації вашого зовнішнього облікового запису сталася помилка, ми радимо спробувати інше з'єднання."
-                },
-                "success": "<strong>Реєстрація збережена!</strong> Будь ласка, перевірте свою електронну пошту для підтвердження."
-            },
-            "title": "Зареєструватися за {{label}}"
-        }
-    },
-    "swagger": {
-        "select-component": "Оберiть компонент"
-    },
-    "translate-managment": {
-        "clear-cache-button": "Очистити поточний кеш перекладів",
-        "download-button": "Зкачати переклади",
-        "filter-by-key": "Фільтрувати по ключу",
-        "filter-by-value": "Фільтрувати по значенню",
-        "save-all-button": "Зберегти все",
-        "title": {
-          "main": "Керування перекладами",
-          "project": "Переклади проекту",
-          "config": "Переклад конфігурації"
-        }
-    },
-    "userManagement": {
-        "activated": "Активовано",
-        "autoLogout": "Автоматичний вихід",
-        "createdBy": "Створений",
-        "createdDate": "Дата створення",
-        "deactivated": "Деактивовано",
-        "delete": {
-            "question": "Ви впевнені, що хочете видалити користувача з логіном {{userKey}}?"
-        },
-        "detail": {
-            "title": "Користувач"
-        },
-        "actions": {
-          "block": "Ви впевнені, що бажаєте заблокувати користувача?",
-          "unblock": "Ви впевнені, що бажаєте активувати користувача?",
-          "enable2famsg": "Ви впевнені, що хочете увімкнути 2FA?",
-          "enable2fabtn": "Так, увімкнути",
-          "disable2famsg": "Ви впевнені, що хочете вимкнути 2FA?",
-          "disable2fabtn": "Так, вимкнути"
-        },
-        "error": "Помилка",
-        "firstName": "Ім'я",
-        "home": {
-            "createOrEditLabel": "Створіть або відредагуйте користувача",
-            "editLoginsLabel": "Оновити логіни користувачів",
-            "title": "Користувачі"
-        },
-        "id": "ID",
-        "langKey": "Мова",
-        "lastModifiedBy": "Змінено",
-        "lastModifiedDate": "Дата зміни",
-        "lastName": "Прізвище",
-        "logins": "Логіни",
-        "onlineUsers": "Користувачів онлайн: ",
-        "role": "Роль",
-        "search-by-login": "Шукати за логіном",
+    "dashboard-detail-dialog": {
+      "add": {
         "success": "Успішно",
-        "twoFADisabled": "Двофакторна аутентифікація деактивована",
-        "twoFAEnabled": "Двофакторна аутентифікація активована",
-        "userKey": "Ключ користувача"
+        "title": "Додати нову панель"
+      },
+      "edit": {
+        "success": "Успішно",
+        "title": "Редагувати панель"
+      }
     },
-    "wordAutocomplete": {
-        "hint": "Введіть Ctrl+Space для відображення підказки",
-        "noVariables": "Слово не знайдено"
+    "dashboard-list-card": {
+      "export-action": "експорт в JSON",
+      "import-action": "імпорт з JSON",
+      "title": "Панелі"
     },
-    "xm-balance": {
-        "balance-detail-dialog": {
-            "title": "Деталізація балансу"
-        },
-        "balance-list-card": {
-            "title": "Баланси"
-        },
-        "common": {
-            "cancel": "Скасувати",
-            "fields": {
-                "amount": "Кількість",
-                "end-date": "Дата закінчення",
-                "label": "Позначка",
-                "start-date": "Дата початку"
-            }
-        }
+    "specification-mng": {
+      "editor": {
+        "add-entity-spec": "Додайте специфікацію об'єкта",
+        "add-state-spec": "Додайте специфікацію стану",
+        "apply-changes": "Застосувати зміни",
+        "attachments": "Вкладення",
+        "color": "Колір",
+        "coming-soon": "Незабаром...",
+        "comments": "Коментарі",
+        "data-spec": "Специфікація даних",
+        "delete": "Видалити",
+        "form-spec": "Специфікація форми",
+        "functions": "Функції",
+        "icon": "Іконка",
+        "is-abstract": "Абстрактний?",
+        "is-application": "Додаток?",
+        "key": "Ключ",
+        "links": "Зв'язки",
+        "locations": "Місцеположення",
+        "name": "Назва",
+        "next": "Наступні",
+        "plural-name": "Множинна назва",
+        "states": "Стани"
+      },
+      "entity": {
+        "save": "Оновити специфікацію Моделі",
+        "title": "Модель"
+      },
+      "loading": "завантаження специфікації...",
+      "privateui": {
+        "save": "Оновити приватну специфікацію Інтерфейсу",
+        "title": "Приватна специфікація Інтерфейсу"
+      },
+      "tenant": {
+        "save": "Оновити специфікацію Тенанта",
+        "title": "Тенант"
+      },
+      "timeline": {
+        "save": "Оновити специфікацію Історії",
+        "title": "Історія"
+      },
+      "uaa-login": {
+        "save": "Оновити специфікацію Логіна",
+        "title": "Логін"
+      },
+      "uaa": {
+        "save": "Оновити специфікацію UAA",
+        "title": "UAA"
+      },
+      "ui": {
+        "save": "Оновити специфікацію Інтерфейсу",
+        "title": "Інтерфейс"
+      },
+      "validate": "Перевірка"
     },
-    "xm-bool-control": {
-        "cancel": "Скасувати",
-        "false": "Ні",
-        "true": "Так"
+    "widget-detail-dialog": {
+      "add": {
+        "success": "Успішно",
+        "title": "Додати новий віджет"
+      },
+      "edit": {
+        "success": "Успішно",
+        "title": "Редагувати віджет"
+      }
     },
-    "xm-control-errors": {
-        "validators": {
-            "email": "Ваша електронна адреса некоректна.",
-            "max": "Максимальне значення {{max}}.",
-            "maxlength": "Не може перевищувати {{requiredLength}} символів.",
-            "min": "Мінімальне значення {{min}}.",
-            "minlength": "Повинно містити принаймні {{requiredLength}} символів.",
-            "pattern": "Поле заповнено некоректно.",
-            "required": "Поле обов'язкове для заповнення."
-        }
-    },
-    "xm-entity": {
-        "attachment-card": {
-            "delete": {
-                "button": "Так, видалити!",
-                "button-cancel": "Скасувати",
-                "remove-error": "Вкладення не видалено. Спробуй ще раз.",
-                "remove-success": "Вкладення успішно видалено.",
-                "title": "Ви дійсно хочете видалити вкладення?"
-            },
-            "no-data": "Ще не додано жодного файлу",
-            "title": "Файли",
-            "volume": {
-                "GB": "Гб",
-                "KB": "Кб",
-                "MB": "Мб",
-                "PB": "Пб",
-                "TB": "Тб",
-                "bytes": "байт"
-            }
-        },
-        "attachment-detail-dialog": {
-            "add": {
-                "success": "Вкладення успішно додано."
-            },
-            "choose-type": "Виберіть тип вкладення",
-            "title": "Додати нове вкладення для",
-            "upload": "Натисніть, щоб завантажити, або перетягніть файл сюди.",
-            "wrong-type-error": "Заборонений тип файлу {{fileType}}"
-        },
-        "calendar-card": {
-            "calendar": {
-                "btn-list-day": "День (список)",
-                "btn-list-week": "Тиждень (список)"
-            },
-            "delete": {
-                "button": "Так, видалити!",
-                "button-cancel": "Скасувати",
-                "remove-error": "Подію не видалено. Спробуй ще раз.",
-                "remove-success": "Подію успішно видалено.",
-                "title": "Ви дійсно хочете видалити подію?"
-            }
-        },
-        "calendar-event-dialog": {
-            "add": {
-                "success": "Подію додано успішно."
-            },
-            "choose-type": "Виберіть тип події",
-            "title": "Додати нову подію для",
-            "title-edit": "Редагувати подію для"
-        },
-        "comment-detail-dialog": {
-            "add": {
-                "success": "Коментар успішно додано."
-            },
-            "choose-type": "Виберіть тип коментаря",
-            "title": "Додати коментар для"
-        },
-        "common": {
-            "add": "Додати",
-            "add-avatar": "Додати фото",
-            "cancel": "Скасувати",
-            "change-avatar": "Звінити фото",
-            "close": "Закрити",
-            "fields": {
-                "addressLine1": "Адресний Рядок 1",
-                "addressLine2": "Адресний Рядок 2",
-                "city": "Населений пункт",
-                "description": "Опис",
-                "end-date": "Дата закінчення",
-                "id": "ID",
-                "latitude": "Широта",
-                "longitude": "Довгота",
-                "message": "Коментар",
-                "name": "Ім'я/Назва",
-                "region": "Область",
-                "start-date": "Дата створення",
-                "state": "Статус",
-                "title": "Тема",
-                "type": "Тип",
-                "zip": "Поштовий індекс"
-            },
-            "save": "Зберегти",
-            "search": "Пошук",
-            "validation": {
-                "coordinates": "Це поле не відповідає формату широти та довготи.",
-                "date-time": "Це поле повинно бути дата і час.",
-                "pattern": "Це поле не відповідає правилам",
-                "required": "Це поле є обов'язковим!"
-            }
-        },
-        "entity-data-card": {
-            "title": "Дані",
-            "created-by": "Створив(ла)",
-            "created-date": "Дата створення",
-            "updated-by": "Оновив(ла)",
-            "updated-date": "Дата оновлення",
-            "update-error": "Не оновлено. Спробуйте ще раз.",
-            "update-success": "Оновлено успішно.",
-            "change-avatar": "Змінити фото",
-            "current-state": "Поточний статус"
-        },
-        "entity-detail-dialog": {
-            "add": {
-                "choose-type": "Виберіть тип",
-                "title": "Додати новий запис"
-            },
-            "edit": {
-                "title": "Редагування об'єкта"
-            }
-        },
-        "entity-detail-fab": {
-            "new": "Додати новий",
-            "edit-entity": "Редагувати",
-            "new-attachment": "Додати файл",
-            "new-comment": "Додати кометар",
-            "new-link": "Додати посилання",
-            "new-location": "Додати локацiю"
-        },
-        "entity-list-card": {
-            "action-dialog": {
-                "question": "Ви впевнені, що хочете <b>{{action}}</b> для <b>{{name}}</b>?"
-            },
-            "delete": {
-                "button": "Так, видалити!",
-                "button-cancel": "Скасувати",
-                "remove-error": "Не видалено. Спробуй ще раз.",
-                "remove-success": "Успішно видалено.",
-                "title": "Ви дійсно хочете видалити?"
-            },
-            "export": {
-                "action": {
-                    "csv": "csv",
-                    "downloads": "Завантажити",
-                    "xls": "xls"
-                }
-            },
-            "filters-hide": "Сховаты фільтри",
-            "filters-show": "Показати фільтри",
-            "open": "Відкрити",
-            "refresh": "Оновити"
-        },
-        "entity-list-fab": {
-            "new-generated": "Згенеровано!"
-        },
-        "function-list-card": {
-            "change-state": {
-                "button": "Так, змінити!",
-                "error": "Стан не змінився. Спробуй ще раз.",
-                "success": "Стан успішно змінено.",
-                "title": "Ви дійсно хочете змінити стан?"
-            },
-            "current-state": "Поточний стан: ",
-            "general-group": "Загальні Функції",
-            "next-states": "Наступні стани доступні по життєвому циклу:",
-            "other-functions": "Інші Функції:",
-            "title": "Функції"
-        },
-        "link-detail-dialog": {
-            "add-link": "Додати",
-            "add": {
-                "build-type-new": "Нова",
-                "build-type-search": "Пошук",
-                "error": "Посилання не додане. Спробуй ще раз.",
-                "success": "Посилання успішно додане.",
-                "title": "Додати нове Посилання для"
-            },
-            "show-more": "Показати більше"
-        },
-        "link-list-card": {
-            "delete": {
-                "button": "Так, видалити!",
-                "button-cancel": "Скасувати",
-                "remove-error": "Посилання не видалене. Спробуй ще раз.",
-                "remove-success": "Посилання видалене успішно.",
-                "title": "Ви дійсно хочете видалити посилання?"
-            },
-            "list-view": "Перегляд списком",
-            "tree-view": "Перегляд деревом"
-        },
-        "link-list-tree-section": {
-            "collapse": "Згорнути цю гілку"
-        },
-        "location-detail-dialog": {
-            "add": {
-                "success": "Місцезнаходження успішно додано.",
-                "title": "Додати нове місце розташування для"
-            },
-            "choose-country": "Виберіть країну",
-            "choose-type": "Виберіть тип розташування (обов'язково)",
-            "countries": {
-                "AD": "Андорра",
-                "AE": "Об'єднані Арабські Емірати",
-                "AF": "Афганістан",
-                "AG": "Антигуа і Барбуда",
-                "AI": "Ангілья",
-                "AL": "Албанія",
-                "AM": "Арменія",
-                "AO": "Ангола",
-                "AQ": "Антарктида",
-                "AR": "Аргентина",
-                "AS": "Американське Самоа",
-                "AT": "Австрія",
-                "AU": "Австралія",
-                "AW": "Аруба",
-                "AX": "Аландські острови",
-                "AZ": "Азербайджан",
-                "BA": "Боснія і Герцеговина",
-                "BB": "Барбадос",
-                "BD": "Бангладеш",
-                "BE": "Бельгія",
-                "BF": "Буркіна-Фасо",
-                "BG": "Болгарія",
-                "BH": "Бахрейн",
-                "BI": "Бурунді",
-                "BJ": "Бенін",
-                "BL": "Сен-Бартельмі",
-                "BM": "Бермуди",
-                "BN": "Бруней Даруссалам",
-                "BO": "Болівія",
-                "BQ": "Карибські Нідерланди",
-                "BR": "Бразилія",
-                "BS": "Багами",
-                "BT": "Бутан",
-                "BV": "Острів Буве",
-                "BW": "Ботсвана",
-                "BY": "Білорусь",
-                "BZ": "Беліз",
-                "CA": "Канада",
-                "CC": "Кокосові острови",
-                "CD": "Демократична Республіка Конго",
-                "CF": "Центральноафриканська Республіка",
-                "CG": "Республіка Конго",
-                "CH": "Швейцарія",
-                "CI": "Кот-д'Івуар",
-                "CK": "Острови Кука",
-                "CL": "Чілі",
-                "CM": "Камерун",
-                "CN": "КНР (Китайська Народна Республіка)",
-                "CO": "Колумбія",
-                "CR": "Коста-Рика",
-                "CU": "Куба",
-                "CV": "Кабо-Верде",
-                "CW": "Кюрасао",
-                "CX": "Острів Різдва",
-                "CY": "Кіпр",
-                "CZ": "Чехія",
-                "DE": "Німеччина",
-                "DJ": "Джибуті",
-                "DK": "Данія",
-                "DM": "Домініка",
-                "DO": "Домініканська Республіка",
-                "DZ": "Алжир",
-                "EC": "Еквадор",
-                "EE": "Естонія",
-                "EG": "Єгипет",
-                "EH": "САДР",
-                "ER": "Еритрея",
-                "ES": "Іспанія",
-                "ET": "Ефіопія",
-                "FI": "Фінляндія",
-                "FJ": "Фіджі",
-                "FK": "Фолклендські Острови",
-                "FM": "Мікронезія",
-                "FO": "Фарерські острови",
-                "FR": "Франція",
-                "GA": "Габон",
-                "GB": "Великобританія",
-                "GD": "Гренада",
-                "GE": "Грузія",
-                "GF": "Гвіана",
-                "GG": "Гернсі",
-                "GH": "Гана",
-                "GI": "Гібралтар",
-                "GL": "Ґренландія",
-                "GM": "Гамбія",
-                "GN": "Гвінея",
-                "GP": "Гваделупа",
-                "GQ": "Екваторіальна Гвінея",
-                "GR": "Греція",
-                "GS": "Південна Джорджія та Південні Сандвічеві Острови",
-                "GT": "Гватемала",
-                "GU": "Гуам",
-                "GW": "Гвінея-Бісау",
-                "GY": "Гаяна",
-                "HK": "Гонконг",
-                "HM": "Острів Герд і острови Макдональд",
-                "HN": "Гондурас",
-                "HR": "Хорватія",
-                "HT": "Гаїті",
-                "HU": "Угорщина",
-                "ID": "Індонезія",
-                "IE": "Ірландія",
-                "IL": "Ізраїль",
-                "IM": "Острів Мен",
-                "IN": "Індія",
-                "IO": "Британська Територія в Індійському Океані",
-                "IQ": "Ірак",
-                "IR": "Іран",
-                "IS": "Ісландія",
-                "IT": "Італія",
-                "JE": "Джерсі",
-                "JM": "Ямайка",
-                "JO": "Йорданія",
-                "JP": "Японія",
-                "KE": "Кенія",
-                "KG": "Киргизстан",
-                "KH": "Камбоджа",
-                "KI": "Кірибаті",
-                "KM": "Коморські Острови",
-                "KN": "Сент-Кіттс і Невіс",
-                "KP": "КНДР (Корейська Народно-Демократична Республіка)",
-                "KR": "Південна Корея",
-                "KW": "Кувейт",
-                "KY": "Кайманові Острови",
-                "KZ": "Казахстан",
-                "LA": "Лаос",
-                "LB": "Ліван",
-                "LC": "Сент-Люсія",
-                "LI": "Ліхтенштейн",
-                "LK": "Шрі-Ланка",
-                "LR": "Ліберія",
-                "LS": "Лесото",
-                "LT": "Литва",
-                "LU": "Люксембург",
-                "LV": "Латвія",
-                "LY": "Лівія",
-                "MA": "Марокко",
-                "MC": "Монако",
-                "MD": "Молдова",
-                "ME": "Чорногорія",
-                "MF": "Сен-Мартен",
-                "MG": "Мадагаскар",
-                "MH": "Маршаллові Острови",
-                "MK": "Македонія",
-                "ML": "Малі",
-                "MM": "М'янма",
-                "MN": "Монголія",
-                "MO": "Аоминь",
-                "MP": "Північні Маріанські Острови",
-                "MQ": "Мартиніка",
-                "MR": "Мавританія",
-                "MS": "Монтсеррат",
-                "MT": "Мальта",
-                "MU": "Маврикій",
-                "MV": "Мальдівы",
-                "MW": "Малаві",
-                "MX": "Мексика",
-                "MY": "Малайзія",
-                "MZ": "Мозамбік",
-                "NA": "Намібія",
-                "NC": "Нова Каледонія",
-                "NE": "Нігер",
-                "NF": "Острів Норфолк",
-                "NG": "Нігерія",
-                "NI": "Нікарагуа",
-                "NL": "Нідерланди",
-                "NO": "Норвегія",
-                "NP": "Непал",
-                "NR": "Науру",
-                "NU": "Ніуе",
-                "NZ": "Нова Зеландія",
-                "OM": "Оман",
-                "PA": "Панама",
-                "PE": "Перу",
-                "PF": "Французька Полінезія",
-                "PG": "Папуа Нова Гвінея",
-                "PH": "Філіппіни",
-                "PK": "Пакистан",
-                "PL": "Польша",
-                "PM": "Сен-П'єр і Мікелон",
-                "PN": "Піткерн",
-                "PR": "Пуерто-Ріко",
-                "PS": "Палестинська держава",
-                "PT": "Португалія",
-                "PW": "Палау",
-                "PY": "Парагвай",
-                "QA": "Катар",
-                "RE": "Реюньйон",
-                "RO": "Румунія",
-                "RS": "Сербія",
-                "RU": "Росія",
-                "RW": "Руанда",
-                "SA": "Саудівська Аравія",
-                "SB": "Соломонові Острови",
-                "SC": "Сейшельські Острови",
-                "SD": "Судан",
-                "SE": "Швеція",
-                "SG": "Сінгапур",
-                "SH": "Острови Святої Єлени, Вознесіння і Тристан-да-Кунья",
-                "SI": "Словенія",
-                "SJ": "Свальбард і Ян-Маєн",
-                "SK": "Словаччина",
-                "SL": "Сьєрра-Леоне",
-                "SM": "Сан-Маріно",
-                "SN": "Сенегал",
-                "SO": "Сомалі",
-                "SR": "Суринам",
-                "SS": "Південний Судан",
-                "ST": "Сан-Томе і Принсіпі",
-                "SV": "Сальвадор",
-                "SX": "Сінт-Мартен",
-                "SY": "Сірія",
-                "SZ": "Свазіленд",
-                "TC": "Острови Теркс і Кайкос",
-                "TD": "Чад",
-                "TF": "Французькі Південні і Антарктичні Території",
-                "TG": "Того",
-                "TH": "Таїланд",
-                "TJ": "Таджикистан",
-                "TK": "Токелау",
-                "TL": "Східний Тимор",
-                "TM": "Туркменістан",
-                "TN": "Туніс",
-                "TO": "Тонга",
-                "TR": "Турція",
-                "TT": "Тринідад і Тобаго",
-                "TV": "Тувалу",
-                "TW": "Республіка Китай",
-                "TZ": "Танзанія",
-                "UA": "Україна",
-                "UG": "Уганда",
-                "UM": "Зовнішні малі острови (США)",
-                "US": "США",
-                "UY": "Уругвай",
-                "UZ": "Узбекистан",
-                "VA": "Ватикан",
-                "VC": "Сент-Вінсент і Гренадини",
-                "VE": "Венесуела",
-                "VG": "Британські Віргінські Острови",
-                "VI": "Віргінські Острови (США)",
-                "VN": "В'єтнам",
-                "VU": "Вануату",
-                "WF": "Волліс і Футуна",
-                "WS": "Самоа",
-                "XK": "Косово",
-                "YE": "Ємен",
-                "YT": "Майотта",
-                "ZA": "ПАР",
-                "ZM": "Замбія",
-                "ZW": "Зімбабве"
-            },
-            "edit": {
-                "success": "Місцезнаходження успішно змінено.",
-                "title": "Відредагуйте розташування для"
-            }
-        },
-        "location-list-card": {
-            "delete": {
-                "button": "Так, видалити!",
-                "button-cancel": "Скасувати",
-                "remove-error": "Місцезнаходження не видалено. Спробуйте ще раз.",
-                "remove-success": "Місцезнаходження успішно видалено.",
-                "title": "Ви дійсно хочете видалити місце розташування?"
-            },
-            "not-defined": "Місцезнаходження не визначено",
-            "add-location": "Додати місцезнаходження",
-            "title": "Місцезнаходження",
-            "title-location": "Місцезнаходження"
-        },
-        "rating-list-section": {
-            "vote-error": "Ваш голос не приймається",
-            "vote-success": "Ваш голос приймається",
-            "votes": "Голос(а)"
-        },
-        "states-management-dialog": {
-            "choose-state": "Виберіть ключ",
-            "title": "Детальна інформація станів"
-        },
-        "tag-list-section": {
-            "add-error": "Тег не додано. Спробуй ще раз.",
-            "remove-error": "Тег не видалений. Спробуй ще раз.",
-            "type-tag": "додати тег ..."
-        }
-    },
-    "xm-enum": {
-        "all": "Всі",
-        "other": "Інше",
-        "others": "Інші"
-    },
-    "xm-navbar-language-menu": {
-        "choose-language": "Виберіть мову"
-    },
-    "xm-notifications": {
-        "showAll": "Дивитися все"
-    },
-    "xm-timeline": {
-        "common": {
-            "no-items": "Відсутні записи по даному запиту!",
-            "show-more-10": "Показати більше",
-            "show-more-all": "Показати все",
-            "title": "Хронологія",
-            "time-ago": {
-                "day": "день тому",
-                "days": "днів тому",
-                "hour": "годину назад",
-                "hours": "години тому",
-                "minute": "хвилину тому",
-                "minutes": "хвилин тому",
-                "month": "місяць тому",
-                "months": "місяці тому",
-                "seconds": "кілька секунд назад",
-                "year": "рік назад",
-                "years": "багато років тому"
-            }
-        },
-        "timeline": {
-            "by": "по",
-            "error": "ПОМИЛКА",
-            "more": "більше часових подій ...",
-            "success": "УСПІШНО",
-            "title": "Історія"
-        }
-    },
-    "xm": {
-        "dashboard": {
-            "config": "Конфігурація",
-            "created": "Нова інформаційна панель створена з ідентифікатором {{param}}",
-            "delete": {
-                "question": "Ви впевнені, що хочете видалити інформаційну панель {{id}}?"
-            },
-            "deleted": "Інформаційна панель видаляється з ідентифікатором {{param}}",
-            "detail": {
-                "title": "Інформаційна панель"
-            },
-            "home": {
-                "createLabel": "Створіть нову інформаційну панель",
-                "createOrEditLabel": "Створення або редагування інформаційної панелі",
-                "search": "Пошук інформаційної панелі",
-                "title": "Інформаційні панелі"
-            },
-            "isPublic": "Є громадським",
-            "layout": "Розмітка",
-            "name": "Ім'я",
-            "owner": "Власник",
-            "updated": "Інформаційна панель оновлюється за ідентифікатором {{param}}",
-            "widgets": "Віджети"
-        },
-        "delete": {
-            "question": "Ви впевнені, що хочете видалити [ <b>{{name}}</b> ]?"
-        },
-        "export-entities": {
-            "btn-cancel": "Скасувати",
-            "btn-export": "Експорт",
-            "details-title": "Експортувати сутність",
-            "message-error": "Помилка експорту!",
-            "message-success": "Експортовано успішно!",
-            "no-params-required": "Немає необхідних параметрів!",
-            "step-1": "Виберіть тип сутності",
-            "step-2": "Виберіть необхідні параметри"
-        },
-        "import-entities": {
-            "btn-cancel": "Скасувати",
-            "btn-import": "Імпорт",
-            "details-title": "Імпортувати сутність",
-            "file-process-error": "Файл пошкоджений або має інше розширення ніж .json!",
-            "message-error": "Не вдалося імпортувати!",
-            "message-success": "Імпортовано успішно!",
-            "upload-btn-text": "Завантажити з файлу JSON"
-        },
-        "xmEntity": {
-            "add": {
-                "chooseType": "Виберіть тип юридичної особи",
-                "title": "Додати новий запис"
-            },
-            "addPhoto": "Додати фотографію",
-            "change": "Змінити",
-            "data": "Дані",
-            "description": "Опис",
-            "edit": {
-                "title": "Редагування об'єкта [ <b>{{name}}</b> ]"
-            },
-            "endDate": "Дата закінчення",
-            "functions": "Функції",
-            "lifecycle": {
-                "nextStates": "Наступні стани доступні через життєвий цикл:",
-                "title": "Життєвий цикл"
-            },
-            "listView": "Перелік списку",
-            "locations": "Місця розташування",
-            "name": "Ім'я/Назва",
-            "redeem": {
-                "title": "Викупити"
-            },
-            "search": "Результат пошуку для",
-            "showMore": "Показати більше",
-            "startDate": "Дата початку",
-            "state": "Стан",
-            "tenant": {
-                "error": {
-                    "alreadyUsed": "Ім'я тенанта вже використовується",
-                    "tenantKeyFormat": "Ім'я тенанта повинно містити тільки букви, цифри та нижнє підкреслення. Перший символ повинен бути літерою. Не повинне починатия з 'pg_'. Максимальна довжина 48 символів"
-                }
-            },
-            "title": "Назва",
-            "treeView": "Вид дерева",
-            "type": "Тип",
-            "votes": "Голос(а)"
-        },
-        "defaultProfile": {
-            "created": "Новий основний профіль із ідентифікатором {{ param }} створено",
-            "dashboard": "Dashboard",
-            "delete": {
-                "question": "Підтвердіть видалення основного профілю: {{ id }}?"
-            },
-            "deleted": "Основний профіль із ідентифікатором {{ param }} видалено",
-            "detail": {
-                "title": "Основний профіль"
-            },
-            "home": {
-                "createLabel": "Створити новий основний профіль",
-                "createOrEditLabel": "Створити або редагувати основний профіль",
-                "search": "Шукати основний профіль",
-                "title": "Основні профілі"
-            },
-            "roleKey": "Ключ ролі",
-            "updated": "Основний профіль із ідентифікатором {{ param }} оновлено"
-        },
-        "profile": {
-            "created": "Новий профіль з ідентифікатором {{ param }} створено",
-            "dashboards": "Dashboards",
-            "delete": {
-                "question": "Підтвердіть видалення профілю: {{ id }}"
-            },
-            "deleted": "Профіль із ідентифікатором {{ param }} видалено",
-            "detail": {
-                "title": "Профіль"
-            },
-            "home": {
-                "createLabel": "Створити профіль",
-                "createOrEditLabel": "Створити або редагувати профіль",
-                "search": "Шукати профіль",
-                "title": "Профілі"
-            },
-            "login": "Login",
-            "updated": "Профіль із ідентифікатором {{ param }} оновлено"
-        }
-    },
-    "xm-validator-processing": {
-        "validators": {
-            "minDate": "Обрана дата менше ніж мінімальна дата ({{minDateI18n}}).",
-            "languageRequired": "Потрібна принаймні одна мова",
-            "minArrayLength": "Масив менший за мінімальну допустиму довжину ({{requiredLength}}).",
-            "valueMoreThanIn": "Значення більше ніж {{compareValue}}",
-            "dateLessOrEqual": "\"Дата до\" не включена в період. \"Дата від\" - \"дата до\" не можуть співпадати.",
-            "valueLessThanIn": "Значення менше ніж {{compareValue}}",
-            "severalEmails": "Невалідний email або значення повинні бути розділені знаком: ';'",
-            "dateMoreThanIn": "Значення вище дозволеного діапазону",
-            "dateLessThanIn": "Значення менше дозволеного діапазону"
-        }
+    "widget-list-card": {
+      "title": "Віджети"
+    }
+  },
+  "admin-webapp-ext": {
+    "common": {
+      "project": "",
+      "save": ""
+    }
+  },
+  "audits": {
+    "filter": {
+      "from": "від",
+      "title": "Фільтр за датою",
+      "to": "до"
     },
     "table": {
-        "filter": {
-            "button": {
-                "search": "Пошук",
-                "reset": "Скинути",
-                "clearAll": "Скинути все",
-                "more": "Ще"
-            }
-        }
+      "data": {
+        "remoteAddress": "Дистанційна адреса:"
+      },
+      "header": {
+        "data": "Додаткові дані",
+        "date": "Дата",
+        "principal": "Користувач",
+        "status": "Стан"
+      }
     },
-    "login-page": {
-        "tfa": {
-            "code-number": "Код був відправлений на номер",
-            "change-number": "Змінити номер",
-            "code-sms": "Введіть код із SMS:",
-            "code-valid": "Код дійсний протягом 2 хвилин. Не повідомляйте цей код нікому.",
-            "no-sms": "Не отримали SMS?",
-            "more-sms": "Відправити ще раз",
-            "signUp": " Зареєструватися",
-            "signUp-no-account": "Немає акаунту?"
-        }
+    "title": "Аудит"
+  },
+  "cancel": "",
+  "clientManagement": {
+    "client": {
+      "already": {
+        "exists": "Клієнт з цим ID вже існує!"
+      }
     },
-    "sessions": {
-        "messages": {
-            "error": "<strong>Сталася помилка!</strong> Сесія не може буде анульована.",
-            "success": "<strong>Сесія анульована!</strong>"
-        },
-        "table": {
-            "button": "Анулювати",
-            "date": "Дата",
-            "ipaddress": "IP адреса",
-            "useragent": "User Agent"
-        },
-        "title": "Активна сесія для [<b>{{username}}</b>]"
+    "id": "ID",
+    "clientId": "ID клієнта",
+    "clientSecret": "Пароль клієнта",
+    "createdBy": "Створено",
+    "createdDate": "Дата створення",
+    "delete": {
+      "question": "Ви впевнені, що хочете видалити додаток/клієнт з ідентифікатором {{id}}?"
     },
-    "tracker": {
-        "table": {
-            "ipaddress": "IP адреса",
-            "page": "Поточна сторінка",
-            "time": "Час",
-            "userAgent": "User agent",
-            "userlogin": "User"
-        },
-        "title": "Поточні активності користувачів"
+    "description": "Опис",
+    "detail": {
+      "title": "Додаток/Клієнт"
+    },
+    "actions": {
+      "block": "Ви впевнені, що бажаєте заблокувати додаток/клієнта?",
+      "unblock": "Ви впевнені, що бажаєте активувати додаток/клієнта?",
+      "confirm": "Так, підтвердити"
+    },
+    "home": {
+      "createOrEditLabel": "Створіть або відредагуйте дані автентифікації додатку/клієнта",
+      "title": "Додатки/Клієнти"
+    },
+    "lastModifiedBy": "Змінено",
+    "lastModifiedDate": "Дата зміни",
+    "role": "Роль",
+    "roleKey": "Роль",
+    "roles": "Ролі",
+    "scopes-add": "Дозволи(scopes)",
+    "search-by-client-id": "Пошук за ID додатку/клієнта",
+    "validityPeriod": "Термін дії"
+  },
+  "commons": {
+    "required-field": ""
+  },
+  "dashboard-config-widget": {
+    "add-widget": "Додати віджет",
+    "cancel": "Скасувати",
+    "close": "Закрити",
+    "config": "Конфігурація",
+    "copy": "Копія",
+    "copy-clipboard": "Копіювати в буфер обміну",
+    "create": "Створити",
+    "create-dashboard": "Створити панель",
+    "created": "Створено {{value}}",
+    "dashboard": "Інформаційна панель",
+    "dashboards": "Інформаційні панелі",
+    "delete": "Видалити {{value}}",
+    "deleted": "Видалено {{value}}",
+    "duplicate": "Дублювати",
+    "paste": "Вставити з буферу обміну",
+    "back": "Повернутися",
+    "edit-dashboard": "Редагувати панель",
+    "edit-widget": "Редагувати віджет",
+    "empty": "Порожньо",
+    "export": "Експорт",
+    "feedback": {
+      "error": "Помилки при надсиланні відгуку. Спробуйте пізніше",
+      "success": "Відгук надіслано",
+      "tooltip": "Надіслати відгук"
+    },
+    "filter": "Фільтр",
+    "id": "ID",
+    "info": "Відомості",
+    "editor": "Редактор",
+    "samples": "Зразки",
+    "import": "Імпорт",
+    "delete-existing-dashboards": "Видалити існуючі панелі?",
+    "layout": "Розмітка",
+    "hidden": "Прихований",
+    "name": "Назва",
+    "owner": "Автор",
+    "project": "Проект",
+    "save": "Зберегти",
+    "saved": "Збережено {{value}}",
+    "selector": "Селектор",
+    "typeKey": "TypeKey",
+    "updated": "Оновлено {{value}}",
+    "widgets": "Віджети",
+    "historyChangesBtnTitle": "Історія змін",
+    "change-history": "Історія змін",
+    "type": "Тип",
+    "changed-type": "Зміни в",
+    "no-active": "Відстуня активна подія історії",
+    "change-lists": "Перелік змін",
+    "empty-history": "Відстуні записи в історії",
+    "show-more": "Показати більше"
+  },
+  "date-time-picker": {
+    "labels": {
+      "from": "Від",
+      "to": "До"
     }
+  },
+  "entity": {
+    "action": {
+      "back": "Назад",
+      "cancel": "Скасувати",
+      "delete": "Видалити",
+      "save": "Зберегти"
+    },
+    "add": "Додати",
+    "delete": {
+      "title": "Підтвердьте операцію видалення"
+    },
+    "detail": {
+      "square": "Площа: {{квадратний}} м"
+    },
+    "search": "Пошук",
+    "validation": {
+      "maxlength": "Це поле не може перевищувати {{max}} символів.",
+      "required": "Це поле є обов'язковим!"
+    }
+  },
+  "error": {
+    "403": "Ви не маєте дозволу на доступ до цієї сторінки.",
+    "500": "Внутрішня помилка сервера.",
+    "413": "Перевищено ліміт розміру файлу сервера",
+    "NotNull": "Поле {{fieldName}} не може бути порожнім!",
+    "Size": "Поле {{fieldName}} не відповідає мінімальному / максовому розміру!",
+    "accessDenied": "Доступ заборонено",
+    "access_denied": "Доступ заборонено",
+    "business": "Помилка переадресації",
+    "concurrencyFailure": "Помилка паралельного запиту.",
+    "emailexists": "Електронна пошта вже використовується!",
+    "idexists": "Новий {{entityName}} не може вже мати ідентифікатор",
+    "insufficient_scope": "Недостатній обсяг",
+    "internalServerError": "Внутрішня помилка сервера",
+    "invalid_credentials": "Недійсні облікові дані",
+    "invalid_client": "Недійсний клієнт",
+    "invalid_grant": "Недійсний грант",
+    "invalid_request": "Невірний запит",
+    "invalid_scope": "Невірний дозвіл",
+    "invalid_token": "Неприпустимий маркер",
+    "notfound": "Ресурс не знайдено",
+    "privilegeInsufficient": "Недостатньо привилеїв '{{ name }}'!",
+    "privilegeOperationWrong": "Операція не підтримується '{{ name }}'!",
+    "redirect_uri_mismatch": "Невідповідність uri",
+    "server": {
+      "not": {
+        "reachable": "Сервер недоступний"
+      }
+    },
+    "session_expired": "Сесія закінчилася. Будь ласка, авторизуйтесь!",
+    "title": "Сторінка помилки!",
+    "unauthorized": "Необхідна авторизація",
+    "unauthorized_client": "Неавторизований клієнт",
+    "unsupported_grant_type": "Тип гранту не підтримується",
+    "unsupported_response_type": "Тип відповіді не підтримується",
+    "url": {
+      "not": {
+        "found": "Не знайдено"
+      }
+    },
+    "userexists": "Ім'я входу вже використовується!",
+    "validation": "Помилка вхідних параметрів",
+    "NotBlank": "Не пустий",
+    "Unauthorized": "Потрібна авторизація!",
+    "error": {
+      "accessDenied": "Доступ заборонено",
+      "business": "Помилка переадресації",
+      "internalServerError": "Внутрішня помилка сервера"
+    },
+    "not": {
+      "enough": {
+        "credits": "Не достатньо кредитів!"
+      }
+    },
+    "wallet": {
+      "not": {
+        "active": "Гаманець неактивний!"
+      }
+    }
+  },
+  "ext-common-entity": {
+    "available-offerings-widget": {
+      "action-dialog": {
+        "question": "Ви впевнені, що хочете <b>{{action}}</b> для <b>{{name}}</b>?"
+      }
+    },
+    "entity-fab-actions": {
+      "operation-error": "Операція не успішна!",
+      "operation-success": "Операція успішна!"
+    }
+  },
+  "ext-common": {
+    "clock-widget": {
+      "title": "Годинник"
+    },
+    "exchange-widget": {
+      "code": "Код",
+      "course": "Офіційний курс",
+      "currency": "Валюта",
+      "from": "Від",
+      "number-units": "Кількість одиниць",
+      "select-from": "Виберіть валюту з",
+      "select-to": "Виберіть валюту в",
+      "title": "Обмінний калькулятор"
+    },
+    "sign-in-up-widget": {
+      "sign-in": "Вхід",
+      "sign-up": "Зареєструватися"
+    },
+    "weather-widget": {
+      "humidity": "Вологість",
+      "ms": "м/с",
+      "wind-speed": "Швидкість вітру"
+    }
+  },
+  "formPlayground": {
+    "definition": "Визначення",
+    "errors": "- помилки з валідації помилок ():",
+    "liveData": "Живі дані - з onChanges ():",
+    "loading": "(специфікація форми завантаження ...)",
+    "na": "н.д.",
+    "output": "Вихідні дані",
+    "result": "Результат",
+    "selectSchema": "ВИБЕРІТЬ СХЕМУ",
+    "valid": "Коректно?:"
+  },
+  "gateway": {
+    "routes": {
+      "error": "Увага! Сервер не доступний!",
+      "servers": "Доступні сервери",
+      "service": "сервіс",
+      "url": "URL-адреса"
+    },
+    "title": "Шлюз"
+  },
+  "global": {
+    "policies": {
+      "count-passed": "{{count}} з {{required}} умов виконано"
+    },
+    "actionPerformed": "Дія виконана",
+    "all": "Все",
+    "common": {
+      "accept": "Прийняти",
+      "are-you-sure": "Ви впевнені?",
+      "cancel": "Скасувати",
+      "delete": "Видалити",
+      "add-to": "Додати до",
+      "delete-message": "Видалити {{value}}?",
+      "maintenance-description": "Зазвичай це займає кілька хвилин, в іншому випадку зверніться до системного адміністратром.",
+      "maintenance-export-entities": "Експорт сутності",
+      "maintenance-import-entities": "Імпорт сутності",
+      "maintenance-message": "Технічні роботи... <br> Будь ласка, спробуйте пізніше.",
+      "maintenance-reindex-elastic": "Reindex elastic",
+      "maintenance-update-tenant-configuration": "Оновити конфігурацію тенанту",
+      "maintenance-update-tenants-configuration": "Оновити конфігурацію тенантів",
+      "no": "Ні",
+      "set": "Задати",
+      "yes": "Так",
+      "yes-exit": "Так, вийти!",
+      "dbclick-to-edit": "Двічі клацніть, щоб редагувати"
+    },
+    "field": {
+      "id": "Ідентифікатор"
+    },
+    "form": {
+      "confirmpassword": "Нове підтвердження пароля",
+      "email": "Електронна пошта",
+      "firstname": "Ім'я",
+      "language": "Мова",
+      "lastname": "Прізвище",
+      "login": "Логін",
+      "newpassword": "Новий пароль",
+      "oldpassword": "Старий пароль",
+      "otp": "Одноразовий пароль",
+      "show-password": "Показати пароль",
+      "signin": "увійти"
+    },
+    "item-count": "Показано {{first}} - {{second}} із {{total}} елементів.",
+    "menu": {
+      "account": {
+        "help": "Допомога",
+        "help-not-provided": "Контент для сторінки допомоги не задано!",
+        "logout": "Вийти",
+        "mini": {
+          "password": "П",
+          "profile": "В",
+          "settings": "Н"
+        },
+        "password": "Пароль",
+        "passwordSetup": "Запрошення до системи",
+        "profile": "Профіль",
+        "settings": "Налаштування"
+      },
+      "admin": {
+        "apidocs": "API",
+        "audits": "Аудит",
+        "clientManagement": "Керування клієнтами",
+        "dashboard": "Панель управління",
+        "formPlayground": "Тестовый майданчик форми",
+        "gateway": "Шлюз",
+        "health": "Здоров'я",
+        "logs": "Журнали",
+        "main": "Адміністрування",
+        "maintenance": "Обслуговування",
+        "metrics": "Показники",
+        "mini": {
+          "apidocs": "А.",
+          "audits": "А.",
+          "clientManagement": "К",
+          "formPlayground": "Г",
+          "gateway": "Ш",
+          "health": "С",
+          "logs": "Л",
+          "maintenance": "О",
+          "metrics": "М",
+          "rolesManagement": "Р",
+          "rolesMatrix": "Р",
+          "translation": "П",
+          "userManagement": "К",
+          "dashboard": "D"
+        },
+        "rolesManagement": "Управління ролями",
+        "rolesMatrix": "Матриця ролей",
+        "translation": "Переклади",
+        "userManagement": "Керування користувачами"
+      },
+      "applications": {
+        "application": "Програма",
+        "main": "Програми"
+      },
+      "dashboards": {
+        "main": "Інформаційні панелі"
+      },
+      "entities": {
+        "attachment": "Вкладення",
+        "calendar": "Календар",
+        "comment": "Коментар",
+        "content": "Вміст",
+        "country": "Країна",
+        "event": "Подія",
+        "jhipster-needle-menu-add-entry": "JHipster will add additional entities here (do not translate!)",
+        "link": "Посилання",
+        "location": "Місцезнаходження",
+        "main": "Об'єкти",
+        "rating": "Рейтинг",
+        "tag": "Тег",
+        "vote": "Голосувати",
+        "xmEntity": "Xm Entity"
+      }
+    },
+    "messages": {
+      "error": {
+        "captchaempty": "Будь ласка, перевірте captcha.",
+        "dontmatch": "Пароль та його підтвердження не збігаються!",
+        "upload-fail": "Сервіс завантаження недосяжний!"
+      },
+      "info": {
+        "authenticated": {
+          "link": "увійти",
+          "prefix": "Якщо ти хочеш ",
+          "suffix": ", ви можете спробувати облікові записи за умовчанням:"
+        }
+      },
+      "validate": {
+        "captcha": {
+          "required": "Потрібна сaptcha."
+        },
+        "confirmpassword": {
+          "maxlength": "Ваш пароль підтвердження не може перевищувати 50 символів.",
+          "minlength": "Ваш пароль підтвердження повинен складатися не менше 4 символів.",
+          "password-max-length": "Ваш пароль підтвердження не може перевищувати {{maxLength}} символів.",
+          "password-min-length": "Ваш пароль підтвердження повинен складатися не менше {{minLength}} символів.",
+          "password-pattern": "Ваш пароль не відповідає шаблону {{pattern}}",
+          "space": "Ваш пароль підтвердження не може містити пробілів.",
+          "required": "Ваш пароль для підтвердження необхідний.",
+          "not-match": "Ваш пароль і пароль підтвердження не збігаються."
+        },
+        "email": {
+          "invalid": "Ваша електронна адреса недійсна.",
+          "maxlength": "Ваш електронний лист не може перевищувати 50 символів.",
+          "minlength": "Ваша електронна адреса повинна містити принаймні 5 символів.",
+          "required": "Ваша електронна адреса обов'язкова."
+        },
+        "firstname": {
+          "maxlength": "Ваше ім'я не може перевищувати 50 символів",
+          "minlength": "Ваше ім'я має містити принаймні 1 символ",
+          "required": "Ваше ім'я обов'язкове."
+        },
+        "lastname": {
+          "maxlength": "Ваше прізвище не може перевищувати 50 символів",
+          "minlength": "Ваше прізвище має містити принаймні 1 символ",
+          "required": "Ваше прізвище потрібно."
+        },
+        "newpassword": {
+          "maxlength": "Ваш пароль не може перевищувати 50 символів.",
+          "minlength": "Ваш пароль повинен складатися не менше 4 символів.",
+          "password-max-length": "Ваш пароль не може перевищувати {{maxLength}} символів.",
+          "password-min-length": "Ваш пароль повинен складатися не менше {{minLength}} символів.",
+          "password-pattern": "Ваш пароль не відповідає шаблону {{pattern}}",
+          "space": "Ваш пароль не може містити пробілів.",
+          "required": "Ваш пароль потрібен.",
+          "strength": "Надійність паролю:"
+        },
+        "oldpassword": {
+          "maxlength": "Старий пароль не може перевищувати 50 символів.",
+          "minlength": "Старий пароль повинен складатися не менше 4 символів.",
+          "password-max-length": "Старий пароль не може перевищувати {{maxLength}} символів.",
+          "password-min-length": "Старий пароль повинен складатися не менше {{minLength}} символів.",
+          "password-pattern": "Ваш пароль не відповідає шаблону {{pattern}}",
+          "required": "Потрібний старий пароль."
+        }
+      }
+    },
+    "new": "Новий",
+    "noData": "Немає даних!",
+    "perPage": "елементів на сторінці",
+    "rest-select-none-option": "Нічого",
+    "rest-select-placeholder-noresults": "Нічого не знайдено",
+    "rest-select-placeholder-search": {
+      "prefix": "",
+      "simple": "Пошук",
+      "suffix": ""
+    },
+    "rest-select-search-more": "Доступні ще результати. Уточніть пошуковий запит!",
+    "ribbon": {
+      "dev": "Розвиток"
+    },
+    "shared": {
+      "ext-md-editor": {
+        "placeholder": "Натисніть кнопку редагувати щоб змінити опис в полі",
+        "placeholder-empty": "Поле пусте! Натисніть кнопку редагувати щоб додати опис в полі",
+        "save-button": "Зберегти зміни"
+      },
+      "privacy-and-terms-dialog": {
+        "i-agree": "Я згоден з Умовами Обслуговування і обробкою своєї інформації, як описано в Політиці Конфіденційності",
+        "title": "Конфіденційність і Умови"
+      }
+    }
+  },
+  "health": {
+    "details": {
+      "details": "Подробиці",
+      "error": "Помилка",
+      "name": "Ім'я",
+      "properties": "Властивості",
+      "value": "Значення"
+    },
+    "indicator": {
+      "binders": "Біндери",
+      "cassandra": "Cassandra",
+      "cdb": "CDB",
+      "configServer": "Сервер конфігурації Microservice",
+      "consul": "Консул",
+      "db": "База даних",
+      "discoveryComposite": "Discovery Composite",
+      "diskSpace": "Дисковий простір",
+      "elasticsearch": "Elastic Search",
+      "healthIndicator": "Health Indicator",
+      "hlr": "HLR",
+      "hystrix": "Hystrix",
+      "mail": "Електронна пошта",
+      "refreshScope": "Обновити обсяги Microservice"
+    },
+    "options": {
+      "done": "Закрити",
+      "instance-name": "Інстанс",
+      "service-name": "Назва сервісу"
+    },
+    "refresh": {
+      "button": "Оновити"
+    },
+    "stacktrace": "Stack trace",
+    "status": {
+      "DOWN": "DOWN",
+      "OUT_OF_SERVICE": "OUT_OF_SERVICE",
+      "UNKNOWN": "UNKNOWN",
+      "UP": "UP"
+    },
+    "table": {
+      "service": "Назва служби",
+      "status": "Статус"
+    },
+    "title": "Перевірки здоров'я"
+  },
+  "home": {
+    "subtitle": "Це ваша домашня сторінка",
+    "title": "Ласкаво просимо!"
+  },
+  "login": {
+    "separator": "Або",
+    "form": {
+      "button": "Увійти",
+      "hide-password": "Приховати пароль",
+      "otpValidateButton": "Вхід",
+      "otpValidateCancel": "Назад",
+      "password": "Пароль",
+      "rememberMe": "Запам'ятати мене",
+      "show-password": "Показати пароль"
+    },
+    "messages": {
+      "error": {
+        "authentication": "<strong>Не вдалося ввійти!</strong> Будь ласка, перевірте свої облікові дані та повторіть спробу."
+      },
+      "otp": {
+        "notification": "Будьласка введіть одноразовий пароль з листа на email"
+      },
+      "idp": {
+        "login-title": "Вхід з OAuth 2.0",
+        "wrong-key": "Неправильний ключ IDP або конфігурація клієнта"
+      }
+    },
+    "password": {
+      "forgot": "Ви забули свій пароль?"
+    },
+    "signin": "Увійти",
+    "signup": "Зареєструватися",
+    "title": "Увійти"
+  },
+  "logs": {
+    "filter": "Фільтрувати",
+    "nbloggers": "Є лічильники {{total}}.",
+    "table": {
+      "level": "Рівень",
+      "name": "Ім'я"
+    },
+    "title": "Журнали"
+  },
+  "mat": {
+    "paginator": {
+      "firstPageLabel": "Перша сторінка",
+      "itemsPerPageLabel": "Показувати по:",
+      "lastPageLabel": "Остання сторінка",
+      "nextPageLabel": "Наступна сторінка",
+      "of": "з",
+      "previousPageLabel": "Попередня сторінка"
+    }
+  },
+  "metrics": {
+    "datasource": {
+      "count": "Рахувати",
+      "max": "Макс",
+      "mean": "Середня",
+      "min": "Хв",
+      "p50": "p50",
+      "p75": "p75",
+      "p95": "p95",
+      "p99": "p99",
+      "title": "Статистика даних (час у мілісекунди)",
+      "usage": "Використання"
+    },
+    "jvm": {
+      "gc": {
+        "marksweepcount": "Відмітити знак &quot;Розминути&quot;",
+        "marksweeptime": "Позначити Sweep час",
+        "scavengecount": "Підраховувати втрати",
+        "scavengetime": "Вичерпати час",
+        "title": "Сміттєві колекції"
+      },
+      "http": {
+        "active": "Активні запити:",
+        "code": {
+          "notfound": "Не знайдено",
+          "ok": "Добре",
+          "servererror": "помилка серверу"
+        },
+        "table": {
+          "average": "Середній",
+          "code": "Код",
+          "count": "Рахувати",
+          "mean": "Середня"
+        },
+        "title": "HTTP-запити (події в секунду)",
+        "total": "Загальна кількість запитів:"
+      },
+      "memory": {
+        "heap": "Купа пам'яті",
+        "nonheap": "Без пам'яті",
+        "title": "Пам'ять",
+        "total": "Загальна пам'ять"
+      },
+      "threads": {
+        "blocked": "Заблоковано",
+        "dump": {
+          "blockedcount": "Заблокований граф",
+          "blockedtime": "Заблокований час",
+          "hide": "Приховати Stcktrace",
+          "lockname": "Закріпити ім'я",
+          "show": "Показати Стаккрайс",
+          "title": "Нитки скидання",
+          "waitedcount": "Чекав графа",
+          "waitedtime": "Очікуване час"
+        },
+        "runnable": "Runnable",
+        "timedwaiting": "Час очікування",
+        "title": "Нитки",
+        "waiting": "Очікування"
+      },
+      "title": "JVM Metrics"
+    },
+    "options": {
+      "done": "Закрити",
+      "f-all": "Всі",
+      "f-blocked": "Заблоковані",
+      "f-runnable": "Runnable",
+      "f-timed-waiting": "Час очікування",
+      "f-waiting": "Очікування",
+      "instance-name": "Інстанс",
+      "service-name": "Назва сервісу"
+    },
+    "servicesstats": {
+      "table": {
+        "count": "Рахувати",
+        "max": "Макс",
+        "mean": "Середня",
+        "min": "Хв",
+        "name": "Назва служби",
+        "p50": "p50",
+        "p75": "p75",
+        "p95": "p95",
+        "p99": "p99"
+      },
+      "title": "Статистика послуг (час у мілісекунди)"
+    },
+    "title": "Метрики додатків",
+    "updating": "Оновлення ..."
+  },
+  "navbar": {
+    "notification": "Сповіщення",
+    "search": "Пошук",
+    "toggleNotification": "Переключити навігацію"
+  },
+  "time": {
+    "now": "Щойно",
+    "minAgo": "1 хвилину тому",
+    "minsAgo": " хвилин(-и) тому",
+    "hourAgo": "1 годину тому",
+    "hoursAgo": " годин(-и) тому",
+    "yesterday": "Вчора",
+    "daysAgo": " дні(-в) тому",
+    "weeksAgo": " тиж. тому"
+  },
+  "password": {
+    "form": {
+      "button": "Зберегти"
+    },
+    "messages": {
+      "error": "<strong>Сталася помилка!</strong> Пароль не може бути змінений.",
+      "success": "<strong>Пароль змінено!</strong>"
+    },
+    "title": "Пароль для [ <b>{{username}}</b> ]"
+  },
+  "register": {
+    "form": {
+      "button": "Зареєструватися"
+    },
+    "messages": {
+      "error": {
+        "emailempty": "<strong>Email не може бути порожнім!</strong> Будь ласка, виберіть один.",
+        "fail": "<strong>Реєстрація не вдалося!</strong> Будь-ласка спробуйте пізніше.",
+        "userexists": "<strong>Логін вже зареєстрований!</strong> Будь ласка, виберіть інший."
+      },
+      "success": "<strong>Реєстрація збережена!</strong> Будь ласка, перевірте свою електронну пошту для підтвердження."
+    },
+    "title": "Реєстрація"
+  },
+  "reset": {
+    "finish": {
+      "form": {
+        "button": "Перевірити новий пароль"
+      },
+      "messages": {
+        "error": "Ваш пароль неможливо скинути. Пам'ятайте, що запит на введення пароля дійсний лише 24 години.",
+        "info": "Виберіть новий пароль",
+        "keyexpired": "Ключ запиту вже не дійсний.",
+        "keymissing": "Ключ скидання відсутній.",
+        "keyused": "Ключ запиту вже використовувався.",
+        "success": "<strong>Ваш пароль був скинутий.</strong> Будь ласка&nbsp;"
+      },
+      "title": "Скинути пароль"
+    },
+    "request": {
+      "form": {
+        "button": "Скинути пароль"
+      },
+      "messages": {
+        "info": "Введіть електронну адресу, яку ви використовували для реєстрації",
+        "notfound": "<strong>Електронна адреса не зареєстрована!</strong> Будь ласка, перевірте та повторіть спробу",
+        "success": "Перегляньте свої електронні листи, щоб дізнатись, як змінити пароль."
+      },
+      "title": "Скинути пароль"
+    },
+    "setup": {
+      "form": {
+        "button": "Встановити пароль"
+      },
+      "messages": {
+        "error": "Ваш пароль неможливо створити. Пам'ятайте, що запит на введення пароля дійсний лише 24 години.",
+        "info": "Вигадайте новий пароль",
+        "success": "<strong>Ваш пароль було створено.</strong> Будь ласка,&nbsp;"
+      },
+      "title": "Налаштуйте свій пароль"
+    }
+  },
+  "rolesManagement": {
+    "basedOn": "На основі",
+    "chooseRole": "Виберіть роль",
+    "createdBy": "Створено",
+    "createdDate": "Дата створення",
+    "delete": {
+      "question": "Ви впевнені, що хочете видалити роль '{{ roleKey }}'?"
+    },
+    "description": "Опис",
+    "detail": {
+      "permissions": "права доступу",
+      "title": "Роль"
+    },
+    "home": {
+      "labelCreate": "Створити нову роль",
+      "labelEdit": "Редагувати роль",
+      "title": "Ролі"
+    },
+    "key": "Ім'я",
+    "lastModifiedBy": "Змінено",
+    "lastModifiedDate": "Дата зміни",
+    "matrix": {
+      "title": "Матриця ролей"
+    },
+    "ok": "Ok",
+    "permission": {
+      "checkAll": "Відзначити всі",
+      "condition": "Умова",
+      "conditionEnvInfo": "1. використовуйте SpEL функцiональнiсть<br>2. використовуйте # перед змiнною<br>3. #subject.role, #subject.userKey, #subject.login змiннi доступнi<br>4. #env['ipAddress'] змiнна доступна",
+      "conditionResourceInfo": "1. використовуйте SpEL функцiональнiсть<br>2. використовуйте # перед змiнною<br>3. #subject.role, #subject.userKey, #subject.login змiннi доступнi",
+      "createCondition": "Створення умови",
+      "desc": "Опис",
+      "editCondition": "Редагування умови",
+      "envCondition": "Умови середовища",
+      "msName": "Назва МС",
+      "notPermitted": "недозволенi",
+      "onForbid": "При забороні",
+      "permit": "Дозвіл",
+      "permitted": "дозволенi",
+      "permittedAny": "принаймні один",
+      "privilegeKey": "Ключ привілею",
+      "resourceCondition": "Умови ресурсу"
+    },
+    "selected": "Тільки обрані",
+    "variables": "Доступні змінні"
+  },
+  "settings": {
+    "form": {
+      "button": "Зберегти",
+      "general": "Загальна інформація",
+      "local-time": "Місцевий час: ",
+      "logins": "Логіни",
+      "offset-time": "Зміщення часового поясу: ",
+      "utc-time": "UTC-час: "
+    },
+    "messages": {
+      "logins": {
+        "success": "<strong>Логін збережений!</strong>"
+      },
+      "success": "<strong>Налаштування збережено!</strong>"
+    },
+    "security": {
+      "autoLogout": "Авто вихід",
+      "name": "Параметри безпеки",
+      "seconds": "секунди",
+      "twoFAStatus": "Двофакторна аутентифікація"
+    }
+  },
+  "social": {
+    "register": {
+      "errorTitle": "Зареєструйтеся за допомогою зовнішнього облікового запису",
+      "messages": {
+        "error": {
+          "fail": "<strong>Реєстрація не вдалося!</strong> Під час валідації вашого зовнішнього облікового запису сталася помилка, ми радимо спробувати інше з'єднання."
+        },
+        "success": "<strong>Реєстрація збережена!</strong> Будь ласка, перевірте свою електронну пошту для підтвердження."
+      },
+      "title": "Зареєструватися за {{label}}"
+    }
+  },
+  "swagger": {
+    "select-component": "Оберiть компонент"
+  },
+  "translate-managment": {
+    "clear-cache-button": "Очистити поточний кеш перекладів",
+    "download-button": "Зкачати переклади",
+    "filter-by-key": "Фільтрувати по ключу",
+    "filter-by-value": "Фільтрувати по значенню",
+    "save-all-button": "Зберегти все",
+    "title": {
+      "main": "Керування перекладами",
+      "project": "Переклади проекту",
+      "config": "Переклад конфігурації"
+    }
+  },
+  "userManagement": {
+    "activated": "Активовано",
+    "autoLogout": "Автоматичний вихід",
+    "createdBy": "Створений",
+    "createdDate": "Дата створення",
+    "deactivated": "Деактивовано",
+    "delete": {
+      "question": "Ви впевнені, що хочете видалити користувача з логіном {{userKey}}?"
+    },
+    "detail": {
+      "title": "Користувач"
+    },
+    "actions": {
+      "block": "Ви впевнені, що бажаєте заблокувати користувача?",
+      "unblock": "Ви впевнені, що бажаєте активувати користувача?",
+      "enable2famsg": "Ви впевнені, що хочете увімкнути 2FA?",
+      "enable2fabtn": "Так, увімкнути",
+      "disable2famsg": "Ви впевнені, що хочете вимкнути 2FA?",
+      "disable2fabtn": "Так, вимкнути"
+    },
+    "error": "Помилка",
+    "firstName": "Ім'я",
+    "home": {
+      "createOrEditLabel": "Створіть або відредагуйте користувача",
+      "editLoginsLabel": "Оновити логіни користувачів",
+      "title": "Користувачі"
+    },
+    "id": "ID",
+    "langKey": "Мова",
+    "lastModifiedBy": "Змінено",
+    "lastModifiedDate": "Дата зміни",
+    "lastName": "Прізвище",
+    "logins": "Логіни",
+    "onlineUsers": "Користувачів онлайн: ",
+    "role": "Роль",
+    "search-by-login": "Шукати за логіном",
+    "success": "Успішно",
+    "twoFADisabled": "Двофакторна аутентифікація деактивована",
+    "twoFAEnabled": "Двофакторна аутентифікація активована",
+    "userKey": "Ключ користувача"
+  },
+  "wordAutocomplete": {
+    "hint": "Введіть Ctrl+Space для відображення підказки",
+    "noVariables": "Слово не знайдено"
+  },
+  "xm-balance": {
+    "balance-detail-dialog": {
+      "title": "Деталізація балансу"
+    },
+    "balance-list-card": {
+      "title": "Баланси"
+    },
+    "common": {
+      "cancel": "Скасувати",
+      "fields": {
+        "amount": "Кількість",
+        "end-date": "Дата закінчення",
+        "label": "Позначка",
+        "start-date": "Дата початку"
+      }
+    }
+  },
+  "xm-bool-control": {
+    "cancel": "Скасувати",
+    "false": "Ні",
+    "true": "Так"
+  },
+  "xm-control-errors": {
+    "validators": {
+      "email": "Ваша електронна адреса некоректна.",
+      "max": "Максимальне значення {{max}}.",
+      "maxlength": "Не може перевищувати {{requiredLength}} символів.",
+      "min": "Мінімальне значення {{min}}.",
+      "minlength": "Повинно містити принаймні {{requiredLength}} символів.",
+      "pattern": "Поле заповнено некоректно.",
+      "required": "Поле обов'язкове для заповнення.",
+      "invalidUrl": "Невірний формат URL"
+    }
+  },
+  "xm-entity": {
+    "attachment-card": {
+      "delete": {
+        "button": "Так, видалити!",
+        "button-cancel": "Скасувати",
+        "remove-error": "Вкладення не видалено. Спробуй ще раз.",
+        "remove-success": "Вкладення успішно видалено.",
+        "title": "Ви дійсно хочете видалити вкладення?"
+      },
+      "no-data": "Ще не додано жодного файлу",
+      "title": "Файли",
+      "volume": {
+        "GB": "Гб",
+        "KB": "Кб",
+        "MB": "Мб",
+        "PB": "Пб",
+        "TB": "Тб",
+        "bytes": "байт"
+      }
+    },
+    "attachment-detail-dialog": {
+      "add": {
+        "success": "Вкладення успішно додано."
+      },
+      "choose-type": "Виберіть тип вкладення",
+      "title": "Додати нове вкладення для",
+      "upload": "Натисніть, щоб завантажити, або перетягніть файл сюди.",
+      "wrong-type-error": "Заборонений тип файлу {{fileType}}"
+    },
+    "calendar-card": {
+      "calendar": {
+        "btn-list-day": "День (список)",
+        "btn-list-week": "Тиждень (список)"
+      },
+      "delete": {
+        "button": "Так, видалити!",
+        "button-cancel": "Скасувати",
+        "remove-error": "Подію не видалено. Спробуй ще раз.",
+        "remove-success": "Подію успішно видалено.",
+        "title": "Ви дійсно хочете видалити подію?"
+      }
+    },
+    "calendar-event-dialog": {
+      "add": {
+        "success": "Подію додано успішно."
+      },
+      "choose-type": "Виберіть тип події",
+      "title": "Додати нову подію для",
+      "title-edit": "Редагувати подію для"
+    },
+    "comment-detail-dialog": {
+      "add": {
+        "success": "Коментар успішно додано."
+      },
+      "choose-type": "Виберіть тип коментаря",
+      "title": "Додати коментар для"
+    },
+    "common": {
+      "add": "Додати",
+      "add-avatar": "Додати фото",
+      "cancel": "Скасувати",
+      "change-avatar": "Звінити фото",
+      "close": "Закрити",
+      "fields": {
+        "addressLine1": "Адресний Рядок 1",
+        "addressLine2": "Адресний Рядок 2",
+        "city": "Населений пункт",
+        "description": "Опис",
+        "end-date": "Дата закінчення",
+        "id": "ID",
+        "latitude": "Широта",
+        "longitude": "Довгота",
+        "message": "Коментар",
+        "name": "Ім'я/Назва",
+        "region": "Область",
+        "start-date": "Дата створення",
+        "state": "Статус",
+        "title": "Тема",
+        "type": "Тип",
+        "zip": "Поштовий індекс"
+      },
+      "save": "Зберегти",
+      "search": "Пошук",
+      "validation": {
+        "coordinates": "Це поле не відповідає формату широти та довготи.",
+        "date-time": "Це поле повинно бути дата і час.",
+        "pattern": "Це поле не відповідає правилам",
+        "required": "Це поле є обов'язковим!"
+      }
+    },
+    "entity-data-card": {
+      "title": "Дані",
+      "created-by": "Створив(ла)",
+      "created-date": "Дата створення",
+      "updated-by": "Оновив(ла)",
+      "updated-date": "Дата оновлення",
+      "update-error": "Не оновлено. Спробуйте ще раз.",
+      "update-success": "Оновлено успішно.",
+      "change-avatar": "Змінити фото",
+      "current-state": "Поточний статус"
+    },
+    "entity-detail-dialog": {
+      "add": {
+        "choose-type": "Виберіть тип",
+        "title": "Додати новий запис"
+      },
+      "edit": {
+        "title": "Редагування об'єкта"
+      }
+    },
+    "entity-detail-fab": {
+      "new": "Додати новий",
+      "edit-entity": "Редагувати",
+      "new-attachment": "Додати файл",
+      "new-comment": "Додати кометар",
+      "new-link": "Додати посилання",
+      "new-location": "Додати локацiю"
+    },
+    "entity-list-card": {
+      "action-dialog": {
+        "question": "Ви впевнені, що хочете <b>{{action}}</b> для <b>{{name}}</b>?"
+      },
+      "delete": {
+        "button": "Так, видалити!",
+        "button-cancel": "Скасувати",
+        "remove-error": "Не видалено. Спробуй ще раз.",
+        "remove-success": "Успішно видалено.",
+        "title": "Ви дійсно хочете видалити?"
+      },
+      "export": {
+        "action": {
+          "csv": "csv",
+          "downloads": "Завантажити",
+          "xls": "xls"
+        }
+      },
+      "filters-hide": "Сховаты фільтри",
+      "filters-show": "Показати фільтри",
+      "open": "Відкрити",
+      "refresh": "Оновити"
+    },
+    "entity-list-fab": {
+      "new-generated": "Згенеровано!"
+    },
+    "function-list-card": {
+      "change-state": {
+        "button": "Так, змінити!",
+        "error": "Стан не змінився. Спробуй ще раз.",
+        "success": "Стан успішно змінено.",
+        "title": "Ви дійсно хочете змінити стан?"
+      },
+      "current-state": "Поточний стан: ",
+      "general-group": "Загальні Функції",
+      "next-states": "Наступні стани доступні по життєвому циклу:",
+      "other-functions": "Інші Функції:",
+      "title": "Функції"
+    },
+    "link-detail-dialog": {
+      "add-link": "Додати",
+      "add": {
+        "build-type-new": "Нова",
+        "build-type-search": "Пошук",
+        "error": "Посилання не додане. Спробуй ще раз.",
+        "success": "Посилання успішно додане.",
+        "title": "Додати нове Посилання для"
+      },
+      "show-more": "Показати більше"
+    },
+    "link-list-card": {
+      "delete": {
+        "button": "Так, видалити!",
+        "button-cancel": "Скасувати",
+        "remove-error": "Посилання не видалене. Спробуй ще раз.",
+        "remove-success": "Посилання видалене успішно.",
+        "title": "Ви дійсно хочете видалити посилання?"
+      },
+      "list-view": "Перегляд списком",
+      "tree-view": "Перегляд деревом"
+    },
+    "link-list-tree-section": {
+      "collapse": "Згорнути цю гілку"
+    },
+    "location-detail-dialog": {
+      "add": {
+        "success": "Місцезнаходження успішно додано.",
+        "title": "Додати нове місце розташування для"
+      },
+      "choose-country": "Виберіть країну",
+      "choose-type": "Виберіть тип розташування (обов'язково)",
+      "countries": {
+        "AD": "Андорра",
+        "AE": "Об'єднані Арабські Емірати",
+        "AF": "Афганістан",
+        "AG": "Антигуа і Барбуда",
+        "AI": "Ангілья",
+        "AL": "Албанія",
+        "AM": "Арменія",
+        "AO": "Ангола",
+        "AQ": "Антарктида",
+        "AR": "Аргентина",
+        "AS": "Американське Самоа",
+        "AT": "Австрія",
+        "AU": "Австралія",
+        "AW": "Аруба",
+        "AX": "Аландські острови",
+        "AZ": "Азербайджан",
+        "BA": "Боснія і Герцеговина",
+        "BB": "Барбадос",
+        "BD": "Бангладеш",
+        "BE": "Бельгія",
+        "BF": "Буркіна-Фасо",
+        "BG": "Болгарія",
+        "BH": "Бахрейн",
+        "BI": "Бурунді",
+        "BJ": "Бенін",
+        "BL": "Сен-Бартельмі",
+        "BM": "Бермуди",
+        "BN": "Бруней Даруссалам",
+        "BO": "Болівія",
+        "BQ": "Карибські Нідерланди",
+        "BR": "Бразилія",
+        "BS": "Багами",
+        "BT": "Бутан",
+        "BV": "Острів Буве",
+        "BW": "Ботсвана",
+        "BY": "Білорусь",
+        "BZ": "Беліз",
+        "CA": "Канада",
+        "CC": "Кокосові острови",
+        "CD": "Демократична Республіка Конго",
+        "CF": "Центральноафриканська Республіка",
+        "CG": "Республіка Конго",
+        "CH": "Швейцарія",
+        "CI": "Кот-д'Івуар",
+        "CK": "Острови Кука",
+        "CL": "Чілі",
+        "CM": "Камерун",
+        "CN": "КНР (Китайська Народна Республіка)",
+        "CO": "Колумбія",
+        "CR": "Коста-Рика",
+        "CU": "Куба",
+        "CV": "Кабо-Верде",
+        "CW": "Кюрасао",
+        "CX": "Острів Різдва",
+        "CY": "Кіпр",
+        "CZ": "Чехія",
+        "DE": "Німеччина",
+        "DJ": "Джибуті",
+        "DK": "Данія",
+        "DM": "Домініка",
+        "DO": "Домініканська Республіка",
+        "DZ": "Алжир",
+        "EC": "Еквадор",
+        "EE": "Естонія",
+        "EG": "Єгипет",
+        "EH": "САДР",
+        "ER": "Еритрея",
+        "ES": "Іспанія",
+        "ET": "Ефіопія",
+        "FI": "Фінляндія",
+        "FJ": "Фіджі",
+        "FK": "Фолклендські Острови",
+        "FM": "Мікронезія",
+        "FO": "Фарерські острови",
+        "FR": "Франція",
+        "GA": "Габон",
+        "GB": "Великобританія",
+        "GD": "Гренада",
+        "GE": "Грузія",
+        "GF": "Гвіана",
+        "GG": "Гернсі",
+        "GH": "Гана",
+        "GI": "Гібралтар",
+        "GL": "Ґренландія",
+        "GM": "Гамбія",
+        "GN": "Гвінея",
+        "GP": "Гваделупа",
+        "GQ": "Екваторіальна Гвінея",
+        "GR": "Греція",
+        "GS": "Південна Джорджія та Південні Сандвічеві Острови",
+        "GT": "Гватемала",
+        "GU": "Гуам",
+        "GW": "Гвінея-Бісау",
+        "GY": "Гаяна",
+        "HK": "Гонконг",
+        "HM": "Острів Герд і острови Макдональд",
+        "HN": "Гондурас",
+        "HR": "Хорватія",
+        "HT": "Гаїті",
+        "HU": "Угорщина",
+        "ID": "Індонезія",
+        "IE": "Ірландія",
+        "IL": "Ізраїль",
+        "IM": "Острів Мен",
+        "IN": "Індія",
+        "IO": "Британська Територія в Індійському Океані",
+        "IQ": "Ірак",
+        "IR": "Іран",
+        "IS": "Ісландія",
+        "IT": "Італія",
+        "JE": "Джерсі",
+        "JM": "Ямайка",
+        "JO": "Йорданія",
+        "JP": "Японія",
+        "KE": "Кенія",
+        "KG": "Киргизстан",
+        "KH": "Камбоджа",
+        "KI": "Кірибаті",
+        "KM": "Коморські Острови",
+        "KN": "Сент-Кіттс і Невіс",
+        "KP": "КНДР (Корейська Народно-Демократична Республіка)",
+        "KR": "Південна Корея",
+        "KW": "Кувейт",
+        "KY": "Кайманові Острови",
+        "KZ": "Казахстан",
+        "LA": "Лаос",
+        "LB": "Ліван",
+        "LC": "Сент-Люсія",
+        "LI": "Ліхтенштейн",
+        "LK": "Шрі-Ланка",
+        "LR": "Ліберія",
+        "LS": "Лесото",
+        "LT": "Литва",
+        "LU": "Люксембург",
+        "LV": "Латвія",
+        "LY": "Лівія",
+        "MA": "Марокко",
+        "MC": "Монако",
+        "MD": "Молдова",
+        "ME": "Чорногорія",
+        "MF": "Сен-Мартен",
+        "MG": "Мадагаскар",
+        "MH": "Маршаллові Острови",
+        "MK": "Македонія",
+        "ML": "Малі",
+        "MM": "М'янма",
+        "MN": "Монголія",
+        "MO": "Аоминь",
+        "MP": "Північні Маріанські Острови",
+        "MQ": "Мартиніка",
+        "MR": "Мавританія",
+        "MS": "Монтсеррат",
+        "MT": "Мальта",
+        "MU": "Маврикій",
+        "MV": "Мальдівы",
+        "MW": "Малаві",
+        "MX": "Мексика",
+        "MY": "Малайзія",
+        "MZ": "Мозамбік",
+        "NA": "Намібія",
+        "NC": "Нова Каледонія",
+        "NE": "Нігер",
+        "NF": "Острів Норфолк",
+        "NG": "Нігерія",
+        "NI": "Нікарагуа",
+        "NL": "Нідерланди",
+        "NO": "Норвегія",
+        "NP": "Непал",
+        "NR": "Науру",
+        "NU": "Ніуе",
+        "NZ": "Нова Зеландія",
+        "OM": "Оман",
+        "PA": "Панама",
+        "PE": "Перу",
+        "PF": "Французька Полінезія",
+        "PG": "Папуа Нова Гвінея",
+        "PH": "Філіппіни",
+        "PK": "Пакистан",
+        "PL": "Польша",
+        "PM": "Сен-П'єр і Мікелон",
+        "PN": "Піткерн",
+        "PR": "Пуерто-Ріко",
+        "PS": "Палестинська держава",
+        "PT": "Португалія",
+        "PW": "Палау",
+        "PY": "Парагвай",
+        "QA": "Катар",
+        "RE": "Реюньйон",
+        "RO": "Румунія",
+        "RS": "Сербія",
+        "RU": "Росія",
+        "RW": "Руанда",
+        "SA": "Саудівська Аравія",
+        "SB": "Соломонові Острови",
+        "SC": "Сейшельські Острови",
+        "SD": "Судан",
+        "SE": "Швеція",
+        "SG": "Сінгапур",
+        "SH": "Острови Святої Єлени, Вознесіння і Тристан-да-Кунья",
+        "SI": "Словенія",
+        "SJ": "Свальбард і Ян-Маєн",
+        "SK": "Словаччина",
+        "SL": "Сьєрра-Леоне",
+        "SM": "Сан-Маріно",
+        "SN": "Сенегал",
+        "SO": "Сомалі",
+        "SR": "Суринам",
+        "SS": "Південний Судан",
+        "ST": "Сан-Томе і Принсіпі",
+        "SV": "Сальвадор",
+        "SX": "Сінт-Мартен",
+        "SY": "Сірія",
+        "SZ": "Свазіленд",
+        "TC": "Острови Теркс і Кайкос",
+        "TD": "Чад",
+        "TF": "Французькі Південні і Антарктичні Території",
+        "TG": "Того",
+        "TH": "Таїланд",
+        "TJ": "Таджикистан",
+        "TK": "Токелау",
+        "TL": "Східний Тимор",
+        "TM": "Туркменістан",
+        "TN": "Туніс",
+        "TO": "Тонга",
+        "TR": "Турція",
+        "TT": "Тринідад і Тобаго",
+        "TV": "Тувалу",
+        "TW": "Республіка Китай",
+        "TZ": "Танзанія",
+        "UA": "Україна",
+        "UG": "Уганда",
+        "UM": "Зовнішні малі острови (США)",
+        "US": "США",
+        "UY": "Уругвай",
+        "UZ": "Узбекистан",
+        "VA": "Ватикан",
+        "VC": "Сент-Вінсент і Гренадини",
+        "VE": "Венесуела",
+        "VG": "Британські Віргінські Острови",
+        "VI": "Віргінські Острови (США)",
+        "VN": "В'єтнам",
+        "VU": "Вануату",
+        "WF": "Волліс і Футуна",
+        "WS": "Самоа",
+        "XK": "Косово",
+        "YE": "Ємен",
+        "YT": "Майотта",
+        "ZA": "ПАР",
+        "ZM": "Замбія",
+        "ZW": "Зімбабве"
+      },
+      "edit": {
+        "success": "Місцезнаходження успішно змінено.",
+        "title": "Відредагуйте розташування для"
+      }
+    },
+    "location-list-card": {
+      "delete": {
+        "button": "Так, видалити!",
+        "button-cancel": "Скасувати",
+        "remove-error": "Місцезнаходження не видалено. Спробуйте ще раз.",
+        "remove-success": "Місцезнаходження успішно видалено.",
+        "title": "Ви дійсно хочете видалити місце розташування?"
+      },
+      "not-defined": "Місцезнаходження не визначено",
+      "add-location": "Додати місцезнаходження",
+      "title": "Місцезнаходження",
+      "title-location": "Місцезнаходження"
+    },
+    "rating-list-section": {
+      "vote-error": "Ваш голос не приймається",
+      "vote-success": "Ваш голос приймається",
+      "votes": "Голос(а)"
+    },
+    "states-management-dialog": {
+      "choose-state": "Виберіть ключ",
+      "title": "Детальна інформація станів"
+    },
+    "tag-list-section": {
+      "add-error": "Тег не додано. Спробуй ще раз.",
+      "remove-error": "Тег не видалений. Спробуй ще раз.",
+      "type-tag": "додати тег ..."
+    }
+  },
+  "xm-enum": {
+    "all": "Всі",
+    "other": "Інше",
+    "others": "Інші"
+  },
+  "xm-navbar-language-menu": {
+    "choose-language": "Виберіть мову"
+  },
+  "xm-notifications": {
+    "showAll": "Дивитися все"
+  },
+  "xm-timeline": {
+    "common": {
+      "no-items": "Відсутні записи по даному запиту!",
+      "show-more-10": "Показати більше",
+      "show-more-all": "Показати все",
+      "title": "Хронологія",
+      "time-ago": {
+        "day": "день тому",
+        "days": "днів тому",
+        "hour": "годину назад",
+        "hours": "години тому",
+        "minute": "хвилину тому",
+        "minutes": "хвилин тому",
+        "month": "місяць тому",
+        "months": "місяці тому",
+        "seconds": "кілька секунд назад",
+        "year": "рік назад",
+        "years": "багато років тому"
+      }
+    },
+    "timeline": {
+      "by": "по",
+      "error": "ПОМИЛКА",
+      "more": "більше часових подій ...",
+      "success": "УСПІШНО",
+      "title": "Історія"
+    }
+  },
+  "xm": {
+    "dashboard": {
+      "config": "Конфігурація",
+      "created": "Нова інформаційна панель створена з ідентифікатором {{param}}",
+      "delete": {
+        "question": "Ви впевнені, що хочете видалити інформаційну панель {{id}}?"
+      },
+      "deleted": "Інформаційна панель видаляється з ідентифікатором {{param}}",
+      "detail": {
+        "title": "Інформаційна панель"
+      },
+      "home": {
+        "createLabel": "Створіть нову інформаційну панель",
+        "createOrEditLabel": "Створення або редагування інформаційної панелі",
+        "search": "Пошук інформаційної панелі",
+        "title": "Інформаційні панелі"
+      },
+      "isPublic": "Є громадським",
+      "layout": "Розмітка",
+      "name": "Ім'я",
+      "owner": "Власник",
+      "updated": "Інформаційна панель оновлюється за ідентифікатором {{param}}",
+      "widgets": "Віджети"
+    },
+    "delete": {
+      "question": "Ви впевнені, що хочете видалити [ <b>{{name}}</b> ]?"
+    },
+    "export-entities": {
+      "btn-cancel": "Скасувати",
+      "btn-export": "Експорт",
+      "details-title": "Експортувати сутність",
+      "message-error": "Помилка експорту!",
+      "message-success": "Експортовано успішно!",
+      "no-params-required": "Немає необхідних параметрів!",
+      "step-1": "Виберіть тип сутності",
+      "step-2": "Виберіть необхідні параметри"
+    },
+    "import-entities": {
+      "btn-cancel": "Скасувати",
+      "btn-import": "Імпорт",
+      "details-title": "Імпортувати сутність",
+      "file-process-error": "Файл пошкоджений або має інше розширення ніж .json!",
+      "message-error": "Не вдалося імпортувати!",
+      "message-success": "Імпортовано успішно!",
+      "upload-btn-text": "Завантажити з файлу JSON"
+    },
+    "xmEntity": {
+      "add": {
+        "chooseType": "Виберіть тип юридичної особи",
+        "title": "Додати новий запис"
+      },
+      "addPhoto": "Додати фотографію",
+      "change": "Змінити",
+      "data": "Дані",
+      "description": "Опис",
+      "edit": {
+        "title": "Редагування об'єкта [ <b>{{name}}</b> ]"
+      },
+      "endDate": "Дата закінчення",
+      "functions": "Функції",
+      "lifecycle": {
+        "nextStates": "Наступні стани доступні через життєвий цикл:",
+        "title": "Життєвий цикл"
+      },
+      "listView": "Перелік списку",
+      "locations": "Місця розташування",
+      "name": "Ім'я/Назва",
+      "redeem": {
+        "title": "Викупити"
+      },
+      "search": "Результат пошуку для",
+      "showMore": "Показати більше",
+      "startDate": "Дата початку",
+      "state": "Стан",
+      "tenant": {
+        "error": {
+          "alreadyUsed": "Ім'я тенанта вже використовується",
+          "tenantKeyFormat": "Ім'я тенанта повинно містити тільки букви, цифри та нижнє підкреслення. Перший символ повинен бути літерою. Не повинне починатия з 'pg_'. Максимальна довжина 48 символів"
+        }
+      },
+      "title": "Назва",
+      "treeView": "Вид дерева",
+      "type": "Тип",
+      "votes": "Голос(а)"
+    },
+    "defaultProfile": {
+      "created": "Новий основний профіль із ідентифікатором {{ param }} створено",
+      "dashboard": "Dashboard",
+      "delete": {
+        "question": "Підтвердіть видалення основного профілю: {{ id }}?"
+      },
+      "deleted": "Основний профіль із ідентифікатором {{ param }} видалено",
+      "detail": {
+        "title": "Основний профіль"
+      },
+      "home": {
+        "createLabel": "Створити новий основний профіль",
+        "createOrEditLabel": "Створити або редагувати основний профіль",
+        "search": "Шукати основний профіль",
+        "title": "Основні профілі"
+      },
+      "roleKey": "Ключ ролі",
+      "updated": "Основний профіль із ідентифікатором {{ param }} оновлено"
+    },
+    "profile": {
+      "created": "Новий профіль з ідентифікатором {{ param }} створено",
+      "dashboards": "Dashboards",
+      "delete": {
+        "question": "Підтвердіть видалення профілю: {{ id }}"
+      },
+      "deleted": "Профіль із ідентифікатором {{ param }} видалено",
+      "detail": {
+        "title": "Профіль"
+      },
+      "home": {
+        "createLabel": "Створити профіль",
+        "createOrEditLabel": "Створити або редагувати профіль",
+        "search": "Шукати профіль",
+        "title": "Профілі"
+      },
+      "login": "Login",
+      "updated": "Профіль із ідентифікатором {{ param }} оновлено"
+    }
+  },
+  "xm-validator-processing": {
+    "validators": {
+      "minDate": "Обрана дата менше ніж мінімальна дата ({{minDateI18n}}).",
+      "languageRequired": "Потрібна принаймні одна мова",
+      "minArrayLength": "Масив менший за мінімальну допустиму довжину ({{requiredLength}}).",
+      "valueMoreThanIn": "Значення більше ніж {{compareValue}}",
+      "dateLessOrEqual": "\"Дата до\" не включена в період. \"Дата від\" - \"дата до\" не можуть співпадати.",
+      "valueLessThanIn": "Значення менше ніж {{compareValue}}",
+      "severalEmails": "Невалідний email або значення повинні бути розділені знаком: ';'",
+      "dateMoreThanIn": "Значення вище дозволеного діапазону",
+      "dateLessThanIn": "Значення менше дозволеного діапазону"
+    }
+  },
+  "table": {
+    "filter": {
+      "button": {
+        "search": "Пошук",
+        "reset": "Скинути",
+        "clearAll": "Скинути все",
+        "more": "Ще"
+      }
+    }
+  },
+  "login-page": {
+    "tfa": {
+      "code-number": "Код був відправлений на номер",
+      "change-number": "Змінити номер",
+      "code-sms": "Введіть код із SMS:",
+      "code-valid": "Код дійсний протягом 2 хвилин. Не повідомляйте цей код нікому.",
+      "no-sms": "Не отримали SMS?",
+      "more-sms": "Відправити ще раз",
+      "signUp": " Зареєструватися",
+      "signUp-no-account": "Немає акаунту?"
+    }
+  },
+  "sessions": {
+    "messages": {
+      "error": "<strong>Сталася помилка!</strong> Сесія не може буде анульована.",
+      "success": "<strong>Сесія анульована!</strong>"
+    },
+    "table": {
+      "button": "Анулювати",
+      "date": "Дата",
+      "ipaddress": "IP адреса",
+      "useragent": "User Agent"
+    },
+    "title": "Активна сесія для [<b>{{username}}</b>]"
+  },
+  "tracker": {
+    "table": {
+      "ipaddress": "IP адреса",
+      "page": "Поточна сторінка",
+      "time": "Час",
+      "userAgent": "User agent",
+      "userlogin": "User"
+    },
+    "title": "Поточні активності користувачів"
+  },
+  "transfer-dashboards": {
+    "actions": {
+      "next": "Далі",
+      "back": "Назад",
+      "transfer": "Перенести",
+      "nextWithoutUpdatingRoles": "Далі (без оновлення ролей)",
+      "updateRoles": "Оновити ролі",
+      "doItAgain": "Зробити це ще раз"
+    },
+    "steps": {
+      "actionTypeStepLabel": "Яку дію ви хочете виконати?",
+      "actionTypeStepTitle": "Виберіть дію",
+      "environmentStepLabel": "Введіть дані про оточення",
+      "environmentStepTitle": "Дані про оточення",
+      "dashboardsStepLabel": "Які дашборди будете переносити?",
+      "dashboardsStepTitle": "Дашборди",
+      "dashboardsConfirmationStepLabel": "Підтвердьте вибір дашбордів",
+      "dashboardsConfirmationStepTitle": "Підтвердьте вибір дашбордів",
+      "rolesStepLabel": "Які ролі будуть оновлюватися?",
+      "rolesStepTitle": "Ролі",
+      "rolesConfirmationStepLabel": "Підтвердьте вибір ролей",
+      "rolesConfirmationStepTitle": "Підтвердьте вибір ролей",
+      "doneStepLabel": "Завершено"
+    },
+    "actionTypeStep": {
+      "transferDashboards": "Перенесення дашбордів",
+      "updateRoles": "Оновлення ролей"
+    },
+    "envStep": {
+      "urlLabel": "URL-адреса оточення",
+      "urlPlaceholder": "Введіть URL-адресу оточення",
+      "tokenLabel": "Токен",
+      "tokenPlaceholder": "Введіть токен"
+    },
+    "dashboardsStep": {
+      "searchLabel": "Знайдіть дашборди за назвою",
+      "searchPlaceholder": "Введіть ім'я дашборду",
+      "selectAllDashboards": "Вибрати всі дашборди"
+    },
+    "rolesStep": {
+      "searchLabel": "Знайдіть ролі за roleKey",
+      "searchPlaceholder": "Введіть roleKey",
+      "selectAllRoles": "Вибрати всі ролі"
+    },
+    "doneStep": {
+      "title": "Вітаю!",
+      "successTransferredDashboards": "Ви успішно перенесли дашборди",
+      "successUpdatedRoles": "Ви успішно оновили ролі",
+      "inEnvironment": "на оточенні",
+      "pleaseNote": "зверніть увагу!",
+      "errorsOccurredWhileUpdating": "Під час оновлення виникли помилки з",
+      "roles": "ролями",
+      "statusCode": "Статус код",
+      "errorDescription": "Опис помилки"
+    },
+    "errors": {
+      "atLeastOneDashboardRequired": "Виберіть принаймні одну інформаційну панель",
+      "atLeastOneRoleRequired": "Виберіть хоча б одну роль"
+    },
+    "successMessages": {
+      "dashboardSuccessfullyCreated": "Дашборди успішно створено",
+      "rolesSuccessfullyUpdated": "Ролі успішно оновлено"
+    }
+  }
 }


### PR DESCRIPTION
Dashboards Transfer is a functionality that allows transferring dashboards or roles from one environment to another. Currently, this functionality only allows the creation of dashboards and roles on the environments where we want to transfer them, but in the future, there will also be the possibility to update the existing ones