### PR TITLE
feat(role-transfer): Add ability to create roles on target env if not exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "8.0.20",
+  "version": "8.0.21",
   "release": "6.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/packages/administration/dashboards-config/components/dashboards-transfer/dashboards-transfer.component.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/dashboards-transfer.component.ts
@@ -182,7 +182,11 @@ export class DashboardsTransferComponent implements OnInit, AfterViewInit, OnDes
         this.processAction(STEP_NAME).pipe(
             tap(() => {
                 this.actionDone = true;
-            })
+            }),
+            delay(500),
+            tap(() => {
+                this.stepperRef.next();
+            }),
         ).subscribe();
     }
 

--- a/packages/administration/dashboards-config/components/dashboards-transfer/services/dashboards-transfer-api.service.ts
+++ b/packages/administration/dashboards-config/components/dashboards-transfer/services/dashboards-transfer-api.service.ts
@@ -93,6 +93,16 @@ export class DashboardsTransferApiService {
         );
     }
 
+    public createRole(role: Role, env: TransferEnv): Observable<any> {
+        const { host, headers } = this.getRequestData(env);
+
+        return this.http.post(
+            `${host}/${this.ROLES_URL}`,
+            role,
+            { headers },
+        );
+    }
+
     public getWidgets(queryParams: QueryParams = {}, env?: TransferEnv): Observable<DashboardWidget[]> {
         const { host, headers } = this.getRequestData(env);
 


### PR DESCRIPTION
Add the ability to create roles in the target environment based on the corresponding local environment role, if a role with the same typeKey does not exist in the target environment.