### PR TITLE
Added dashboard configuration for not showing if session is not active

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "8.0.28",
+  "version": "8.0.29",
   "release": "6.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/packages/dashboard/src/components/dashboard/dashboard.component.html
+++ b/packages/dashboard/src/components/dashboard/dashboard.component.html
@@ -1,5 +1,5 @@
 <xm-loader [showLoader]="showLoader"></xm-loader>
-
+<ng-container *ngIf="show$ | async">
 <div [style]="dashboard?.layout?.style" class="dashboard-container {{dashboard?.layout?.class}}">
   @for (item of dashboard?.layout?.grid; track item) {
     <ng-container *ngTemplateOutlet="dashboardItem; context: {item: item}"></ng-container>
@@ -56,3 +56,4 @@
 } @else {
   <no-data [show]="!dashboard?.layout?.grid?.length"></no-data>
 }
+</ng-container>

--- a/packages/dashboard/src/components/dashboard/dashboard.component.ts
+++ b/packages/dashboard/src/components/dashboard/dashboard.component.ts
@@ -55,14 +55,7 @@ export class DashboardComponent extends DashboardBase implements OnInit, OnDestr
 
     public ngOnInit(): void {
         this.xmEntitySpecWrapperService.spec().then((spec) => this.spec = spec);
-        this.eventManager.listenTo('USER-LOGOUT-INIT')
-            .pipe(takeUntilOnDestroy(this))
-            .subscribe(() => this.loggingOut$.next(true));
-      
-        merge(
-            this.eventManager.listenTo('USER-LOGOUT'),
-            this.eventManager.listenTo('authenticationSuccess'),
-        ).pipe(takeUntilOnDestroy(this)).subscribe(() => this.loggingOut$.next(false));
+        this.observeSessionEvents();
         this.route.params
             .pipe(takeUntilOnDestroy(this))
             .subscribe(() => {
@@ -130,5 +123,16 @@ export class DashboardComponent extends DashboardBase implements OnInit, OnDestr
             config: layout.widget.config,
             spec: this.spec,
         };
+    }
+
+    private observeSessionEvents(): void {
+        this.eventManager.listenTo('USER-LOGOUT-INIT')
+            .pipe(takeUntilOnDestroy(this))
+            .subscribe(() => this.loggingOut$.next(true));
+
+        merge(
+            this.eventManager.listenTo('USER-LOGOUT'),
+            this.eventManager.listenTo('authenticationSuccess'),
+        ).pipe(takeUntilOnDestroy(this)).subscribe(() => this.loggingOut$.next(false));
     }
 }


### PR DESCRIPTION
With logout for 0.5 seconds we have block of our dashboard. 
<img width="1824" height="1156" alt="image" src="https://github.com/user-attachments/assets/b6d34454-e0e0-4bc6-927b-38462dbbd308" />

To fix it i`ve added session and logout event subscription for validate block 
