### PR TITLE
feat(BS1-12397): Extends refresh table logic & service creation config token available

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xm-webapp",
-  "version": "9.0.73",
+  "version": "9.0.77",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xm-webapp",
-      "version": "9.0.73",
+      "version": "9.0.77",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "9.0.73",
+  "version": "9.0.77",
   "release": "6.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/packages/components/table/components/refresh-btn/refresh-btn.component.ts
+++ b/packages/components/table/components/refresh-btn/refresh-btn.component.ts
@@ -11,10 +11,10 @@ import { RefreshBtnConfig } from './types/refresh-btn-config.model';
 import { MatIconButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { defaultsDeep } from 'lodash';
-import { XmEventManagerService } from '@xm-ngx/core';
-import { XmTableEventType } from '../../directives/xm-table.model';
 import { XmLoadingModule } from '@xm-ngx/components/loading';
 import { DEFAULT_REFRESH_BUTTON_CONFIG } from './constants/default-refresh-btn-config.constants';
+import { XmEventManagerService } from '@xm-ngx/core';
+import { XmTableEventType } from '../../directives/xm-table.model';
 
 @Component({
     selector: 'refresh-btn',
@@ -25,7 +25,7 @@ import { DEFAULT_REFRESH_BUTTON_CONFIG } from './constants/default-refresh-btn-c
     imports: [MatIconButton, MatIcon, XmLoadingModule],
 })
 export class RefreshBtnComponent {
-    private readonly eventManagerService: XmEventManagerService = inject(XmEventManagerService);
+    private readonly eventManager: XmEventManagerService = inject(XmEventManagerService);
 
     public refreshConfig: InputSignal<RefreshBtnConfig> = input<RefreshBtnConfig>();
     public tableKey: InputSignal<string | undefined> = input<string>();
@@ -37,8 +37,8 @@ export class RefreshBtnComponent {
     });
 
     public handleClick(): void {
-        this.eventManagerService.broadcast({
-            name: this.tableKey() + XmTableEventType.XM_TABLE_UPDATE,
+        this.eventManager.broadcast({
+            name: `${this.tableKey()}${XmTableEventType.XM_TABLE_REFRESH}`,
         });
     }
 }

--- a/packages/components/table/directives/xm-table.directive.ts
+++ b/packages/components/table/directives/xm-table.directive.ts
@@ -22,8 +22,8 @@ import { XmUiConfigService } from '@xm-ngx/core/config';
 import { toSignal } from '@angular/core/rxjs-interop';
 
 export interface IXmTableContext {
-    collection: IXmTableCollectionState<unknown>,
-    settings: { displayedColumns: string [] };
+    collection: IXmTableCollectionState<unknown>;
+    settings: { displayedColumns: string[] };
 }
 
 export interface StaticQueryParams {
@@ -33,7 +33,7 @@ export interface StaticQueryParams {
 
 function getDisplayedColumns(config: XmTableConfig): ColumnsSettingStorageItem[] {
     const displayedColumns = config.columns;
-    return displayedColumns.map(column => ({
+    return displayedColumns.map((column) => ({
         name: column.name || column.field,
         hidden: column['hidden'] || false,
         title: column.title,
@@ -47,7 +47,7 @@ function getDisplayedColumns(config: XmTableConfig): ColumnsSettingStorageItem[]
 @Directive({
     selector: '[xmTable]',
     exportAs: 'xmTable',
-    host: {class: 'xm-table'},
+    host: { class: 'xm-table' },
     providers: [
         XmTableFilterController,
         XmTableColumnsSettingStorageService,
@@ -58,11 +58,12 @@ function getDisplayedColumns(config: XmTableConfig): ColumnsSettingStorageItem[]
 export class XmTableDirective implements OnInit, OnDestroy {
     private readonly xmConfigService = inject(XmUiConfigService);
 
-    public useSkeletonLoading: boolean = toSignal(this.xmConfigService.config$())()?.skeleton?.table?.isSkeletonLoading || false;
+    public useSkeletonLoading: boolean =
+        toSignal(this.xmConfigService.config$())()?.skeleton?.table?.isSkeletonLoading || false;
     public context$: Observable<IXmTableContext>;
     public pageableAndSortable$ = new Subject<PageableAndSortable>();
-    @ContentChild(MatPaginator, {static: false}) public paginator: MatPaginator | null;
-    @ContentChild(MatSort, {static: false}) public sort: MatSort | null;
+    @ContentChild(MatPaginator, { static: false }) public paginator: MatPaginator | null;
+    @ContentChild(MatSort, { static: false }) public sort: MatSort | null;
     @Input()
     public xmTableController: IXmTableCollectionController<unknown>;
     private skipLoadOnInit = false;
@@ -72,8 +73,7 @@ export class XmTableDirective implements OnInit, OnDestroy {
         private columnsSettingStorageService: XmTableColumnsSettingStorageService,
         private queryParamsStoreService: XmTableQueryParamsStoreService,
         private eventManagerService: XmEventManagerService,
-    ) {
-    }
+    ) {}
 
     private _config: XmTableConfig;
     public filters: {};
@@ -115,13 +115,19 @@ export class XmTableDirective implements OnInit, OnDestroy {
             this.columnsSettingStorageService.getStore(),
         ]).pipe(
             map(([state, a]) => {
-                const displayedColumns = _.map(_.filter(a, i => !i.hidden), i => i.name);
-                const collection: IXmTableCollectionState<unknown> = this.getCollection(state, displayedColumns);
+                const displayedColumns = _.map(
+                    _.filter(a, (i) => !i.hidden),
+                    (i) => i.name,
+                );
+                const collection: IXmTableCollectionState<unknown> = this.getCollection(
+                    state,
+                    displayedColumns,
+                );
 
-                return ({
+                return {
                     collection,
-                    settings: {displayedColumns},
-                });
+                    settings: { displayedColumns },
+                };
             }),
             shareReplay(1),
         );
@@ -129,73 +135,88 @@ export class XmTableDirective implements OnInit, OnDestroy {
         const queryParams = this.getInitialQueryParams();
 
         const tableUpdateEventsObs = this.config.tableUpdateEvents
-            ? this.config.tableUpdateEvents.map(event =>
-                this.eventManagerService.listenTo(event).pipe(startWith({} as any))
-            )
+            ? this.config.tableUpdateEvents.map((event) =>
+                  this.eventManagerService.listenTo(event).pipe(startWith({} as any)),
+              )
             : [];
 
         combineLatest([
-            this.queryParamsStoreService.listenQueryParamsToFilter(this.config.queryParamsFilter).pipe(
-                startWith(queryParams?.filterParams ?? {}),
-            ),
-            this.eventManagerService.listenTo<{
-                queryParams: Params
-            }>(`${this.config.triggerTableKey}${XmTableEventType.XM_TABLE_UPDATE}`).pipe(
-                startWith({} as any),
-                map((evt) => {
-                    return {
-                        eventFilter: evt.payload?.queryParams,
-                        triggerEvent: true,
-                    };
-                }),
-
-            ),
+            this.queryParamsStoreService
+                .listenQueryParamsToFilter(this.config.queryParamsFilter)
+                .pipe(startWith(queryParams?.filterParams ?? {})),
+            this.eventManagerService
+                .listenTo<{
+                    queryParams: Params;
+                }>(`${this.config.triggerTableKey}${XmTableEventType.XM_TABLE_UPDATE}`)
+                .pipe(
+                    startWith({} as any),
+                    map((evt) => {
+                        return {
+                            eventFilter: evt.payload?.queryParams,
+                            triggerEvent: true,
+                        };
+                    }),
+                ),
             ...tableUpdateEventsObs,
-        ]).pipe(
-            tap(([queryFilter, eventManager]) => {
-                const mergeFilters = _.merge({}, queryFilter, eventManager.eventFilter);
+        ])
+            .pipe(
+                tap(([queryFilter, eventManager]) => {
+                    const mergeFilters = _.merge({}, queryFilter, eventManager.eventFilter);
 
-                if (eventManager.triggerEvent) {
+                    if (eventManager.triggerEvent) {
+                        this.tableFilterController.update(mergeFilters);
+                        return;
+                    }
+
+                    if (_.isEmpty(mergeFilters)) {
+                        return;
+                    }
+
                     this.tableFilterController.update(mergeFilters);
-                    return;
-                }
-
-                if (_.isEmpty(mergeFilters)) {
-                    return;
-                }
-
-                this.tableFilterController.update(mergeFilters);
-            }),
-            takeUntilOnDestroy(this),
-        ).subscribe();
+                }),
+                takeUntilOnDestroy(this),
+            )
+            .subscribe();
 
         combineLatest({
             tableFilter: this.tableFilterController.change$(),
             pageableAndSortable: this.pageableAndSortable$.pipe(
                 startWith(queryParams.pageableAndSortable ?? {}),
             ),
-        }).pipe(
-            takeUntilOnDestroy(this),
-        ).subscribe((obsObj) => {
-            const filterParams = obsObj.tableFilter;
-            const pageableAndSortable = this.mapPageableAndSortable(filterParams, obsObj.pageableAndSortable);
-            this.filters = cloneDeep(filterParams);
-            const queryParams = _.merge({}, {pageableAndSortable}, {filterParams});
+        })
+            .pipe(takeUntilOnDestroy(this))
+            .subscribe((obsObj) => {
+                const filterParams = obsObj.tableFilter;
+                const pageableAndSortable = this.mapPageableAndSortable(
+                    filterParams,
+                    obsObj.pageableAndSortable,
+                );
+                this.filters = cloneDeep(filterParams);
+                const queryParams = _.merge({}, { pageableAndSortable }, { filterParams });
 
-            this.queryParamsStoreService.set(queryParams, this.config);
+                this.queryParamsStoreService.set(queryParams, this.config);
 
-            if (!this.skipLoadOnInit) {
-                this.xmTableController.load(queryParams);
-            }
-            this.skipLoadOnInit = false;
-        });
+                if (!this.skipLoadOnInit) {
+                    this.xmTableController.load(queryParams);
+                }
+                this.skipLoadOnInit = false;
+            });
+
+        this.listenRefreshEvent();
     }
 
-    private getCollection(state: IXmTableCollectionState<unknown>, displayedColumns: string[]): IXmTableCollectionState<unknown> {
+    private getCollection(
+        state: IXmTableCollectionState<unknown>,
+        displayedColumns: string[],
+    ): IXmTableCollectionState<unknown> {
         if (state?.loading && (this._config.isSkeletonLoading || this.useSkeletonLoading)) {
             const pageSize: number = state.pageableAndSortable?.pageSize ?? 10;
-            const expectedItem: Record<string, string> = Object.fromEntries(displayedColumns.map((colName: string) => [colName, '']));
-            const skeletonRows: Record<string, string>[] = Array.from({length: pageSize}, () => ({...expectedItem}));
+            const expectedItem: Record<string, string> = Object.fromEntries(
+                displayedColumns.map((colName: string) => [colName, '']),
+            );
+            const skeletonRows: Record<string, string>[] = Array.from({ length: pageSize }, () => ({
+                ...expectedItem,
+            }));
 
             return {
                 ...state,
@@ -206,30 +227,33 @@ export class XmTableDirective implements OnInit, OnDestroy {
         return state;
     }
 
-    private mapPageableAndSortable(filterParams: FiltersControlValue, pageableAndSortable: PageableAndSortable): PageableAndSortable {
+    private mapPageableAndSortable(
+        filterParams: FiltersControlValue,
+        pageableAndSortable: PageableAndSortable,
+    ): PageableAndSortable {
         if (this.filters && !isEqual(filterParams, this.filters)) {
             set(pageableAndSortable, 'pageIndex', 0);
         }
         return pageableAndSortable;
     }
 
-
     public ngOnDestroy(): void {
         takeUntilOnDestroyDestroy(this);
     }
 
     public updatePagination(refreshIndex?: boolean): void {
-        const {sortBy: defaultSortBy, sortOrder: defaultSortOrder} = this._config.pageableAndSortable;
+        const { sortBy: defaultSortBy, sortOrder: defaultSortOrder } =
+            this._config.pageableAndSortable;
 
-        const sortBy = this._config.columns.find((i) => i.name === this.sort.active)?.name ?? defaultSortBy;
+        const sortBy =
+            this._config.columns.find((i) => i.name === this.sort.active)?.name ?? defaultSortBy;
         const sortOrder = this.sort.direction ?? defaultSortOrder;
         const pageIndex = refreshIndex ? 0 : this.paginator.pageIndex;
         const pageSize = this.paginator.pageSize;
         const total = this.paginator.length;
-        const pageAndSort: PageableAndSortable = {pageIndex, pageSize, sortOrder, sortBy, total};
+        const pageAndSort: PageableAndSortable = { pageIndex, pageSize, sortOrder, sortBy, total };
         this.pageableAndSortable$.next(pageAndSort);
     }
-
 
     private setStorageKeys(): void {
         this.columnsSettingStorageService.key = this.config.storageKey;
@@ -237,19 +261,36 @@ export class XmTableDirective implements OnInit, OnDestroy {
     }
 
     private getInitialQueryParams(): StaticQueryParams {
-        const {filterParams, pageableAndSortable} = (this.queryParamsStoreService.get() ?? {}) as StaticQueryParams;
-        const {pageIndex, pageSize, sortBy, sortOrder} = this._config.pageableAndSortable;
+        const { filterParams, pageableAndSortable } = (this.queryParamsStoreService.get() ??
+            {}) as StaticQueryParams;
+        const { pageIndex, pageSize, sortBy, sortOrder } = this._config.pageableAndSortable;
 
-        const mergePageAndSort = _.merge({}, {
-            pageIndex,
-            pageSize,
-            sortBy,
-            sortOrder,
-        }, pageableAndSortable);
+        const mergePageAndSort = _.merge(
+            {},
+            {
+                pageIndex,
+                pageSize,
+                sortBy,
+                sortOrder,
+            },
+            pageableAndSortable,
+        );
 
         return {
             pageableAndSortable: mergePageAndSort,
             filterParams,
         };
+    }
+
+    private listenRefreshEvent(): void {
+        this.eventManagerService
+            .listenTo(`${this.config.triggerTableKey}${XmTableEventType.XM_TABLE_REFRESH}`)
+            .pipe(
+                takeUntilOnDestroy(this),
+                tap(() => {
+                    this.tableFilterController.refresh();
+                }),
+            )
+            .subscribe();
     }
 }

--- a/packages/components/table/directives/xm-table.model.ts
+++ b/packages/components/table/directives/xm-table.model.ts
@@ -63,4 +63,5 @@ export const XM_TABLE_CONFIG_DEFAULT: XmTableConfig = {
 
 export enum XmTableEventType {
     XM_TABLE_UPDATE = 'XM_TABLE_UPDATE',
+    XM_TABLE_REFRESH = 'XM_TABLE_REFRESH',
 }

--- a/packages/dynamic/index.ts
+++ b/packages/dynamic/index.ts
@@ -41,7 +41,7 @@ export { XmDynamicWidgetLayoutComponent } from './widget/xm-dynamic-widget-layou
 export { XmDynamicWidget } from './widget/xm-dynamic-widget';
 export { XmDynamicWidgetModule } from './widget/xm-dynamic-widget-module.interface';
 
-export { XM_DYNAMIC_ENTRIES, XM_DYNAMIC_EXTENSIONS, XM_DYNAMIC_COMPONENT_CONFIG } from './src/dynamic.injectors';
+export { XM_DYNAMIC_ENTRIES, XM_DYNAMIC_EXTENSIONS, XM_DYNAMIC_COMPONENT_CONFIG, XM_DYNAMIC_SERVICE_CONFIG } from './src/dynamic.injectors';
 
 export { XmDynamicModule, dynamicModuleInitializer } from './src/module/xm-dynamic.module';
 

--- a/packages/dynamic/src/dynamic.injectors.ts
+++ b/packages/dynamic/src/dynamic.injectors.ts
@@ -5,6 +5,12 @@ import { XmDynamicExtensionEntry } from './interfaces/xm-dynamic-extension.model
 
 export const XM_DYNAMIC_ENTRIES = new InjectionToken<XmDynamicEntries>('XM_DYNAMIC_ENTRIES');
 
-export const XM_DYNAMIC_EXTENSIONS = new InjectionToken<XmDynamicExtensionEntry[]>('XM_DYNAMIC_EXTENSION-ENTRIES');
+export const XM_DYNAMIC_EXTENSIONS = new InjectionToken<XmDynamicExtensionEntry[]>(
+    'XM_DYNAMIC_EXTENSION-ENTRIES',
+);
 
-export const XM_DYNAMIC_COMPONENT_CONFIG = new InjectionToken<XmConfig>('XM_DYNAMIC_COMPONENT_CONFIG');
+export const XM_DYNAMIC_COMPONENT_CONFIG = new InjectionToken<XmConfig>(
+    'XM_DYNAMIC_COMPONENT_CONFIG',
+);
+
+export const XM_DYNAMIC_SERVICE_CONFIG = new InjectionToken<XmConfig>('XM_DYNAMIC_SERVICE_CONFIG');

--- a/packages/dynamic/src/services/xm-dynamic-controller-injector-factory.service.ts
+++ b/packages/dynamic/src/services/xm-dynamic-controller-injector-factory.service.ts
@@ -2,15 +2,18 @@ import { inject, Injectable, Injector, StaticProvider } from '@angular/core';
 import { XmDynamicServiceFactory } from '../../services/xm-dynamic-service-factory.service';
 import { XmDynamicControllerDeclaration } from '../../presentation/xm-dynamic-presentation-base.directive';
 import { XmDynamicInjectionTokenStoreService } from './xm-dynamic-injection-token-store.service';
-
+import { XM_DYNAMIC_SERVICE_CONFIG } from '../dynamic.injectors';
 
 @Injectable()
 export class XmDynamicControllerInjectorFactoryService {
-
     private dynamicInjectionTokenStore = inject(XmDynamicInjectionTokenStoreService);
     private dynamicServices = inject(XmDynamicServiceFactory);
 
-    public async defineProviders(controllers: XmDynamicControllerDeclaration[], providers: StaticProvider[], parentInjector: Injector): Promise<Injector> {
+    public async defineProviders(
+        controllers: XmDynamicControllerDeclaration[],
+        providers: StaticProvider[],
+        parentInjector: Injector,
+    ): Promise<Injector> {
         if (controllers?.length > 0) {
             for (const controller of controllers) {
                 providers.push(await this.createControllerProvider(controller, parentInjector));
@@ -23,7 +26,7 @@ export class XmDynamicControllerInjectorFactoryService {
         });
 
         if (controllers?.length > 0) {
-            controllers.forEach(controller => {
+            controllers.forEach((controller) => {
                 this.enrichControllerData(controller, injector);
             });
         }
@@ -31,18 +34,34 @@ export class XmDynamicControllerInjectorFactoryService {
         return injector;
     }
 
-    private async createControllerProvider(controller: XmDynamicControllerDeclaration, parentInjector: Injector): Promise<StaticProvider> {
-        const entry = {
-            classType: await this.dynamicServices.find(controller.selector, parentInjector),
-            config: controller.config,
-            key: controller.key,
-        };
+    private async createControllerProvider(
+        controller: XmDynamicControllerDeclaration,
+        parentInjector: Injector,
+    ): Promise<StaticProvider> {
+        const classType = await this.dynamicServices.find(controller.selector, parentInjector);
+        const token = this.dynamicInjectionTokenStore.resolve(controller.key);
+        const config = controller.config ?? null;
 
-        const token = this.dynamicInjectionTokenStore.resolve(entry.key);
-        return {provide: token, useClass: entry.classType, deps: []};
+        return {
+            provide: token,
+            useFactory: (sharedInjector: Injector) => {
+                const controllerInjector = Injector.create({
+                    providers: [
+                        { provide: classType, useClass: classType, deps: [] },
+                        { provide: XM_DYNAMIC_SERVICE_CONFIG, useValue: config },
+                    ],
+                    parent: sharedInjector,
+                });
+                return controllerInjector.get(classType);
+            },
+            deps: [Injector],
+        };
     }
 
-    private enrichControllerData(controller: XmDynamicControllerDeclaration, injector: Injector): any {
+    private enrichControllerData(
+        controller: XmDynamicControllerDeclaration,
+        injector: Injector,
+    ): any {
         const token = this.dynamicInjectionTokenStore.resolve(controller.key);
         const instance = injector.get(token);
         instance.config = controller.config;


### PR DESCRIPTION
1. Changes related to refresh xm-table using new XmTableEventType
2. Ability to read controller config using Injection Token instead of waiting when it will be assigned into service property config after service creation; Backward capability still work;