### PR TITLE
feat(datetime-control): add min date in config for datetime-control

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xm-webapp",
-  "version": "9.0.87",
+  "version": "9.0.88",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xm-webapp",
-      "version": "9.0.87",
+      "version": "9.0.88",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "9.0.87",
+  "version": "9.0.88",
   "release": "6.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/packages/components/date/xm-datetime-control.ts
+++ b/packages/components/date/xm-datetime-control.ts
@@ -511,7 +511,20 @@ export class XmDateTimeControlComponent extends NgModelWrapper<XmDateTimeControl
     public messageErrors = inject<XmControlErrorsTranslates>(XM_CONTROL_ERRORS_TRANSLATES);
 
     @Input() public pickerFilter: XmDateTimePickerFilter;
-    @Input() public config: XmDateTimeControlConfig;
+    private _config: XmDateTimeControlConfig;
+
+    @Input()
+    set config(config: XmDateTimeControlConfig) {
+        this._config = config;
+
+        if (config.minDate) {
+            this.minDate = new Date(config.minDate);
+        }
+    }
+
+    get config(): XmDateTimeControlConfig {
+        return this._config;
+    }
 
     public minDate: Date;
 
@@ -527,10 +540,6 @@ export class XmDateTimeControlComponent extends NgModelWrapper<XmDateTimeControl
         if (this.config?.initValue) {
             const value = this.value || interpolate(this.config.initValue, null);
             this.change(value);
-        }
-
-        if (this.config?.minDate) {
-            this.minDate = new Date(this.config.minDate);
         }
     }
 

--- a/packages/components/date/xm-datetime-control.ts
+++ b/packages/components/date/xm-datetime-control.ts
@@ -50,6 +50,7 @@ export interface XmDateTimeControlConfig {
     required?: boolean;
     disableDateTimeValidator?: boolean;
     initValue?: string;
+    minDate?: string;
 }
 
 export type XmDateTimePickerFilter = (date: Date | null) => boolean;
@@ -125,6 +126,7 @@ const dateTimeValidator = (localeId: string) => {
                     matInput
                     formControlName="date"
                     placeholder="DD.MM.YYYY"
+                    [min]="minDate"
                     [matDatepicker]="picker"
                     [matDatepickerFilter]="pickerFilter"
                     (focus)="picker.open()"
@@ -201,6 +203,7 @@ export class XmDateTimeControlFieldComponent implements ControlValueAccessor, Ma
 
     @Input() public pickerFilter: XmDateTimePickerFilter;
     @Input() public picker: MatDatepickerPanel<MatDatepickerInput<any>, any>;
+    @Input() public minDate: Date;
 
     @Input()
     set placeholder(value: string) {
@@ -414,7 +417,7 @@ export class XmDateTimeControlFieldComponent implements ControlValueAccessor, Ma
     public onChange = (_: any): void => {
     };
 
-    // eslint-disable-next-line
+
     public onTouched = (): void => {
     };
 
@@ -485,6 +488,7 @@ export class XmDateTimeControlFieldComponent implements ControlValueAccessor, Ma
                 [disabled]="disabled"
                 [required]="config?.required"
                 [disableDateTimeValidator]="config?.disableDateTimeValidator"
+                [minDate]="minDate"
                 (ngModelChange)="change($event)">
             </xm-datetime-control-field>
 
@@ -509,6 +513,8 @@ export class XmDateTimeControlComponent extends NgModelWrapper<XmDateTimeControl
     @Input() public pickerFilter: XmDateTimePickerFilter;
     @Input() public config: XmDateTimeControlConfig;
 
+    public minDate: Date;
+
     constructor() {
         super();
 
@@ -521,6 +527,10 @@ export class XmDateTimeControlComponent extends NgModelWrapper<XmDateTimeControl
         if (this.config?.initValue) {
             const value = this.value || interpolate(this.config.initValue, null);
             this.change(value);
+        }
+
+        if (this.config?.minDate) {
+            this.minDate = new Date(this.config.minDate);
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to set a minimum date constraint for date/time fields, preventing selection of earlier dates.

* **Chores**
  * Package version bumped to 9.0.88.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->