### PR TITLE
fix(xm-table-widget): display expanded row by default fixed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xm-webapp",
-  "version": "9.0.90",
+  "version": "9.0.91",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xm-webapp",
-      "version": "9.0.90",
+      "version": "9.0.91",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "9.0.90",
+  "version": "9.0.91",
   "release": "6.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/packages/components/table/table-widget/xm-table-widget.component.html
+++ b/packages/components/table/table-widget/xm-table-widget.component.html
@@ -157,11 +157,13 @@
               (click)="rowClicked.emit(row)"
           ></tr>
 
-          <tr *matRowDef="let row; columns: [expandableColumnName + '_detail']; when: isExpandableRow"
-              mat-row
-              [class.xm-table-expandable-detail-row-expanded]="isRowExpanded(row)"
-              class="xm-table-expandable-detail-row">
-          </tr>
+          <ng-container *ngIf="hasExpandableRows">
+            <tr *matRowDef="let row; columns: [expandableColumnName + '_detail']; when: isExpandableRow"
+                mat-row
+                [class.xm-table-expandable-detail-row-expanded]="isRowExpanded(row)"
+                class="xm-table-expandable-detail-row">
+            </tr>
+          </ng-container>
 
         </table>
       </div>


### PR DESCRIPTION
display expanded row by default fixed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where expandable detail rows in tables were being rendered even when the expandable rows feature was disabled, improving performance and preventing unnecessary markup.

* **Chores**
  * Version bumped to 9.0.91.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xm-online/xm-webapp/pull/2576)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->