### PR TITLE
feat(rest-repo-propagate-errors): Add config property to propagate error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xm-webapp",
-  "version": "9.0.94",
+  "version": "9.0.95",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xm-webapp",
-      "version": "9.0.94",
+      "version": "9.0.95",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "9.0.94",
+  "version": "9.0.95",
   "release": "6.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/packages/controllers/features/repository/rest-repository/rest-repository.model.ts
+++ b/packages/controllers/features/repository/rest-repository/rest-repository.model.ts
@@ -1,5 +1,6 @@
 export type RestResourceConfig = {
     resource: ResourceConfig;
+    propagateErrors?: boolean;
     byType: {
         create: ResourceConfig;
         read: ResourceConfig;

--- a/packages/controllers/features/repository/rest-repository/rest-repository.service.ts
+++ b/packages/controllers/features/repository/rest-repository/rest-repository.service.ts
@@ -118,6 +118,9 @@ export class RestRepositoryService<T = any> {
     }
 
     protected handleFetchErrors<T>(errors: HttpErrorResponse): Observable<T> {
+        if (this.config?.propagateErrors) {
+            return of(errors as unknown as T);
+        }
         return of({} as T);
     }
 

--- a/packages/controllers/features/repository/rest-repository/rest-repository.service.ts
+++ b/packages/controllers/features/repository/rest-repository/rest-repository.service.ts
@@ -119,7 +119,7 @@ export class RestRepositoryService<T = any> {
 
     protected handleFetchErrors<T>(errors: HttpErrorResponse): Observable<T> {
         if (this.config?.propagateErrors) {
-            return of(errors as unknown as T);
+            return throwError(() => errors);
         }
         return of({} as T);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to REST operations that lets services surface HTTP errors directly instead of returning empty fallback responses. This makes real errors visible to callers when enabled.

* **Chores**
  * Package version bumped to 9.0.95.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xm-online/xm-webapp/pull/2581?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->