### PR TITLE
fix(menu-categories): menu open in safari, add ngZone wrapper, markFo…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xm-webapp",
-  "version": "9.0.105",
+  "version": "9.0.106",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xm-webapp",
-      "version": "9.0.105",
+      "version": "9.0.106",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "9.0.105",
+  "version": "9.0.106",
   "release": "6.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/packages/components/menu/menu-categories/menu-categories.component.ts
+++ b/packages/components/menu/menu-categories/menu-categories.component.ts
@@ -189,6 +189,7 @@ export class MenuCategoriesComponent implements OnInit, OnDestroy, AfterViewInit
 
         this.isSidenavPinned = !this.isSidenavPinned;
         await this.menuService.complexToggleSidenav();
+        this.ngZone.run(() => this.cdr.markForCheck());
     }
 
     public async onNavigate(category: MenuCategory): Promise<void> {

--- a/packages/components/menu/menu.component.ts
+++ b/packages/components/menu/menu.component.ts
@@ -332,10 +332,10 @@ export class MenuComponent implements OnInit, AfterViewInit, OnDestroy {
                 !this.menuService.sidenav.opened && isOpenMenu ? from(this.menuService.sidenav.open()) : timer(0);
             return next$.pipe(
                 observeOn(animationFrameScheduler),
-                tap(() => {
+                tap(() => this.ngZone.run(() => {
                     this.showSubCategoriesState = MenuSubcategoriesAnimationStateEnum.SHOW;
                     this.menuService.setMobileMenuState({showCategories: false, category: hoveredCategory});
-                }),
+                })),
             );
         }
 
@@ -346,16 +346,16 @@ export class MenuComponent implements OnInit, AfterViewInit, OnDestroy {
     private observeSidenavOpen(): void {
         this.menuService.sidenav.openedStart
             .pipe(takeUntilOnDestroy(this))
-            .subscribe(() => this.menuService.setIsSidenavOpen(true));
+            .subscribe(() => this.ngZone.run(() => this.menuService.setIsSidenavOpen(true)));
     }
 
     private observeSidenavClose(): void {
         this.menuService.sidenav.closedStart
             .pipe(takeUntilOnDestroy(this))
-            .subscribe(() => {
+            .subscribe(() => this.ngZone.run(() => {
                 this.hoveredCategory = null;
                 this.menuService.setIsSidenavOpen(false);
-            });
+            }));
     }
 
     public setSelectedCategory(node: MenuItem): void {


### PR DESCRIPTION
…rCheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved menu and sidenav change detection so category switching, opening, and closing reliably refresh in the interface.
  * Fixed mobile menu state not always updating to reflect the most recent interaction.
  * Ensured closing actions properly clear the hovered/active category highlight and keep the sidenav-open indicator accurate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->