### PR TITLE
fix(menu): add flushSidenavTransition for safari

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xm-webapp",
-  "version": "9.0.109",
+  "version": "9.0.110",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xm-webapp",
-      "version": "9.0.109",
+      "version": "9.0.110",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "9.0.109",
+  "version": "9.0.110",
   "release": "6.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/packages/components/menu/menu.service.ts
+++ b/packages/components/menu/menu.service.ts
@@ -1,4 +1,5 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable, NgZone } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
 import { BehaviorSubject, combineLatest, filter, from, map, Observable, of, Subject, switchMap, take } from 'rxjs';
 import { BrandLogo, HoveredMenuCategory, MenuCategory, MenuItem, MenuOptions, MobileMenuState } from './menu.interface';
 import { MatDrawerMode, MatDrawerToggleResult, MatSidenav } from '@angular/material/sidenav';
@@ -33,6 +34,9 @@ export class MenuService {
     public isCategoriesHidden$: Observable<boolean>;
     public mobileMenuPositioning: MenuPositionEnum;
     public categories: Record<string, MenuCategory>;
+
+    private readonly document: Document = inject(DOCUMENT);
+    private readonly ngZone: NgZone = inject(NgZone);
 
     constructor(
         private readonly breakpointObserver: BreakpointObserver,
@@ -268,7 +272,29 @@ export class MenuService {
     }
 
     public async toggleSidenav(): Promise<void> {
-        await this.sidenav.toggle();
+        const result: Promise<MatDrawerToggleResult> = this.sidenav.toggle();
+        this.flushSidenavTransition();
+        await result;
+    }
+
+    /**
+     * Safari (production builds) does not schedule a paint/composite frame after a
+     * discrete click handler finishes. Forcing a
+     * synchronous reflow and requesting an animation frame kicks the rendering loop
+     * immediately, so the menu opens/closes right away in every browser.
+     */
+    private flushSidenavTransition(): void {
+        if (typeof requestAnimationFrame === 'undefined') {
+            return;
+        }
+        this.ngZone.runOutsideAngular(() => {
+            const drawer: HTMLElement | null = this.document?.querySelector<HTMLElement>('.mat-drawer');
+            const target: HTMLElement | undefined = drawer ?? this.document?.documentElement;
+            void target?.offsetHeight;
+            requestAnimationFrame(() => {
+                void target?.offsetHeight;
+            });
+        });
     }
 
     public isMenuPinned(isOpen?: boolean): boolean {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sidenav opening and closing transitions for smoother, more consistent visual rendering.
  - Reduced potential layout glitches by ensuring transition updates are applied immediately and reliably.

- **Chores**
  - Updated the package version from 9.0.109 to 9.0.110.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->