### PR TITLE
fix(menu): add css styles for open animation in safari

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xm-webapp",
-  "version": "9.0.110",
+  "version": "9.0.111",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xm-webapp",
-      "version": "9.0.110",
+      "version": "9.0.111",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xm-webapp",
-  "version": "9.0.109",
+  "version": "9.0.111",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xm-webapp",
-      "version": "9.0.109",
+      "version": "9.0.111",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "9.0.109",
+  "version": "9.0.111",
   "release": "6.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "9.0.110",
+  "version": "9.0.111",
   "release": "6.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/packages/components/menu/menu.animation.ts
+++ b/packages/components/menu/menu.animation.ts
@@ -32,10 +32,6 @@ export const showHideSubCategoriesMobile: AnimationTriggerMetadata = trigger('sh
 ]);
 
 export const hideCategories: AnimationTriggerMetadata = trigger('hideCategories', [
-    transition(':enter', [
-        style({opacity: 0, transform: 'translateX(-15px)', position: 'absolute'}),
-        animate('100ms', style({opacity: 1, transform: 'translateX(0)', position: 'absolute'})),
-    ]),
     transition(':leave', [
         style({opacity: 1, transform: 'translateX(0)', position: 'absolute'}),
         animate('100ms', style({opacity: 0, transform: 'translateX(-15px)', position: 'absolute'})),

--- a/packages/components/menu/menu.component.ts
+++ b/packages/components/menu/menu.component.ts
@@ -68,6 +68,29 @@ export type ISideBarConfig = {
 @Component({
     selector: 'xm-menu',
     templateUrl: './menu.component.html',
+    styles: [`
+        /**
+         * CSS replacement for the previous Angular ':enter' animation of the categories
+         * panel. Angular's Web Animations API driven ':enter' transitions do not advance on
+         * production Safari (they only start after an unrelated user event), so the panel
+         * appeared without animation / stuck on open while closing worked. A plain CSS
+         * keyframe animation is composited natively and runs reliably in every browser.
+         */
+        .menu-categories {
+            animation: xm-menu-categories-enter 100ms linear;
+        }
+
+        @keyframes xm-menu-categories-enter {
+            from {
+                opacity: 0;
+                transform: translateX(-15px);
+            }
+            to {
+                opacity: 1;
+                transform: translateX(0);
+            }
+        }
+    `],
     animations: [
         matExpansionAnimations.bodyExpansion,
         matExpansionAnimations.indicatorRotate,

--- a/packages/components/menu/menu.service.ts
+++ b/packages/components/menu/menu.service.ts
@@ -1,5 +1,4 @@
-import { inject, Injectable, NgZone } from '@angular/core';
-import { DOCUMENT } from '@angular/common';
+import { Injectable } from '@angular/core';
 import { BehaviorSubject, combineLatest, filter, from, map, Observable, of, Subject, switchMap, take } from 'rxjs';
 import { BrandLogo, HoveredMenuCategory, MenuCategory, MenuItem, MenuOptions, MobileMenuState } from './menu.interface';
 import { MatDrawerMode, MatDrawerToggleResult, MatSidenav } from '@angular/material/sidenav';
@@ -34,9 +33,6 @@ export class MenuService {
     public isCategoriesHidden$: Observable<boolean>;
     public mobileMenuPositioning: MenuPositionEnum;
     public categories: Record<string, MenuCategory>;
-
-    private readonly document: Document = inject(DOCUMENT);
-    private readonly ngZone: NgZone = inject(NgZone);
 
     constructor(
         private readonly breakpointObserver: BreakpointObserver,
@@ -272,29 +268,7 @@ export class MenuService {
     }
 
     public async toggleSidenav(): Promise<void> {
-        const result: Promise<MatDrawerToggleResult> = this.sidenav.toggle();
-        this.flushSidenavTransition();
-        await result;
-    }
-
-    /**
-     * Safari (production builds) does not schedule a paint/composite frame after a
-     * discrete click handler finishes. Forcing a
-     * synchronous reflow and requesting an animation frame kicks the rendering loop
-     * immediately, so the menu opens/closes right away in every browser.
-     */
-    private flushSidenavTransition(): void {
-        if (typeof requestAnimationFrame === 'undefined') {
-            return;
-        }
-        this.ngZone.runOutsideAngular(() => {
-            const drawer: HTMLElement | null = this.document?.querySelector<HTMLElement>('.mat-drawer');
-            const target: HTMLElement | undefined = drawer ?? this.document?.documentElement;
-            void target?.offsetHeight;
-            requestAnimationFrame(() => {
-                void target?.offsetHeight;
-            });
-        });
+        await this.sidenav.toggle();
     }
 
     public isMenuPinned(isOpen?: boolean): boolean {

--- a/src/app/layouts/components/layout-wrapper/layout-wrapper.component.html
+++ b/src/app/layouts/components/layout-wrapper/layout-wrapper.component.html
@@ -9,6 +9,7 @@
                      }"
                  [mode]="'side'"
                  [opened]="false"
+                 [inert]="!sidenav.opened"
                  [fixedInViewport]="!isMobileScreen"
                  [autoFocus]="false"
     >

--- a/src/app/layouts/components/layout-wrapper/layout-wrapper.component.scss
+++ b/src/app/layouts/components/layout-wrapper/layout-wrapper.component.scss
@@ -15,6 +15,39 @@
       }
     }
 
+    /**
+     * Safari does not animate the drawer's `transform` transition when the element
+     * simultaneously switches from a non-rendered state to a rendered one in the same frame -
+     * which is exactly what Angular Material does on open. When closed the drawer has BOTH:
+     *   .mat-drawer:not(.mat-drawer-opened):not(.mat-drawer-animating){visibility:hidden}
+     *   .mat-drawer:not(.mat-drawer-opened):not(.mat-drawer-animating) .mat-drawer-inner-container{display:none}
+     * so on open `visibility`, the inner container's `display` and `transform` all flip in one
+     * frame. With no painted "from" state Safari skips the transform transition, which is why
+     * closing animates but opening jumps/stalls.
+     *
+     * We keep the drawer permanently rendered (it is already translated off-screen via
+     * `transform: translate3d(-100%, 0, 0)` when closed) by neutralising BOTH the `visibility`
+     * and the inner-container `display` flips. The open transition is then reduced to a pure
+     * `transform` change from a painted state, so it animates smoothly in every browser.
+     *
+     * This intentionally stays a CSS `transition` (not a keyframe animation): Material relies on
+     * the drawer's `transitionend` event to emit `openedChange` and update the content margins /
+     * focus trap. A keyframe animation would fire `animationend` instead and break that contract.
+     */
+    .mat-drawer.menu-sidenav {
+      will-change: transform;
+
+      &:not(.mat-drawer-opened):not(.mat-drawer-animating) {
+        visibility: visible;
+
+        // `.mat-drawer-inner-container` belongs to Material's own template, so it needs
+        // `::ng-deep` to be reached from this emulated-encapsulation stylesheet.
+        ::ng-deep .mat-drawer-inner-container {
+          display: block;
+        }
+      }
+    }
+
     .border-none {
       border: none;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved menu category enter/exit animations for more consistent browser behavior.
  * Refined Safari sidenav drawer transitions to reduce visual jumps, stalls, and rendering inconsistencies.
  * Enhanced sidenav interaction behavior by updating how it’s toggled and applying an inert state when closed.
* **Chores**
  * Updated the package version from 9.0.109 to 9.0.111.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->