### PR TITLE
fix(menu): fix open subcategories in safari

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xm-webapp",
-  "version": "9.0.111",
+  "version": "9.0.112",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xm-webapp",
-      "version": "9.0.111",
+      "version": "9.0.112",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "9.0.111",
+  "version": "9.0.112",
   "release": "6.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/packages/components/menu/menu.component.html
+++ b/packages/components/menu/menu.component.html
@@ -26,8 +26,9 @@
       <cdk-tree *ngIf="showMenuTree && subCategories$ | async"
                 [dataSource]="filteredCategories"
                 [treeControl]="treeControl"
-                [@showHideSubCategoriesDesktop]="!isMobileScreen ? showSubCategoriesState : null"
-                (@showHideSubCategoriesDesktop.done)="onHideSubCategoriesDone()"
+                class="sub-categories-tree"
+                [class.sub-categories-tree--visible]="isMobileScreen || showSubCategoriesState === menuSubcategoriesAnimationStateEnum.SHOW"
+                (transitionend)="onSubCategoriesTransitionEnd($event)"
       >
         <cdk-tree-node *cdkTreeNodeDef="let node">
           <a class="menu-link"

--- a/packages/components/menu/menu.component.ts
+++ b/packages/components/menu/menu.component.ts
@@ -47,7 +47,7 @@ import { Translate, XmTranslateService, XmTranslationModule } from '@xm-ngx/tran
 import { CommonModule, DOCUMENT } from '@angular/common';
 import { XmPermissionModule } from '@xm-ngx/core/permission';
 import { XmEventManager, XmEventManagerAction } from '@xm-ngx/core';
-import { hideCategories, showHideSubCategoriesDesktop, showHideSubCategoriesMobile } from './menu.animation';
+import { hideCategories, showHideSubCategoriesMobile } from './menu.animation';
 import { MenuService } from './menu.service';
 import { MatDrawerToggleResult } from '@angular/material/sidenav';
 import { MenuPositionEnum, MenuSubcategoriesAnimationStateEnum } from './menu.model';
@@ -90,11 +90,26 @@ export type ISideBarConfig = {
                 transform: translateX(0);
             }
         }
+
+        /**
+         * CSS replacement for the previous Angular 'showHideSubCategoriesDesktop' animation.
+         * The desktop subcategory list was faded in through a WAAPI-driven opacity animation
+         * which - exactly like the categories panel and the inline table filters - does not
+         * advance on production Safari until an unrelated event. A plain CSS opacity transition
+         * is honoured natively in every browser.
+         */
+        .sub-categories-tree {
+            opacity: 0;
+            transition: opacity 150ms 50ms;
+        }
+
+        .sub-categories-tree.sub-categories-tree--visible {
+            opacity: 1;
+        }
     `],
     animations: [
         matExpansionAnimations.bodyExpansion,
         matExpansionAnimations.indicatorRotate,
-        showHideSubCategoriesDesktop,
         showHideSubCategoriesMobile,
         hideCategories,
     ],
@@ -352,7 +367,7 @@ export class MenuComponent implements OnInit, AfterViewInit, OnDestroy {
             this.showSubCategoriesState = MenuSubcategoriesAnimationStateEnum.HIDE;
             this.hoveredCategory = hoveredCategory;
             const next$: Observable<MatDrawerToggleResult | number> =
-                !this.menuService.sidenav.opened && isOpenMenu ? from(this.menuService.sidenav.open()) : timer(0);
+                !this.menuService.sidenav.opened && isOpenMenu ? from(this.menuService.openSidenav()) : timer(0);
             return next$.pipe(
                 observeOn(animationFrameScheduler),
                 tap(() => {
@@ -492,6 +507,14 @@ export class MenuComponent implements OnInit, AfterViewInit, OnDestroy {
             behavior: 'smooth',
             block: 'center',
         });
+    }
+
+    public onSubCategoriesTransitionEnd(event: TransitionEvent): void {
+        const target: HTMLElement = event.target as HTMLElement;
+
+        if (event.propertyName === 'opacity' && target?.classList?.contains('sub-categories-tree')) {
+            this.onHideSubCategoriesDone();
+        }
     }
 
     private get isOnlyOtherCategory(): boolean {

--- a/packages/components/menu/menu.service.ts
+++ b/packages/components/menu/menu.service.ts
@@ -1,4 +1,5 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable, NgZone } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
 import { BehaviorSubject, combineLatest, filter, from, map, Observable, of, Subject, switchMap, take } from 'rxjs';
 import { BrandLogo, HoveredMenuCategory, MenuCategory, MenuItem, MenuOptions, MobileMenuState } from './menu.interface';
 import { MatDrawerMode, MatDrawerToggleResult, MatSidenav } from '@angular/material/sidenav';
@@ -33,6 +34,9 @@ export class MenuService {
     public isCategoriesHidden$: Observable<boolean>;
     public mobileMenuPositioning: MenuPositionEnum;
     public categories: Record<string, MenuCategory>;
+
+    private readonly document: Document = inject(DOCUMENT);
+    private readonly ngZone: NgZone = inject(NgZone);
 
     constructor(
         private readonly breakpointObserver: BreakpointObserver,
@@ -180,7 +184,7 @@ export class MenuService {
 
                     if (!categories?.length && !this.sidenav.opened && !isMaterial3Menu) {
                         this.setHoveredCategory(this.otherCategory);
-                        return selectedCategory && this.breakpointObserver.isMatched(this.DESKTOP_BIG_SCREEN) ? from(this.sidenav.open()) : of(null);
+                        return selectedCategory && this.breakpointObserver.isMatched(this.DESKTOP_BIG_SCREEN) ? from(this.openSidenav()) : of(null);
                     }
 
                     if (categories?.length && isMaterial3Menu) {
@@ -189,7 +193,7 @@ export class MenuService {
                         const isMediumAndClosed: boolean = this.isMediumScreen(breakpoints) && this.isMenuPinned(this.sidenav.opened);
                         const selectedCategoryValue: MenuCategory = this.selectedCategory.value || selectedCategory;
                         return selectedCategoryValue && (isLargeAndClosed || isMediumAndClosed) && !selectedCategoryValue.isLinkWithoutSubcategories ?
-                            from(this.sidenav.open()) : of(breakpointState);
+                            from(this.openSidenav()) : of(breakpointState);
                     }
                     return of(null);
                 }),
@@ -268,7 +272,80 @@ export class MenuService {
     }
 
     public async toggleSidenav(): Promise<void> {
-        await this.sidenav.toggle();
+        const willOpen = !this.sidenav.opened;
+        const result: Promise<MatDrawerToggleResult> = this.sidenav.toggle();
+
+        if (willOpen) {
+            this.kickOpenTransition();
+        }
+
+        await result;
+    }
+
+    /**
+     * Opens the sidenav while applying the same Safari transition kick as {@link toggleSidenav}.
+     * The categories are opened through this direct `open()` path (not `toggle()`), so it needs
+     * the kick too - otherwise selecting a category with subcategories leaves the drawer stuck
+     * until an unrelated event flushes Safari's rendering pipeline.
+     */
+    public openSidenav(): Promise<MatDrawerToggleResult> {
+        const willOpen = !this.sidenav.opened;
+        const result: Promise<MatDrawerToggleResult> = this.sidenav.open();
+
+        if (willOpen) {
+            this.kickOpenTransition();
+        }
+
+        return result;
+    }
+
+    /**
+     * Production Safari does not start the drawer's `transform` CSS transition when Material
+     * toggles the `.mat-drawer-opened` class programmatically from a click handler: the open
+     * stays "pending" until an unrelated event (another click, scroll, etc.) flushes the
+     * rendering pipeline.
+     * Because the transition never runs, its `transitionend` never fires, Material never emits
+     * `openedChange`, and the drawer looks stuck open-less.
+     *
+     * Re-applying the closed `transform` inline, forcing a synchronous reflow and then setting
+     * the open `transform` inline starts a fresh transition in the current frame, which Safari
+     * does honour. Material's own `transitionend` listener then completes the open normally.
+     * The inline transform is cleared once the animation ends (`.mat-drawer.mat-drawer-opened`
+     * already resolves to `transform: none`), so Material keeps full control afterwards.
+     *
+     * Closing is left untouched because it already animates correctly.
+     */
+    private kickOpenTransition(): void {
+        const drawer: HTMLElement | null = this.document?.querySelector<HTMLElement>('.mat-drawer');
+
+        if (!drawer) {
+            return;
+        }
+
+        const closedTransform: string = this.sidenav.position === 'end'
+            ? 'translate3d(100%, 0, 0)'
+            : 'translate3d(-100%, 0, 0)';
+
+        this.ngZone.runOutsideAngular(() => {
+            drawer.style.transform = closedTransform;
+            void drawer.offsetHeight;
+            drawer.style.transform = 'translate3d(0, 0, 0)';
+
+            const clear: () => void = () => {
+                drawer.style.transform = '';
+                drawer.removeEventListener('transitionend', onTransitionEnd);
+                clearTimeout(fallbackTimer);
+            };
+
+            const onTransitionEnd: (event: TransitionEvent) => void = (event: TransitionEvent) => {
+                if (event.target === drawer && event.propertyName === 'transform') {
+                    clear();
+                }
+            };
+
+            drawer.addEventListener('transitionend', onTransitionEnd);
+            const fallbackTimer: ReturnType<typeof setTimeout> = setTimeout(clear, 600);
+        });
     }
 
     public isMenuPinned(isOpen?: boolean): boolean {

--- a/src/app/layouts/components/layout-wrapper/layout-wrapper.component.html
+++ b/src/app/layouts/components/layout-wrapper/layout-wrapper.component.html
@@ -9,7 +9,6 @@
                      }"
                  [mode]="'side'"
                  [opened]="false"
-                 [inert]="!sidenav.opened"
                  [fixedInViewport]="!isMobileScreen"
                  [autoFocus]="false"
     >

--- a/src/app/layouts/components/layout-wrapper/layout-wrapper.component.scss
+++ b/src/app/layouts/components/layout-wrapper/layout-wrapper.component.scss
@@ -15,39 +15,6 @@
       }
     }
 
-    /**
-     * Safari does not animate the drawer's `transform` transition when the element
-     * simultaneously switches from a non-rendered state to a rendered one in the same frame -
-     * which is exactly what Angular Material does on open. When closed the drawer has BOTH:
-     *   .mat-drawer:not(.mat-drawer-opened):not(.mat-drawer-animating){visibility:hidden}
-     *   .mat-drawer:not(.mat-drawer-opened):not(.mat-drawer-animating) .mat-drawer-inner-container{display:none}
-     * so on open `visibility`, the inner container's `display` and `transform` all flip in one
-     * frame. With no painted "from" state Safari skips the transform transition, which is why
-     * closing animates but opening jumps/stalls.
-     *
-     * We keep the drawer permanently rendered (it is already translated off-screen via
-     * `transform: translate3d(-100%, 0, 0)` when closed) by neutralising BOTH the `visibility`
-     * and the inner-container `display` flips. The open transition is then reduced to a pure
-     * `transform` change from a painted state, so it animates smoothly in every browser.
-     *
-     * This intentionally stays a CSS `transition` (not a keyframe animation): Material relies on
-     * the drawer's `transitionend` event to emit `openedChange` and update the content margins /
-     * focus trap. A keyframe animation would fire `animationend` instead and break that contract.
-     */
-    .mat-drawer.menu-sidenav {
-      will-change: transform;
-
-      &:not(.mat-drawer-opened):not(.mat-drawer-animating) {
-        visibility: visible;
-
-        // `.mat-drawer-inner-container` belongs to Material's own template, so it needs
-        // `::ng-deep` to be reached from this emulated-encapsulation stylesheet.
-        ::ng-deep .mat-drawer-inner-container {
-          display: block;
-        }
-      }
-    }
-
     .border-none {
       border: none;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved menu subcategory transitions for smoother visibility changes.
  * Improved sidenav opening and toggling behavior, including better Safari compatibility.
  * Updated mobile subcategory state handling during transitions.
  * Removed accessibility and styling behavior that could interfere with sidenav interaction.

* **Chores**
  * Updated the package version to 9.0.112.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->