### PR TITLE
Add table warning message component with CSS slide animation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xm-webapp",
-  "version": "9.1.3",
+  "version": "9.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xm-webapp",
-      "version": "9.1.3",
+      "version": "9.1.5",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "9.1.3",
+  "version": "9.1.5",
   "release": "6.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/packages/components/table/components/chips-filter-btn/chips-filter-btn.component.html
+++ b/packages/components/table/components/chips-filter-btn/chips-filter-btn.component.html
@@ -137,7 +137,7 @@
                 class="value-txt"
                 [style.max-width]="textWidth ? textWidth : ''"
             >
-                : {{ skipValueTextTranslation ? (valueText || value) : ((valueText || value) | xmTranslate) }}
+                : {{ skipValueTextTranslation && isString(valueText || value) ? (valueText || value) : ((valueText || value) | xmTranslate) }}
             </span>
         </ng-container>
     </span>

--- a/packages/components/table/components/chips-filter-btn/chips-filter-btn.component.html
+++ b/packages/components/table/components/chips-filter-btn/chips-filter-btn.component.html
@@ -137,7 +137,7 @@
                 class="value-txt"
                 [style.max-width]="textWidth ? textWidth : ''"
             >
-                : {{ valueText || value | xmTranslate }}
+                : {{ skipValueTextTranslation ? (valueText || value) : ((valueText || value) | xmTranslate) }}
             </span>
         </ng-container>
     </span>

--- a/packages/components/table/components/chips-filter-btn/chips-filter-btn.component.ts
+++ b/packages/components/table/components/chips-filter-btn/chips-filter-btn.component.ts
@@ -83,4 +83,8 @@ export class ChipsFilterBtnComponent implements OnInit {
     public isArray<T>(value: T): boolean {
         return Array.isArray(value);
     }
+
+    public isString(value: unknown): boolean {
+        return typeof value === 'string';
+    }
 }

--- a/packages/components/table/components/chips-filter-btn/chips-filter-btn.component.ts
+++ b/packages/components/table/components/chips-filter-btn/chips-filter-btn.component.ts
@@ -36,6 +36,7 @@ export class ChipsFilterBtnComponent implements OnInit {
     @Input() public showClearBtn: boolean = true;
     @Input() public showIcon: boolean = true;
     @Input() public showValue: boolean = true;
+    @Input() public skipValueTextTranslation: boolean = false;
     @Output() public valueCleared: EventEmitter<void> = new EventEmitter<void>();
     @Output() public valueToggle: EventEmitter<void> = new EventEmitter<void>();
     public isChecked: boolean = false;

--- a/packages/components/table/components/messages/xm-table-warning-message.component.scss
+++ b/packages/components/table/components/messages/xm-table-warning-message.component.scss
@@ -22,6 +22,7 @@
     padding: 0;
     flex-shrink: 0;
 
+    /* stylelint-disable-next-line selector-pseudo-element-no-unknown -- ::ng-deep needed to shrink Angular Material's mat-icon-button touch target inside a 3rd-party component template */
     ::ng-deep .mat-mdc-button-touch-target {
       width: 28px;
       height: 28px;

--- a/packages/components/table/components/messages/xm-table-warning-message.component.scss
+++ b/packages/components/table/components/messages/xm-table-warning-message.component.scss
@@ -1,0 +1,84 @@
+.table-warning-message {
+  padding: 5px 10px;
+  background: #fffbeb;
+  color: #954514;
+  border: 1px solid #feda71;
+  border-radius: 8px;
+  display: flex;
+  margin: 5px 1rem 10px;
+  align-items: center;
+  overflow: hidden;
+  animation: table-warning-message-slide-in 0.3s ease-out;
+
+  &.closing {
+    animation: table-warning-message-slide-out 0.25s ease-in forwards;
+  }
+
+  .close-icon {
+    margin-left: auto;
+    cursor: pointer;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    flex-shrink: 0;
+
+    ::ng-deep .mat-mdc-button-touch-target {
+      width: 28px;
+      height: 28px;
+    }
+
+    .mat-icon {
+      margin-right: 0;
+      width: 18px;
+      height: 18px;
+      font-size: 18px;
+      line-height: 18px;
+    }
+  }
+
+  .warning-icon {
+    margin-right: 10px;
+  }
+}
+
+@keyframes table-warning-message-slide-in {
+  from {
+    opacity: 0;
+    max-height: 0;
+    margin-top: 0;
+    margin-bottom: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    max-height: 40px;
+    margin-top: 5px;
+    margin-bottom: 10px;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    transform: translateY(0);
+  }
+}
+
+@keyframes table-warning-message-slide-out {
+  from {
+    opacity: 1;
+    max-height: 40px;
+    margin-top: 5px;
+    margin-bottom: 10px;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    max-height: 0;
+    margin-top: 0;
+    margin-bottom: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    transform: translateY(-10px);
+  }
+}

--- a/packages/components/table/components/messages/xm-table-warning-message.model.ts
+++ b/packages/components/table/components/messages/xm-table-warning-message.model.ts
@@ -1,0 +1,9 @@
+import { Translate } from '@xm-ngx/translation';
+
+export interface XmTableWarningMessageConfig {
+    controller: {
+        key: string;
+        method: string;
+    };
+    title?: Translate;
+}

--- a/packages/components/table/components/messages/xm-table-warning-message.ts
+++ b/packages/components/table/components/messages/xm-table-warning-message.ts
@@ -1,0 +1,77 @@
+import { Component, inject, Input, OnInit } from '@angular/core';
+import { XM_DYNAMIC_COMPONENT_CONFIG, XmDynamicModule } from '@xm-ngx/dynamic';
+import { isObservable, Observable, of } from 'rxjs';
+import { distinctUntilChanged, tap } from 'rxjs/operators';
+import { MatIconModule } from '@angular/material/icon';
+import { AsyncPipe } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { DynamicInstance } from '@xm-ngx/ext/common-webapp-ext/module/stepper/to-core/dynamic-instance';
+import { XmTranslatePipe } from '@xm-ngx/translation';
+import {
+    XmTableWarningMessageConfig
+} from './xm-table-warning-message.model';
+
+@Component({
+    selector: 'xm-table-warning-message',
+    standalone: true,
+    template: `
+        @if ((isShow$ | async) && !isClosed) {
+            <div class="table-warning-message" [class.closing]="isClosing" (animationend)="onAnimationEnd($event)">
+                <mat-icon class="warning-icon">warning</mat-icon>
+                <span>{{config?.title | xmTranslate}}</span>
+                <button class="close-icon" mat-icon-button (click)="close()">
+                    <mat-icon>close</mat-icon>
+                </button>
+            </div>
+        }
+    `,
+    styleUrls: ['./xm-table-warning-message.component.scss'],
+    imports: [
+        MatIconModule,
+        XmDynamicModule,
+        MatButtonModule,
+        AsyncPipe,
+        XmTranslatePipe,
+    ],
+})
+export class XmTableWarningMessage extends DynamicInstance implements OnInit {
+    @Input() public config = inject<XmTableWarningMessageConfig>(XM_DYNAMIC_COMPONENT_CONFIG);
+
+    public isShow$: Observable<boolean | unknown>;
+    public isClosing = false;
+    public isClosed = false;
+
+    public ngOnInit(): void {
+        this.isShow$ = this.executeControllerMethod().pipe(
+            distinctUntilChanged(),
+            tap((show) => {
+                if (show) {
+                    this.isClosing = false;
+                    this.isClosed = false;
+                }
+            }),
+        );
+    }
+
+    public executeControllerMethod(): Observable<boolean | unknown> {
+        const controller = this.getControllerByKey(this.config.controller?.key);
+        const method = controller?.[this.config.controller?.method];
+        const executedMethod = method ? method.call(controller) : null;
+        if (isObservable(executedMethod)) {
+            return executedMethod;
+        }
+        return of(false);
+    }
+
+    public close(): void {
+        this.isClosing = true;
+    }
+
+    public onAnimationEnd(event: AnimationEvent): void {
+        if (event.target !== event.currentTarget) return;
+
+        if (this.isClosing) {
+            this.isClosed = true;
+        }
+    }
+}

--- a/packages/components/table/components/messages/xm-table-warning-message.ts
+++ b/packages/components/table/components/messages/xm-table-warning-message.ts
@@ -1,7 +1,7 @@
 import { Component, inject, Input, OnInit } from '@angular/core';
 import { XM_DYNAMIC_COMPONENT_CONFIG, XmDynamicModule } from '@xm-ngx/dynamic';
 import { isObservable, Observable, of } from 'rxjs';
-import { distinctUntilChanged, tap } from 'rxjs/operators';
+import { tap } from 'rxjs/operators';
 import { MatIconModule } from '@angular/material/icon';
 import { AsyncPipe } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
@@ -43,7 +43,6 @@ export class XmTableWarningMessage extends DynamicInstance implements OnInit {
 
     public ngOnInit(): void {
         this.isShow$ = this.executeControllerMethod().pipe(
-            distinctUntilChanged(),
             tap((show) => {
                 if (show) {
                     this.isClosing = false;

--- a/packages/components/table/table-widget/xm-table-widget.component.html
+++ b/packages/components/table/table-widget/xm-table-widget.component.html
@@ -71,7 +71,9 @@
       <xm-table-selection-header [defaultCollectionController]="collectionController"
                                  [config]="config.selection"></xm-table-selection-header>
 
-      <xm-table-warning-message [config]="config.warningMessage"></xm-table-warning-message>
+      @if (config.warningMessage) {
+        <xm-table-warning-message [config]="config.warningMessage"></xm-table-warning-message>
+      }
 
       <div class="xm-table-overflow-wrap" [style]="config.tableWrapperStyle">
         <table

--- a/packages/components/table/table-widget/xm-table-widget.component.html
+++ b/packages/components/table/table-widget/xm-table-widget.component.html
@@ -71,6 +71,8 @@
       <xm-table-selection-header [defaultCollectionController]="collectionController"
                                  [config]="config.selection"></xm-table-selection-header>
 
+      <xm-table-warning-message [config]="config.warningMessage"></xm-table-warning-message>
+
       <div class="xm-table-overflow-wrap" [style]="config.tableWrapperStyle">
         <table
           #table

--- a/packages/components/table/table-widget/xm-table-widget.component.ts
+++ b/packages/components/table/table-widget/xm-table-widget.component.ts
@@ -56,6 +56,7 @@ import {
     XM_TABLE_EXPANDABLE_COLUMN_NAME,
 } from '../components/xm-table-expandable-row-column.component';
 import { ConditionDirective } from '@xm-ngx/components/condition';
+import { XmTableWarningMessage } from '../components/messages/xm-table-warning-message';
 
 function getConfig(value: Partial<XmTableWidgetConfig>): XmTableWidgetConfig {
     const config = defaultsDeep(
@@ -107,6 +108,7 @@ function getConfig(value: Partial<XmTableWidgetConfig>): XmTableWidgetConfig {
         RefreshBtnComponent,
         XmTableExpandableRowColumnComponent,
         XmDynamicModule,
+        XmTableWarningMessage
     ],
     providers: [
         ...XM_TABLE_CONTROLLERS,

--- a/packages/components/table/table-widget/xm-table-widget.config.ts
+++ b/packages/components/table/table-widget/xm-table-widget.config.ts
@@ -46,6 +46,13 @@ export interface XmTableWidgetConfig extends XmTableConfig, XmTableFiltersContro
     errorRowCondition?: string;
     titleWidget?: XmTableTitleWidgetConfig;
     expandableRow?: XmDynamicLayout;
+    warningMessage?: {
+        title: Translate;
+        controller: {
+            key: string;
+            method: string;
+        };
+    };
 }
 
 export interface XmTableSelectionConfig {


### PR DESCRIPTION
- Add XmTableWarningMessage standalone component: shows a dismissible warning banner in xm-table-widget, driven by a configurable controller method (config.warningMessage.controller).
- Implement pure CSS slide-in/slide-out animation via keyframes and a local isClosing/isClosed state machine, using native (animationend) event instead of Angular animations or RxJS timers.
- Reset isClosing/isClosed via distinctUntilChanged + tap whenever the source observable re-emits true, so the banner can reappear after being closed.
- Add skipValueTextTranslation input to ChipsFilterBtnComponent to avoid double-translating already-resolved text (e.g. multi-select joined labels) through the xmTranslate pipe.
- Wire XmTableWarningMessage into xm-table-widget template/config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable warning messages to table widgets, including translated titles and controller-driven visibility.
  - Warning messages support close actions, animated transitions, and automatic reset when displayed again.
  - Added an option for chip filters to display selected values without translation.

- **Style**
  - Improved warning message layout, icons, borders, colors, spacing, and open/close animations.

- **Chores**
  - Updated the package version to 9.1.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->