### PR TITLE
fix: add hidePaginationSpacer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xm-webapp",
-  "version": "9.1.6",
+  "version": "9.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xm-webapp",
-      "version": "9.1.6",
+      "version": "9.1.7",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "9.1.6",
+  "version": "9.1.7",
   "release": "6.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/packages/components/table/table-widget/xm-table-widget.component.html
+++ b/packages/components/table/table-widget/xm-table-widget.component.html
@@ -15,7 +15,7 @@
             class="overflow-hidden no-horizontal-paddings"
             [ngClass]="{
               'mb-3': config.isCardMarginBottom,
-              'pb-4': xmTable.config?.pageableAndSortable?.hidePagination && !config.isTitleHidden,
+              'pb-4': xmTable.config?.pageableAndSortable?.hidePagination && !config.isTitleHidden && !config.hidePaginationSpacer,
             }"
             [attr.data-qa]="config?.dataQa"
   >

--- a/packages/components/table/table-widget/xm-table-widget.component.scss
+++ b/packages/components/table/table-widget/xm-table-widget.component.scss
@@ -48,6 +48,10 @@
     background: none;
   }
 
+  .mat-mdc-paginator[hidden] {
+    display: none;
+  }
+
   .xm-table-wrapper {
     overflow: hidden;
   }

--- a/packages/components/table/table-widget/xm-table-widget.config.ts
+++ b/packages/components/table/table-widget/xm-table-widget.config.ts
@@ -29,6 +29,7 @@ export interface XmTableWidgetConfig extends XmTableConfig, XmTableFiltersContro
     tableWrapperStyle?: string;
     isTitleHidden: boolean;
     isCardMarginBottom: boolean;
+    hidePaginationSpacer?: boolean;
     highlightRowOnHover?: boolean;
     highlightRowOnClick?: boolean;
     isRowSelectable: boolean,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to hide extra spacing beneath table widgets when pagination is not displayed.
  * Added support for hiding the table paginator when it is marked as hidden.
* **Bug Fixes**
  * Improved table layout behavior to prevent unnecessary bottom padding when pagination-related elements are unavailable.
* **Chores**
  * Updated the application package version to 9.1.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->