### PR TITLE
Feat: Hide clear button for not removable filters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xm-webapp",
-  "version": "9.1.9",
+  "version": "9.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xm-webapp",
-      "version": "9.1.9",
+      "version": "9.1.10",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xm-webapp",
-  "version": "9.1.8",
+  "version": "9.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xm-webapp",
-      "version": "9.1.8",
+      "version": "9.1.9",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xm-webapp",
-  "version": "9.1.7",
+  "version": "9.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xm-webapp",
-      "version": "9.1.7",
+      "version": "9.1.8",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "9.1.7",
+  "version": "9.1.8",
   "release": "6.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "9.1.9",
+  "version": "9.1.10",
   "release": "6.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "9.1.8",
+  "version": "9.1.9",
   "release": "6.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/packages/components/table/components/xm-table-quick-filter-inline.component.ts
+++ b/packages/components/table/components/xm-table-quick-filter-inline.component.ts
@@ -12,6 +12,7 @@ import { NgClass, NgIf } from '@angular/common';
 import _ from 'lodash';
 import { XmEmptyPipe } from '@xm-ngx/pipes';
 import { XmTableQuickFilterControlsComponent } from '../components/xm-table-quick-filter-controls.component';
+import { XmTableInlineFilterFormLayoutItem } from '@xm-ngx/components/table';
 
 @Component({
     selector: 'xm-table-quick-filter-inline',
@@ -41,11 +42,13 @@ import { XmTableQuickFilterControlsComponent } from '../components/xm-table-quic
                         [ngClass]="{'xm-filters-control-hidden': filterExpand}">
                     </xm-quick-filters-control-request>
 
-                    <button mat-button *ngIf="!config?.hideResetButton && hasActiveFilters"
-                            class="me-3"
-                            (click)="reset()">
-                        {{ 'table.filter.button.reset' | xmTranslate }}
-                    </button>
+                    @if (!config?.hideResetButton && hasActiveFilters) {
+                        <button mat-button
+                                class="me-3"
+                                (click)="reset()">
+                            {{ 'table.filter.button.reset' | xmTranslate }}
+                        </button>
+                    }
                 </div>
             </ng-container>
         </div>
@@ -148,7 +151,8 @@ export class XmTableQuickFilterInlineComponent implements OnInit, OnDestroy {
     }
 
     public reset(): void {
-        this.tableFilterController.clearExceptFixedFilters(this.config.filters);
+        const filters = [...(this.config.filters ?? []), ...(this.config.quickFilters?? [])];
+        this.tableFilterController.clearExceptFixedFilters(filters);
     }
 
     private setValueOnChangeFilter(): void {
@@ -179,8 +183,15 @@ export class XmTableQuickFilterInlineComponent implements OnInit, OnDestroy {
     }
 
     protected checkActiveFilters(): void {
-        this.hasActiveFilters = !!this.value && Object.values(this.value).some(
-            filter => filter != null && filter !== ''
+        const quickFilters = this.config?.quickFilters ?? [];
+        const removableQuickFilterKeys = new Set(
+            quickFilters
+                .filter((f: XmTableInlineFilterFormLayoutItem) => f.removable !== false)
+                .map(f => f.name)
+        );
+
+        this.hasActiveFilters = !!this.value && Object.entries(this.value).some(
+            ([key, filter]) => removableQuickFilterKeys.has(key) && filter != null && filter !== ''
         );
     }
 

--- a/packages/components/table/components/xm-table-quick-filter-inline.component.ts
+++ b/packages/components/table/components/xm-table-quick-filter-inline.component.ts
@@ -184,15 +184,16 @@ export class XmTableQuickFilterInlineComponent implements OnInit, OnDestroy {
 
     protected checkActiveFilters(): void {
         const quickFilters = this.config?.quickFilters ?? [];
-        const removableQuickFilterKeys = new Set(
+        const requiredQuickFilterKeys = new Set(
             quickFilters
-                .filter((f: XmTableInlineFilterFormLayoutItem) => f.removable !== false)
+                .filter((f: XmTableInlineFilterFormLayoutItem) => f.removable === false)
                 .map(f => f.name)
         );
 
         this.hasActiveFilters = !!this.value && Object.entries(this.value).some(
-            ([key, filter]) => removableQuickFilterKeys.has(key) && filter != null && filter !== ''
-        );
+            ([key, filter]) =>
+                !requiredQuickFilterKeys.has(key) &&
+                (Array.isArray(filter) ? filter.length > 0 : filter != null && filter !== ''));
     }
 
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved inline table filtering while preserving fixed filters when resetting standard or quick filters.
  * Reset controls now appear only when removable quick filters are active.

* **Bug Fixes**
  * Corrected active-filter detection for inline quick filters, including array and single-value filters.

* **Chores**
  * Updated the package version from 9.1.8 to 9.1.10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->