### PR TITLE
autocomplete default search limit from configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xm-webapp",
-  "version": "9.1.7",
+  "version": "9.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xm-webapp",
-      "version": "9.1.7",
+      "version": "9.1.8",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "9.1.7",
+  "version": "9.1.8",
   "release": "6.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/packages/components/autocomplete-control/autocomple-control.interface.ts
+++ b/packages/components/autocomplete-control/autocomple-control.interface.ts
@@ -59,6 +59,7 @@ export interface XmAutocompleteSearchParams {
     queryParams: XmAutocompleteControlParams;
     body: XmAutocompleteControlBody;
     headers: Record<string, string>;
+    size?: number;
 }
 
 export interface XmAutocompleteFetchParams {

--- a/packages/components/autocomplete-control/autocomplete-control.ts
+++ b/packages/components/autocomplete-control/autocomplete-control.ts
@@ -275,9 +275,12 @@ export class XmAutocompleteControl extends NgModelWrapper<object | string> imple
     }
 
     private searchByQuery(searchQuery: string): Observable<XmAutocompleteControlListItem[]> {
-        const {queryParams, body} = this.config?.search || {};
+        const {queryParams, body, size} = this.config?.search || {};
 
-        const httpParams = this.formatRequestParams(queryParams, this.getSearchCriteriaContext(searchQuery));
+        const httpParams = this.formatRequestParams(
+            {...(size ? {size: String(size)} : {}), ...queryParams},
+            this.getSearchCriteriaContext(searchQuery),
+        );
         const httpBody = this.formatRequestParams(body, this.getSearchCriteriaContext(searchQuery));
 
         return this.buildRequest(httpParams, httpBody);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional result-size setting for autocomplete searches.
  * Autocomplete requests now support limiting the number of returned results.

* **Chores**
  * Updated the application version from 9.1.7 to 9.1.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->