### PR TITLE
feat(xm-table-widget): add expandableRowCondition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xm-webapp",
-  "version": "9.1.13",
+  "version": "9.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xm-webapp",
-      "version": "9.1.13",
+      "version": "9.1.14",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xm-webapp",
-  "version": "9.1.11",
+  "version": "9.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xm-webapp",
-      "version": "9.1.11",
+      "version": "9.1.13",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "9.1.13",
+  "version": "9.1.14",
   "release": "6.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "9.1.12",
+  "version": "9.1.13",
   "release": "6.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/packages/components/table/components/xm-table-expandable-row-column.component.ts
+++ b/packages/components/table/components/xm-table-expandable-row-column.component.ts
@@ -14,6 +14,7 @@ import { MatTableModule } from '@angular/material/table';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { CommonModule } from '@angular/common';
+import { XmCondition } from '@xm-ngx/pipes';
 
 export const XM_TABLE_EXPANDABLE_COLUMN_NAME = '_expandColumn';
 
@@ -21,12 +22,13 @@ export const XM_TABLE_EXPANDABLE_COLUMN_NAME = '_expandColumn';
     selector: 'xm-table-expandable-row-column',
     standalone: true,
     changeDetection: ChangeDetectionStrategy.Default,
-    imports: [CommonModule, MatTableModule, MatIconModule, MatButtonModule],
+    imports: [CommonModule, MatTableModule, MatIconModule, MatButtonModule, XmCondition],
     template: `
         <ng-container [matColumnDef]="columnName">
             <th *matHeaderCellDef mat-header-cell class="table-expandable-row-column"></th>
             <td *matCellDef="let row" mat-cell class="table-expandable-row-column">
-                <button mat-icon-button
+                <button *ngIf="!rowCondition || (rowCondition | xmCondition: row)"
+                        mat-icon-button
                         (click)="toggleRow(row, $event)"
                         [attr.aria-expanded]="isExpanded(row)"
                         [attr.aria-label]="isExpanded(row) ? 'Collapse row' : 'Expand row'">
@@ -45,6 +47,11 @@ export class XmTableExpandableRowColumnComponent implements OnInit, OnDestroy {
     public readonly columnName = XM_TABLE_EXPANDABLE_COLUMN_NAME;
 
     @Input() public expandedRows: Set<unknown> = new Set();
+    /**
+     * Optional predicate deciding whether a row can be expanded.
+     * Evaluated by the `xmCondition` pipe with the row as `context`.
+     */
+    @Input() public rowCondition: string;
     @Output() public rowExpansionChanged = new EventEmitter<void>();
 
     @ViewChild(CdkColumnDef, { static: true }) private readonly _columnDef: CdkColumnDef;

--- a/packages/components/table/table-widget/xm-table-widget.component.html
+++ b/packages/components/table/table-widget/xm-table-widget.component.html
@@ -120,6 +120,7 @@
           <xm-table-expandable-row-column
             *ngIf="hasExpandableRows"
             [expandedRows]="expandedRows"
+            [rowCondition]="config.expandableRowCondition"
             (rowExpansionChanged)="onRowExpansionChanged()">
           </xm-table-expandable-row-column>
 

--- a/packages/components/table/table-widget/xm-table-widget.config.ts
+++ b/packages/components/table/table-widget/xm-table-widget.config.ts
@@ -47,6 +47,13 @@ export interface XmTableWidgetConfig extends XmTableConfig, XmTableFiltersContro
     errorRowCondition?: string;
     titleWidget?: XmTableTitleWidgetConfig;
     expandableRow?: XmDynamicLayout;
+    /**
+     * Optional predicate deciding whether a row can be expanded.
+     * Evaluated by the `xmCondition` pipe with the row as `context`,
+     * e.g. `return !!context?.someProperty`.
+     * When omitted every row is expandable.
+     */
+    expandableRowCondition?: string;
     warningMessage?: {
         title: Translate;
         controller: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added conditional expansion support for table rows.
  - Configure a row condition to show the expand control only when a row meets specified criteria.
  - Rows remain expandable by default when no condition is provided.

- **Chores**
  - Updated the package version to 9.1.14.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->