### PR TITLE
fix: resolve change detection error in console

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xm-webapp",
-  "version": "9.1.17",
+  "version": "9.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xm-webapp",
-      "version": "9.1.17",
+      "version": "9.1.18",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xm-webapp",
-  "version": "9.1.17",
+  "version": "9.1.18",
   "release": "6.0.0",
   "private": true,
   "description": "Xm-webapp",

--- a/packages/components/table/components/xm-quick-filters-control.component.ts
+++ b/packages/components/table/components/xm-quick-filters-control.component.ts
@@ -96,7 +96,7 @@ export class XmTableQuickFilterControl<T = FiltersControlValue> extends NgContro
         }
 
         if (this.formGroup && changes.value) {
-            this.formGroup.setValue(this.value);
+            this.formGroup.patchValue(this.value || {}, { emitEvent: false });
         }
 
         if (changes.options && !changes.options.isFirstChange()) {

--- a/packages/components/table/components/xm-quick-filters-control.component.ts
+++ b/packages/components/table/components/xm-quick-filters-control.component.ts
@@ -97,6 +97,7 @@ export class XmTableQuickFilterControl<T = FiltersControlValue> extends NgContro
 
         if (this.formGroup && changes.value) {
             this.formGroup.patchValue(this.value || {}, { emitEvent: false });
+            this.syncFormState();
         }
 
         if (changes.options && !changes.options.isFirstChange()) {
@@ -161,14 +162,18 @@ export class XmTableQuickFilterControl<T = FiltersControlValue> extends NgContro
                 takeUntil(this.destroy$),
             ).subscribe(() => {
                 const value = this.formGroup.getRawValue();
-                this.formValue$.next(value);
                 if (!_.isEqual(this.value, value)) {
                     this.emitValue(value);
                 }
 
-                this.validStatusChange.emit(this.formGroup.valid);
+                this.syncFormState(value);
             });
         }
+    }
+
+    private syncFormState(value: Record<string, unknown> = this.formGroup.getRawValue()): void {
+        this.formValue$.next(value);
+        this.validStatusChange.emit(this.formGroup.valid);
     }
 
     private emitValue(value: any): void {


### PR DESCRIPTION

<img width="1405" height="680" alt="Screenshot 2026-09-10 at 12 22 24" src="https://github.com/user-attachments/assets/80b14204-acf3-41e4-904c-d2f7b8399584" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Quick filter controls now keep their form values, active-filter state, and validity status synchronized when values are updated.
  - Updating quick filter values silently refreshes the displayed filter state without triggering unnecessary value-change events.
  - Empty or unavailable filter values continue to be handled safely without causing form errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->